### PR TITLE
Add XSS JSP Functions

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -57,7 +57,8 @@
                             {maven-resources},
                             META-INF/wcmmode.tld=target/classes/META-INF/wcmmode.tld,
                             META-INF/audio.tld=target/classes/META-INF/audio.tld,
-                            META-INF/dhlm.tld=target/classes/META-INF/dhlm.tld
+                            META-INF/dhlm.tld=target/classes/META-INF/dhlm.tld,
+                            META-INF/xss.tld=target/classes/META-INF/xss.tld
                         </Include-Resource>
                     </instructions>
                 </configuration>

--- a/bundle/src/main/java/com/adobe/acs/commons/xss/XSSFunctions.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/xss/XSSFunctions.java
@@ -1,0 +1,178 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.xss;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import tldgen.Function;
+
+import com.adobe.granite.xss.XSSAPI;
+
+/**
+ * XSSAPI JSP Function wrappers.
+ */
+public final class XSSFunctions {
+
+    private static final String LINK_PREFIX = "<a href='";
+    private static final String LINK_SUFFIX = "'></a>";
+
+    private static final String MANGLE_NAMESPACE_IN_PREFIX = "/_";
+
+    private static final String MANGLE_NAMESPACE_IN_SUFFIX = "_";
+
+    private static final String MANGLE_NAMESPACE_OUT = "/([^:/]+):";
+
+    private static final String MANGLE_NAMESPACE_OUT_SUFFIX = ":";
+
+    private static final Pattern MANGLE_NAMESPACE_PATTERN = Pattern.compile(MANGLE_NAMESPACE_OUT);
+
+    /**
+     * Encode a string for HTML.
+     * 
+     * @param xssAPI the XSSAPI
+     * @param source the source string
+     * @return the encoded string
+     */
+    @Function
+    public static CharSequence encodeForHTML(XSSAPI xssAPI, String source) {
+        return xssAPI.encodeForHTML(source);
+    }
+
+    /**
+     * Encode a string for an HTML attribute.
+     * 
+     * @param xssAPI the XSSAPI
+     * @param source the source string
+     * @return the encoded string
+     */
+    @Function
+    public static CharSequence encodeForHTMLAttr(XSSAPI xssAPI, String source) {
+        return xssAPI.encodeForHTMLAttr(source);
+    }
+
+    /**
+     * Encode a string for an JavaScript string.
+     * 
+     * @param xssAPI the XSSAPI
+     * @param source the source string
+     * @return the encoded string
+     */
+    @Function
+    public static CharSequence encodeForJSString(XSSAPI xssAPI, String source) {
+        return xssAPI.encodeForJSString(source);
+    }
+
+    /**
+     * Filter a string for HTML.
+     * 
+     * @param xssAPI the XSSAPI
+     * @param source the source string
+     * @return the encoded string
+     */
+    @Function
+    public static CharSequence filterHTML(XSSAPI xssAPI, String source) {
+        return xssAPI.filterHTML(source);
+    }
+
+    /**
+     * Get a valid href. This does not use the standard XSS API due to a bug
+     * impacting CQ 5.6.1 (and earlier). Internal bug reference: GRANITE-4193
+     * 
+     * @param xssAPI the XSSAPI
+     * @param source the source string
+     * @return the encoded string
+     */
+    @Function
+    public static CharSequence getValidHref(XSSAPI xssAPI, String source) {
+        try {
+            final String testHtml = LINK_PREFIX + mangleNamespaces(source) + LINK_SUFFIX;
+
+            final String safeHtml = xssAPI.filterHTML(testHtml);
+            return safeHtml.substring(LINK_PREFIX.length(), safeHtml.length() - LINK_SUFFIX.length());
+        } catch (final Exception e) {
+            return "";
+        }
+    }
+
+    private static String mangleNamespaces(String absPath) {
+        if (absPath != null && absPath.contains(MANGLE_NAMESPACE_OUT_SUFFIX)) {
+            final Matcher m = MANGLE_NAMESPACE_PATTERN.matcher(absPath);
+
+            final StringBuffer buf = new StringBuffer();
+            while (m.find()) {
+                final String replacement = MANGLE_NAMESPACE_IN_PREFIX + m.group(1) + MANGLE_NAMESPACE_IN_SUFFIX;
+                m.appendReplacement(buf, replacement);
+            }
+
+            m.appendTail(buf);
+
+            absPath = buf.toString();
+        }
+
+        return absPath;
+    }
+    
+    private XSSFunctions() {
+    }
+
+    /**
+     * Validate a string which should contain a dimension, returning a default value if the source is
+     * empty, can't be parsed, or contains XSS risks.  Allows integer dimensions and the keyword "auto".
+     *
+     * @param xssAPI the XSSAPI
+     * @param dimension the source dimension
+     * @param defaultValue a default value if the source can't be used
+     * @return a sanitized dimension
+     */
+    @Function
+    public static String getValidDimension(XSSAPI xssAPI, String dimension, String defaultValue) {
+        return xssAPI.getValidDimension(dimension, defaultValue);
+    }
+    
+    /**
+     * Validate a string which should contain an integer, returning a default value if the source is
+     * empty, can't be parsed, or contains XSS risks.
+     *
+     * @param xssAPI the XSSAPI
+     * @param integer the source integer
+     * @param defaultValue a default value if the source can't be used
+     * @return a sanitized integer
+     */
+    @Function
+    public static Integer getValidInteger(XSSAPI xssAPI, String integer, int defaultValue) {
+        return xssAPI.getValidInteger(integer, defaultValue);
+    }
+
+    /**
+     * Validate a Javascript token.  The value must be either a single identifier, a literal number,
+     * or a literal string.
+     *
+     * @param xssAPI the XSSAPI
+     * @param token the source token
+     * @param defaultValue a default value to use if the source doesn't meet validity constraints.
+     * @return a string containing a single identifier, a literal number, or a literal string token
+     */
+    @Function
+    public static String getValidJSToken(XSSAPI xssAPI, String token, String defaultValue) {
+        return xssAPI.getValidJSToken(token, defaultValue);
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/xss/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/xss/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/**
+ * XSS JSP Functions.
+ */
+@aQute.bnd.annotation.Version("1.0.0")
+@tldgen.TagLibrary(value = "http://www.adobe.com/consulting/acs-aem-commons/xss", descriptorFile = "xss.tld")
+package com.adobe.acs.commons.xss;

--- a/bundle/src/test/java/com/adobe/acs/commons/xss/XSSFunctionsTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/xss/XSSFunctionsTest.java
@@ -1,0 +1,116 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.xss;
+
+import java.util.Random;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.adobe.granite.xss.XSSAPI;
+
+/**
+ * Note - these do not test the actual XSS functionality. They only test that
+ * the EL functions pass through to XSSAPI correctly.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class XSSFunctionsTest {
+
+    @Mock
+    private XSSAPI xssAPI;
+
+    @Test
+    public void testEncodeForHTML() {
+        final String test = new String();
+        XSSFunctions.encodeForHTML(xssAPI, test);
+        verify(xssAPI, only()).encodeForHTML(test);
+    }
+
+    @Test
+    public void testEncodeForHTMLAttr() {
+        final String test = new String();
+        XSSFunctions.encodeForHTMLAttr(xssAPI, test);
+        verify(xssAPI, only()).encodeForHTMLAttr(test);
+    }
+
+    @Test
+    public void testEncodeForJSString() {
+        final String test = new String();
+        XSSFunctions.encodeForJSString(xssAPI, test);
+        verify(xssAPI, only()).encodeForJSString(test);
+    }
+
+    @Test
+    public void testFilterHTML() {
+        final String test = new String();
+        XSSFunctions.filterHTML(xssAPI, test);
+        verify(xssAPI, only()).filterHTML(test);
+    }
+
+    @Test
+    public void testGetValidHrefUnMangled() {
+        final String test = "/content/foo.html";
+        final String expectedHtml = "<a href='/content/foo.html'></a>";
+        when(xssAPI.filterHTML(expectedHtml)).thenReturn(expectedHtml);
+        XSSFunctions.getValidHref(xssAPI, test);
+        verify(xssAPI, only()).filterHTML(expectedHtml);
+    }
+
+    @Test
+    public void testGetValidHrefMangled() {
+        final String test = "/content/foo/jcr:content/bar.html";
+        final String expectedHtml = "<a href='/content/foo/_jcr_content/bar.html'></a>";
+        when(xssAPI.filterHTML(expectedHtml)).thenReturn(expectedHtml);
+        XSSFunctions.getValidHref(xssAPI, test);
+        verify(xssAPI, only()).filterHTML(expectedHtml);
+    }
+
+    @Test
+    public void testGetValidDimension() {
+        final String dimension = RandomStringUtils.randomAlphanumeric(10);
+        final String defaultValue = RandomStringUtils.randomAlphanumeric(10);
+        XSSFunctions.getValidDimension(xssAPI, dimension, defaultValue);
+        verify(xssAPI, only()).getValidDimension(dimension, defaultValue);
+    }
+
+    @Test
+    public void testGetValidInteger() {
+        final String integer = RandomStringUtils.randomAlphanumeric(10);
+        final int defaultValue = new Random().nextInt();
+        XSSFunctions.getValidInteger(xssAPI, integer, defaultValue);
+        verify(xssAPI, only()).getValidInteger(integer, defaultValue);
+
+    }
+
+    @Test
+    public void testGetValidJSToken() {
+        final String token = RandomStringUtils.randomAlphanumeric(10);
+        final String defaultValue = RandomStringUtils.randomAlphanumeric(10);
+        XSSFunctions.getValidJSToken(xssAPI, token, defaultValue);
+        verify(xssAPI, only()).getValidJSToken(token, defaultValue);
+    }
+
+}


### PR DESCRIPTION
This pull request adds a series of JSP functions which wrap the Granite XSSAPI. Usage is like:

```
${xss:filterHTML(xssAPI, someString)}
```
