### PR TITLE
Adding Twitter Client adapter factory

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -48,6 +48,11 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>com.adobe.acs.acs-aem-commons-bundle</Bundle-SymbolicName>
+                        <Import-Package>
+                            twitter4j;resolution:=optional,
+                            twitter4j.*;resolution:=optional,
+                            *
+                         </Import-Package>
                         <Include-Resource>
                             {maven-resources},
                             META-INF/wcmmode.tld=target/classes/META-INF/wcmmode.tld,
@@ -295,6 +300,12 @@
             <version>2.0.28</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.day.cq.wcm</groupId>
+            <artifactId>cq-wcm-webservice-support</artifactId>
+            <version>5.6.4</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>
@@ -331,6 +342,12 @@
                     <groupId>javax.servlet.jsp</groupId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.twitter4j</groupId>
+            <artifactId>twitter4j-core</artifactId>
+            <version>3.0.5</version>
+            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/bundle/src/main/java/com/adobe/acs/commons/twitter/TwitterClient.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/twitter/TwitterClient.java
@@ -1,0 +1,50 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.twitter;
+
+import twitter4j.Twitter;
+
+import com.day.cq.wcm.webservicesupport.Configuration;
+
+/**
+ * Service interface which wraps the Twitter4j API to expose the originating
+ * Cloud Service Configuration.
+ * 
+ * To obtain an instance of this class, adapt either a Page or a Configuration object.
+ * 
+ * Note that these clients always use only Application authentication.
+ */
+public interface TwitterClient{
+    
+    /**
+     * Get the Cloud Service Configuration from which this client was created.
+     * 
+     * @return the service configuration
+     */
+    Configuration getServiceConfiguration();
+    
+    /**
+     * Get the Twitter4j client.
+     * 
+     * @return the client
+     */
+    Twitter getTwitter();
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/twitter/impl/TwitterAdapterFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/twitter/impl/TwitterAdapterFactory.java
@@ -1,0 +1,139 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.twitter.impl;
+
+import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.adapter.AdapterFactory;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceUtil;
+import org.apache.sling.api.resource.ValueMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import twitter4j.Twitter;
+import twitter4j.TwitterException;
+import twitter4j.TwitterFactory;
+import twitter4j.conf.Configuration;
+import twitter4j.conf.ConfigurationBuilder;
+
+import com.adobe.acs.commons.twitter.TwitterClient;
+import com.day.cq.commons.inherit.HierarchyNodeInheritanceValueMap;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.webservicesupport.ConfigurationConstants;
+import com.day.cq.wcm.webservicesupport.ConfigurationManager;
+
+@Component
+@Service
+@Properties({
+        @Property(name = AdapterFactory.ADAPTABLE_CLASSES, value = { "com.day.cq.wcm.api.Page",
+                "com.day.cq.wcm.webservicesupport.Configuration" }),
+        @Property(name = AdapterFactory.ADAPTER_CLASSES, value = { "twitter4j.Twitter",
+                "com.adobe.acs.commons.twitter.TwitterClient" }) })
+public class TwitterAdapterFactory implements AdapterFactory {
+
+    private static final String CLOUD_SERVICE_NAME = "twitterconnect";
+
+    private static final Logger log = LoggerFactory.getLogger(TwitterAdapterFactory.class);
+
+    @Reference
+    private ConfigurationManager configurationManager;
+
+    private TwitterFactory factory;
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <AdapterType> AdapterType getAdapter(Object adaptable, Class<AdapterType> type) {
+        TwitterClient client = null;
+        if (adaptable instanceof Page) {
+            client = createTwitterClient((Page) adaptable);
+        } else if (adaptable instanceof com.day.cq.wcm.webservicesupport.Configuration) {
+            client = createTwitterClient((com.day.cq.wcm.webservicesupport.Configuration) adaptable);
+        }
+
+        if (type == TwitterClient.class) {
+            return (AdapterType) client;
+        } else if (type == Twitter.class) {
+            return (AdapterType) client.getTwitter();
+        } else {
+            return null;
+        }
+
+    }
+
+    private Configuration buildConfiguration() {
+        final ConfigurationBuilder builder = new ConfigurationBuilder();
+        builder.setUseSSL(true);
+        builder.setApplicationOnlyAuthEnabled(true);
+        return builder.build();
+    }
+
+    private TwitterClient createTwitterClient(com.day.cq.wcm.webservicesupport.Configuration config) {
+        Resource oauthConfig = config.getContentResource().listChildren().next();
+        ValueMap oauthProps = ResourceUtil.getValueMap(oauthConfig);
+        String consumerKey = oauthProps.get("oauth.client.id", String.class);
+        String consumerSecret = oauthProps.get("oauth.client.secret", String.class);
+
+        if (consumerKey != null && consumerSecret != null) {
+            Twitter t = factory.getInstance();
+            log.debug("Creating client for key {}.", consumerKey);
+            t.setOAuthConsumer(consumerKey, consumerSecret);
+            try {
+                t.getOAuth2Token();
+                return new TwitterClientImpl(t, config);
+            } catch (TwitterException e) {
+                log.error("Unable to create Twitter client.", e);
+                return null;
+            }
+        } else {
+            log.warn("Key or Secret missing for configuration {}", config.getPath());
+        }
+
+        return null;
+    }
+
+    private TwitterClient createTwitterClient(Page page) {
+        com.day.cq.wcm.webservicesupport.Configuration config = findTwitterConfiguration(page);
+        if (config != null) {
+            return createTwitterClient(config);
+        }
+        return null;
+    }
+
+    private com.day.cq.wcm.webservicesupport.Configuration findTwitterConfiguration(Page page) {
+        final HierarchyNodeInheritanceValueMap pageProperties = new HierarchyNodeInheritanceValueMap(
+                page.getContentResource());
+        final String[] services = pageProperties.getInherited(ConfigurationConstants.PN_CONFIGURATIONS,
+                new String[0]);
+        final com.day.cq.wcm.webservicesupport.Configuration cfg = configurationManager.getConfiguration(
+                CLOUD_SERVICE_NAME, services);
+        return cfg;
+    }
+
+    @Activate
+    protected void activate() {
+        this.factory = new TwitterFactory(buildConfiguration());
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/twitter/impl/TwitterClientImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/twitter/impl/TwitterClientImpl.java
@@ -1,0 +1,49 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.twitter.impl;
+
+import twitter4j.Twitter;
+
+import com.adobe.acs.commons.twitter.TwitterClient;
+import com.day.cq.wcm.webservicesupport.Configuration;
+
+public class TwitterClientImpl implements TwitterClient {
+
+    private final Twitter twitter;
+
+    private final com.day.cq.wcm.webservicesupport.Configuration serviceConfiguration;
+
+    public TwitterClientImpl(Twitter impl, com.day.cq.wcm.webservicesupport.Configuration configuration) {
+        this.twitter = impl;
+        this.serviceConfiguration = configuration;
+    }
+
+    @Override
+    public Configuration getServiceConfiguration() {
+        return serviceConfiguration;
+    }
+
+    @Override
+    public Twitter getTwitter() {
+        return twitter;
+    }
+
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/twitter/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/twitter/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/**
+ * Twitter Client.
+ */
+@aQute.bnd.annotation.Version("1.0.0")
+package com.adobe.acs.commons.twitter;

--- a/content/src/main/content/META-INF/vault/filter.xml
+++ b/content/src/main/content/META-INF/vault/filter.xml
@@ -5,4 +5,7 @@
     <filter root="/etc/designs/acs-commons"/>
     <filter root="/etc/dam/video/mp3hq"/>
     <filter root="/etc/dam/video/ogghq"/>
+    <filter root="/etc/acs-commons">
+        <include pattern="/etc/acs-commons/twitter-rate-limit-checker(.*)?" />
+    </filter>
 </workspaceFilter>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/twitter-rate-limit-checker/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/twitter-rate-limit-checker/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:defaultView="html"
+    jcr:description="Twitter Rate Limit Checker"
+    jcr:primaryType="cq:Component"
+    jcr:title="Twitter Rate Limit Checker"
+    sling:resourceSuperType="foundation/components/page"
+    componentGroup=".hidden"/>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/twitter-rate-limit-checker/body.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/twitter-rate-limit-checker/body.jsp
@@ -1,0 +1,55 @@
+<%--
+  #%L
+  ACS AEM Commons Package
+  %%
+  Copyright (C) 2013 Adobe
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  --%>
+<%@include file="/libs/foundation/global.jsp"%><%
+%><%@ page import="java.util.Iterator,
+                   java.util.TreeMap,
+                   org.apache.sling.api.adapter.AdapterManager,
+                   com.adobe.acs.commons.twitter.TwitterClient,
+                   com.day.cq.wcm.webservicesupport.Configuration,
+                   com.day.cq.wcm.webservicesupport.ConfigurationManager" %>
+
+<body>
+    <h1>Twitter Rate Limits</h1>
+<div id="data">
+<%
+ConfigurationManager configurationManager = sling.getService(ConfigurationManager.class);
+AdapterManager adapterManager = sling.getService(AdapterManager.class);
+Iterator<Configuration> configs = configurationManager.getConfigurations("/etc/cloudservices/twitterconnect");
+while (configs.hasNext()) {
+    Configuration serviceConfig = configs.next();
+    TwitterClient client = adapterManager.getAdapter(serviceConfig, TwitterClient.class);
+    if (client != null) {
+        pageContext.setAttribute("serviceConfig", serviceConfig);
+        pageContext.setAttribute("stati", new TreeMap(client.getTwitter().getRateLimitStatus()));
+%>
+<cq:text value="${serviceConfig.title} (${serviceConfig.path})" escapeXml="true" tagName="h3"/>
+<p>
+    <ul>
+        <c:forEach var="entry" items="${stati}">
+            <li><b>${entry.key}</b> - ${entry.value.remaining} of ${entry.value.limit} remaining. Reset in ${entry.value.secondsUntilReset} seconds.</li>
+        </c:forEach>
+    </ul>
+</p>
+<%
+    }
+}
+%>
+</div>
+</body>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/twitter-rate-limit-checker/head.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/twitter-rate-limit-checker/head.jsp
@@ -1,0 +1,38 @@
+<%--
+  #%L
+  ACS AEM Commons Package
+  %%
+  Copyright (C) 2013 Adobe
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  --%>
+<%@include file="/libs/foundation/global.jsp" %><%
+%><%@ page import="com.day.cq.commons.Doctype" %><%
+    String xs = Doctype.isXHTML(request) ? "/" : "";
+    String favIcon = currentDesign.getPath() + "/favicon.ico";
+    if (resourceResolver.getResource(favIcon) == null) {
+        favIcon = null;
+    }
+%><head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8"<%=xs%>>
+    <meta name="keywords" content="<%= xssAPI.encodeForHTMLAttr(WCMUtils.getKeywords(currentPage, false)) %>"<%=xs%>>
+    <meta name="description" content="<%= xssAPI.encodeForHTMLAttr(properties.get("jcr:description", "")) %>"<%=xs%>>
+    <cq:include script="headlibs.jsp"/>
+    <cq:include script="stats.jsp"/>
+    <% if (favIcon != null) { %>
+    <link rel="icon" type="image/vnd.microsoft.icon" href="<%= xssAPI.getValidHref(favIcon) %>"<%=xs%>>
+    <link rel="shortcut icon" type="image/vnd.microsoft.icon" href="<%= xssAPI.getValidHref(favIcon) %>"<%=xs%>>
+    <% } %>
+    <title><%= currentPage.getTitle() == null ? xssAPI.encodeForHTML(currentPage.getName()) : xssAPI.encodeForHTML(currentPage.getTitle()) %></title>
+</head>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/twitter-rate-limit-checker/headlibs.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/twitter-rate-limit-checker/headlibs.jsp
@@ -1,0 +1,23 @@
+<%--
+  #%L
+  ACS AEM Commons Package
+  %%
+  Copyright (C) 2013 Adobe
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  --%>
+<%@include file="/libs/foundation/global.jsp" %><%
+%><cq:includeClientLib categories="cq.foundation-main"/><%
+    currentDesign.writeCssIncludes(pageContext); %>
+<script src="/libs/cq/ui/resources/cq-ui.js" type="text/javascript"></script>

--- a/content/src/main/content/jcr_root/etc/acs-commons/twitter-rate-limit-checker/.content.xml
+++ b/content/src/main/content/jcr_root/etc/acs-commons/twitter-rate-limit-checker/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        jcr:primaryType="cq:PageContent"
+        jcr:title="Twitter Rate Limit Checker"
+        sling:resourceType="acs-commons/components/utilities/twitter-rate-limit-checker"/>
+</jcr:root>


### PR DESCRIPTION
The crux of this change is to easily use the Twitter4J API using Cloud Service Configurations. With the adapter factory, you can adapt a page or a configuration.

To illustrate this, I also included a status page, accessible under miscadmin which outputs the current rate limit status of each configured Twitter cloud service.
![2013-10-31_1254](https://f.cloud.github.com/assets/65906/1447790/24706fc8-424d-11e3-83b3-b8f0480672dd.png)
