### PR TITLE
Static Reference Rewriter implementation

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -282,6 +282,12 @@
             <version>2.5.3</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.rewriter</artifactId>
+            <version>1.0.4</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/AbstractTransformer.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/AbstractTransformer.java
@@ -1,0 +1,147 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.rewriter;
+
+import java.io.IOException;
+
+import org.apache.sling.rewriter.ProcessingComponentConfiguration;
+import org.apache.sling.rewriter.ProcessingContext;
+import org.apache.sling.rewriter.Transformer;
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.Locator;
+import org.xml.sax.SAXException;
+
+/**
+ * Abstract base class to ease creating transformer pipeline components.
+ * All methods are impelemented as pass-throughs to the next content handler.
+ * Similar to Cocoon's AbstractSAXPipe.
+ */
+public abstract class AbstractTransformer implements Transformer {
+
+    private ContentHandler contentHandler;
+
+    /**
+     * {@inheritDoc}
+     */
+    public void characters(final char[] ch, final int start, final int length) throws SAXException {
+        contentHandler.characters(ch, start, length);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void dispose() {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void endDocument() throws SAXException {
+        contentHandler.endDocument();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void endElement(final String uri, final String localName, final String qName) throws SAXException {
+        contentHandler.endElement(uri, localName, qName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void endPrefixMapping(final String prefix) throws SAXException {
+        contentHandler.endPrefixMapping(prefix);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void ignorableWhitespace(final char[] ch, final int start, final int length) throws SAXException {
+        contentHandler.ignorableWhitespace(ch, start, length);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void init(final ProcessingContext context, final ProcessingComponentConfiguration config)
+            throws IOException {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void processingInstruction(final String target, final String data) throws SAXException {
+        contentHandler.processingInstruction(target, data);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final void setContentHandler(final ContentHandler contentHandler) {
+        this.contentHandler = contentHandler;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void setDocumentLocator(final Locator locator) {
+        contentHandler.setDocumentLocator(locator);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void skippedEntity(final String name) throws SAXException {
+        contentHandler.skippedEntity(name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void startDocument() throws SAXException {
+        contentHandler.startDocument();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void startElement(final String uri, final String localName, final String qName, final Attributes atts)
+            throws SAXException {
+        contentHandler.startElement(uri, localName, qName, atts);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public void startPrefixMapping(final String prefix, final String uri)
+            throws SAXException {
+        contentHandler.startPrefixMapping(prefix, uri);
+    }
+
+    protected final ContentHandler getContentHandler() {
+        return contentHandler;
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/StaticReferenceRewriteTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/StaticReferenceRewriteTransformerFactory.java
@@ -1,0 +1,184 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.rewriter.impl;
+
+import java.util.Dictionary;
+import java.util.Map;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.ConfigurationPolicy;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.PropertyUnbounded;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.commons.osgi.PropertiesUtil;
+import org.apache.sling.rewriter.Transformer;
+import org.apache.sling.rewriter.TransformerFactory;
+import org.osgi.service.component.ComponentContext;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+
+import com.adobe.acs.commons.rewriter.AbstractTransformer;
+import com.adobe.acs.commons.util.OsgiPropertyUtil;
+
+/**
+ * Rewriter pipeline component which 
+ *
+ */
+@Component(
+        label = "ACS AEM Commons - Static Reference Rewriter",
+        description = "Rewriter pipeline component which rewrites host name on static references for cookie-less domain support",
+        metatype = true, configurationFactory = true, policy = ConfigurationPolicy.REQUIRE)
+@Service
+@Property(name = "pipeline.type", label = "Rewriter Pipeline Type",
+        description = "Type identifier to be referenced in rewriter pipeline configuration.")
+public final class StaticReferenceRewriteTransformerFactory implements TransformerFactory {
+
+    public final class StaticReferenceRewriteTransformer extends AbstractTransformer {
+
+        public void startElement(String namespaceURI, String localName, String qName, Attributes atts)
+                throws SAXException {
+            getContentHandler().startElement(namespaceURI, localName, qName, rebuildAttributes(localName, atts));
+        }
+    }
+
+    private static final String ATTR_CLASS = "class";
+
+    private static final String CLASS_NOSTATIC = "nostatic";
+
+    private static final String[] DEFAULT_ATTRIBUTES = { "img:src", "link:href", "script:src" };
+
+    private static final int DEFAULT_HOST_COUNT = 1;
+
+    @Property(label = "Rewrite Attributes", description = "List of element/attribute pairs to rewrite", value = {
+            "img:src", "link:href", "script:src" })
+    private static final String PROP_ATTRIBUTES = "attributes";
+
+    @Property(intValue = DEFAULT_HOST_COUNT, label = "Static Host Count",
+            description = "Number of static hosts available.")
+    private static final String PROP_HOST_COUNT = "host.count";
+
+    @Property(label = "Static Host Pattern", description = "Pattern for generating static host domain names. "
+            + "'{}' will be replaced with the host number.")
+    private static final String PROP_HOST_NAME_PATTERN = "host.pattern";
+
+    @Property(unbounded = PropertyUnbounded.ARRAY, label = "Path Prefixes",
+            description = "Path prefixes to rewrite.")
+    private static final String PROP_PREFIXES = "prefixes";
+
+    private Map<String, String[]> attributes;
+
+    private String[] prefixes;
+
+    private int staticHostCount;
+
+    private String staticHostPattern;
+
+    public Transformer createTransformer() {
+        return new StaticReferenceRewriteTransformer();
+    }
+
+    private String getStaticHostNum(final String filePath) {
+        String hostNumberString = "1";
+        if (staticHostCount > 1) {
+            int fileHash = Math.abs(filePath.hashCode());
+            String baseValue = Integer.toString(fileHash, staticHostCount);
+            if (baseValue.length() >= 2) {
+                // get the 2nd digit as the 1st digit will not contain "0"
+                Character c = baseValue.charAt(1);
+                hostNumberString = c.toString();
+                // If there are more than 10 hosts, convert it back to base10
+                // so we do not have alpha
+                hostNumberString = Integer.toString(Integer.parseInt(hostNumberString, staticHostCount));
+
+                int hostNumberInt = Integer.parseInt(hostNumberString) + 1;
+                hostNumberString = Integer.toString(hostNumberInt);
+            }
+        }
+
+        return hostNumberString;
+    }
+
+    private String prependHostName(String value) {
+        if (staticHostPattern != null) {
+            final String hostNum = this.getStaticHostNum(value);
+            final String host = staticHostPattern.replace("{}", hostNum);
+
+            return String.format("//%s%s", host, value);
+        } else {
+            return value;
+        }
+    }
+
+    private Attributes rebuildAttributes(final String elementName, final Attributes attrs) {
+        if (attributes.containsKey(elementName)) {
+            final String[] modifyableAttributes = attributes.get(elementName);
+
+            // clone the attributes
+            final AttributesImpl newAttrs = new AttributesImpl(attrs);
+            final int len = newAttrs.getLength();
+
+            // first - check for the nostatic class
+            boolean rewriteStatic = true;
+            for (int i = 0; i < len; i++) {
+                final String attrName = newAttrs.getLocalName(i);
+                if (ATTR_CLASS.equals(attrName)) {
+                    String attrValue = newAttrs.getValue(i);
+                    if (attrValue.contains(CLASS_NOSTATIC)) {
+                        rewriteStatic = false;
+                    }
+                }
+            }
+
+            if (rewriteStatic) {
+                for (int i = 0; i < len; i++) {
+                    final String attrName = newAttrs.getLocalName(i);
+                    if (ArrayUtils.contains(modifyableAttributes, attrName)) {
+                        final String attrValue = newAttrs.getValue(i);
+                        for (String prefix : prefixes) {
+                            if (attrValue.startsWith(prefix)) {
+                                newAttrs.setValue(i, prependHostName(attrValue));
+                            }
+                        }
+                    }
+                }
+            }
+            return newAttrs;
+        } else {
+            return attrs;
+        }
+    }
+
+    @Activate
+    protected void activate(final ComponentContext componentContext) {
+        final Dictionary<?, ?> properties = componentContext.getProperties();
+
+        final String[] attrProp = PropertiesUtil
+                .toStringArray(properties.get(PROP_ATTRIBUTES), DEFAULT_ATTRIBUTES);
+        this.attributes = OsgiPropertyUtil.toMap(attrProp, ":", ",");
+
+        this.prefixes = PropertiesUtil.toStringArray(properties.get(PROP_PREFIXES), new String[0]);
+        this.staticHostPattern = PropertiesUtil.toString(properties.get(PROP_HOST_NAME_PATTERN), null);
+        this.staticHostCount = PropertiesUtil.toInteger(properties.get(PROP_HOST_COUNT), DEFAULT_HOST_COUNT);
+
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/util/OsgiPropertyUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/OsgiPropertyUtil.java
@@ -24,7 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.AbstractMap;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class OsgiPropertyUtil {
@@ -64,7 +64,7 @@ public class OsgiPropertyUtil {
      * @return Map of key/value pairs; map.get("dog") => "woof", map.get("cat") => "meow"
      */
     public static Map<String, String> toMap(final String[] values, final String separator) {
-        final Map<String, String> map = new HashMap<String, String>();
+        final Map<String, String> map = new LinkedHashMap<String, String>();
 
         if (values == null || values.length < 1) {
             return map;
@@ -78,5 +78,22 @@ public class OsgiPropertyUtil {
         }
 
         return map;
+    }
+
+    /**
+     * Util for parsing Arrays of Service properties in the form &gt;value&lt;&gt;map-separator&lt;&gt;value&gt;list-separator&lt;&gt;value&lt;&lt;
+     *
+     * @param values    Array of key/value pairs in the format => [ a<map-separator>b, x<map-separator>y<list-separator>z ] ... ex. ["dog:woof", "cat:meow,purr"]
+     * @param mapSeparator separator between the key/values in the amp
+     * @param listSeparator separator between the values in each list
+     * @return Map of key/value pairs; map.get("dog") => "woof", map.get("cat") => "meow"
+     */
+    public static Map<String, String[]> toMap(final String[] values, final String mapSeparator, final String listSeparator) {
+        final Map<String, String> map = toMap(values, mapSeparator);
+        final Map<String, String[]> result = new LinkedHashMap<String, String[]>(map.size());
+        for (final Map.Entry<String, String> entry : map.entrySet()) {
+            result.put(entry.getKey(), StringUtils.split(entry.getValue(), listSeparator));
+        }
+        return result;
     }
 }


### PR DESCRIPTION
This is an implementation of a Sling Rewriter pipeline component which can rewrite script references, CSS references, and image references (actually any HTML attribute) to prepend a host name. This is intended for use when using "cookie-less" domains.

The idea is that you have this:

```
<script src="/etc/clientlibs/granite/jquery-ui.js"></script>
```

And you want

```
<script src="//static.host.com/etc/clientlibs/granite/jquery-ui.js"></script>
```

For even more optimization, this component can also be configured to multiplex between N number of hosts, i.e.

```
<link rel="stylesheet" href="//static1.host.com/etc/clientlibs/foundation/jquery-ui/themes/default.css" type="text/css"/>
<script type="text/javascript" src="//static2.host.com/etc/clientlibs/foundation/shared.js"></script>
<script type="text/javascript" src="//static3.host.com/etc/clientlibs/granite/jquery-ui.js"></script>
<script type="text/javascript" src="//static4.host.com/etc/clientlibs/foundation/jquery-ui.js"></script>
<script type="text/javascript" src="//static5.host.com/etc/clientlibs/social/commons/ckeditor.js"></script>
```

This is done through a hash-based algorithm that ensures a relatively even distribution, but one which is consistent, i.e. /etc/licentlibs/granite/jquery-ui.js will always be served from static3.

Also included is a base class (AbstractTransformer) which cuts down on the boilerplate code needed for a Transformer component. And a minor enhancement to the OsgiPropertiesUtil class.
