### PR TITLE
Initial version of dhml:includeClientLibraries tag

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -51,7 +51,8 @@
                         <Include-Resource>
                             {maven-resources},
                             META-INF/wcmmode.tld=target/classes/META-INF/wcmmode.tld,
-                            META-INF/audio.tld=target/classes/META-INF/audio.tld
+                            META-INF/audio.tld=target/classes/META-INF/audio.tld,
+                            META-INF/dhlm.tld=target/classes/META-INF/dhlm.tld
                         </Include-Resource>
                     </instructions>
                 </configuration>
@@ -280,6 +281,12 @@
             <groupId>org.apache.jackrabbit</groupId>
             <artifactId>jackrabbit-jcr-commons</artifactId>
             <version>2.5.3</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.scripting.jsp</artifactId>
+            <version>2.0.28</version>
             <scope>provided</scope>
         </dependency>
 

--- a/bundle/src/main/java/com/adobe/acs/commons/designer/IncludeDesignLibrariesTag.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/designer/IncludeDesignLibrariesTag.java
@@ -1,0 +1,116 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.designer;
+
+import java.io.IOException;
+
+import javax.servlet.jsp.JspException;
+import javax.servlet.jsp.tagext.TagSupport;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.scripting.SlingBindings;
+import org.apache.sling.scripting.jsp.util.TagUtil;
+
+import tldgen.BodyContentType;
+import tldgen.Tag;
+import tldgen.TagAttribute;
+
+import com.day.cq.wcm.api.designer.Design;
+
+/**
+ * JSP Tag which includes client libraries based on the design.
+ *
+ */
+@SuppressWarnings("serial")
+@Tag(bodyContentType = BodyContentType.EMPTY, value = "includeClientLibraries")
+public final class IncludeDesignLibrariesTag extends TagSupport {
+
+    private PageRegion region;
+
+    private boolean js;
+
+    private boolean css;
+
+    private Design design;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int doEndTag() throws JspException {
+        final SlingHttpServletRequest request = TagUtil.getRequest(pageContext);
+        final SlingBindings bindings = (SlingBindings) request.getAttribute(SlingBindings.class.getName());
+        final DesignHtmlLibraryManager manager = bindings.getSling().getService(DesignHtmlLibraryManager.class);
+        if (manager != null) {
+            try {
+                if (js && css) {
+                    manager.writeIncludes(request, getDesign(), region, pageContext.getOut());
+                } else if (js) {
+                    manager.writeJsInclude(request, getDesign(), region, pageContext.getOut());
+                } else if (css) {
+                    manager.writeCssInclude(request, getDesign(), region, pageContext.getOut());
+                }
+            } catch (IOException e) {
+                throw new JspException("Unable to write client library includes", e);
+            }
+        }
+        reset();
+        return EVAL_PAGE;
+    }
+
+    @Override
+    public void release() {
+        reset();
+        super.release();
+    }
+
+    @TagAttribute(runtimeValueAllowed = true)
+    public void setCss(boolean css) {
+        this.css = css;
+    }
+
+    public void setDesign(Design design) {
+        this.design = design;
+    }
+
+    @TagAttribute(runtimeValueAllowed = true)
+    public void setJs(boolean js) {
+        this.js = js;
+    }
+
+    @TagAttribute(required = true, runtimeValueAllowed = true)
+    public void setRegion(String region) {
+        this.region = PageRegion.valueOf(region.toUpperCase());
+    }
+
+    private Design getDesign() {
+        if (design == null) {
+            return (Design) pageContext.getAttribute("currentDesign");
+        } else {
+            return design;
+        }
+    }
+
+    private void reset() {
+        this.region = null;
+        this.js = false;
+        this.css = false;
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/designer/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/designer/package-info.java
@@ -20,5 +20,6 @@
 /**
  * Client Library Designer API.
  */
-@aQute.bnd.annotation.Version("1.0.0")
+@aQute.bnd.annotation.Version("1.1.0")
+@tldgen.TagLibrary(value = "http://www.adobe.com/consulting/acs-aem-commons/dhlm", descriptorFile = "dhlm.tld")
 package com.adobe.acs.commons.designer;

--- a/bundle/src/test/java/com/adobe/acs/commons/designer/IncludeDesignLibrariesTagTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/designer/IncludeDesignLibrariesTagTest.java
@@ -1,0 +1,120 @@
+package com.adobe.acs.commons.designer;
+
+import static org.mockito.Mockito.*;
+
+import javax.servlet.jsp.JspWriter;
+import javax.servlet.jsp.PageContext;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.scripting.SlingBindings;
+import org.apache.sling.api.scripting.SlingScriptHelper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.day.cq.wcm.api.designer.Design;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IncludeDesignLibrariesTagTest {
+    
+    @Mock
+    private PageContext pageContext;
+    
+    @Mock
+    private SlingHttpServletRequest request;
+    
+    @Mock
+    private DesignHtmlLibraryManager dhlm;
+    
+    @Mock
+    private SlingBindings slingBindings;
+    
+    @Mock
+    private SlingScriptHelper sling;
+    
+    @Mock
+    private Design currentDesign;
+    
+    @Mock
+    private Design otherDesign;
+    
+    @Mock
+    private JspWriter writer;
+    
+    @InjectMocks
+    private IncludeDesignLibrariesTag tag = new IncludeDesignLibrariesTag();
+
+    @Before
+    public void setUp() throws Exception {
+        when(pageContext.getRequest()).thenReturn(request);
+        when(pageContext.getOut()).thenReturn(writer);
+        when(request.getAttribute(SlingBindings.class.getName())).thenReturn(slingBindings);
+        when(slingBindings.getSling()).thenReturn(sling);
+        when(sling.getService(DesignHtmlLibraryManager.class)).thenReturn(dhlm);
+        when(pageContext.getAttribute("currentDesign")).thenReturn(currentDesign);
+    }
+
+    @Test
+    public void test_css_and_js() throws Exception {
+        tag.setCss(true);
+        tag.setJs(true);
+        tag.setRegion("head");
+        tag.doEndTag();
+        verify(dhlm, only()).writeIncludes(request, currentDesign, PageRegion.HEAD, writer);
+    }
+
+    @Test
+    public void test_css_only() throws Exception {
+        tag.setCss(true);
+        tag.setRegion("head");
+        tag.doEndTag();
+        verify(dhlm, only()).writeCssInclude(request, currentDesign, PageRegion.HEAD, writer);
+    }
+
+    @Test
+    public void test_js_only() throws Exception {
+        tag.setJs(true);
+        tag.setRegion("head");
+        tag.doEndTag();
+        verify(dhlm, only()).writeJsInclude(request, currentDesign, PageRegion.HEAD, writer);
+    }
+
+    @Test
+    public void test_nothing_included() throws Exception {
+        tag.setRegion("head");
+        tag.doEndTag();
+        verifyNoMoreInteractions(dhlm);
+    }
+
+    @Test
+    public void test_alternate_design() throws Exception {
+        tag.setJs(true);
+        tag.setRegion("head");
+        tag.setDesign(otherDesign);
+        tag.doEndTag();
+        verify(dhlm, only()).writeJsInclude(request, otherDesign, PageRegion.HEAD, writer);
+    }
+
+    @Test
+    public void test_without_dhlm() throws Exception {
+        when(sling.getService(DesignHtmlLibraryManager.class)).thenReturn(null);
+        tag.setJs(true);
+        tag.setRegion("head");
+        tag.doEndTag();
+        verifyNoMoreInteractions(dhlm);
+    }
+
+    @Test
+    public void testRelease() throws Exception {
+        tag.setJs(true);
+        tag.release();
+        tag.setRegion("head");
+        tag.doEndTag();
+        verifyNoMoreInteractions(dhlm);
+    }
+
+
+}


### PR DESCRIPTION
Use it like this:

   &lt;dhlm:includeClientLibraries js="true" css="true" region="head"/>

or just

   &lt;dhlm:includeClientLibraries js="true" region="head"/>

or even

   &lt;dhlm:includeClientLibraries js="true" design="${someotherdesign}" region="head"/>
