### PR TITLE
PostFormHelperImpl should not be a component; should be abstract

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/forms/helpers/impl/ForwardAsGetFormHelperImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/forms/helpers/impl/ForwardAsGetFormHelperImpl.java
@@ -22,8 +22,10 @@ package com.adobe.acs.commons.forms.helpers.impl;
 import com.adobe.acs.commons.forms.Form;
 import com.adobe.acs.commons.forms.helpers.FormHelper;
 import com.adobe.acs.commons.forms.helpers.ForwardAsGetFormHelper;
+import com.adobe.acs.commons.forms.helpers.PostFormHelper;
 import com.adobe.acs.commons.forms.helpers.impl.synthetics.SyntheticSlingHttpServletGetRequest;
 import com.day.cq.wcm.api.Page;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.felix.scr.annotations.*;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -35,11 +37,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletException;
+
 import java.io.IOException;
 
 @Component(label = "ACS AEM Commons - Forward Form Manager", description = "Internal Forward-as-GET Form Helper", enabled = true, metatype = true, immediate = false, inherit = true)
-@Service(value = { FormHelper.class, ForwardAsGetFormHelper.class })
-public class ForwardAsGetFormHelperImpl extends PostFormHelperImpl implements ForwardAsGetFormHelper {
+@Service
+public final class ForwardAsGetFormHelperImpl extends PostFormHelperImpl implements ForwardAsGetFormHelper, PostFormHelper, FormHelper {
     private static final Logger log = LoggerFactory.getLogger(ForwardAsGetFormHelperImpl.class);
     private static final String CQ_PAGE_RESOURCE_TYPE = "cq/Page";
 

--- a/bundle/src/main/java/com/adobe/acs/commons/forms/helpers/impl/PostFormHelperImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/forms/helpers/impl/PostFormHelperImpl.java
@@ -19,37 +19,36 @@
  */
 package com.adobe.acs.commons.forms.helpers.impl;
 
-import com.adobe.acs.commons.forms.Form;
-import com.adobe.acs.commons.forms.helpers.FormHelper;
-import com.adobe.acs.commons.forms.helpers.PostFormHelper;
-import com.adobe.acs.commons.util.PathInfoUtil;
-import com.adobe.granite.xss.XSSAPI;
-import com.day.cq.wcm.api.Page;
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.felix.scr.annotations.*;
+import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Reference;
 import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestParameter;
 import org.apache.sling.api.request.RequestParameterMap;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
-import org.apache.sling.commons.json.JSONException;
 import org.apache.sling.commons.osgi.PropertiesUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.ServletException;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
-import java.util.Map;
+import com.adobe.acs.commons.forms.Form;
+import com.adobe.acs.commons.forms.helpers.FormHelper;
+import com.adobe.acs.commons.forms.helpers.PostFormHelper;
+import com.adobe.acs.commons.util.PathInfoUtil;
+import com.adobe.granite.xss.XSSAPI;
+import com.day.cq.wcm.api.Page;
 
-@Component(label = "ACS AEM Commons - Abstract POST Form Helper", description = "Abstract Form Helper. Do not use directly; instead use the PostRedirectGetFormHelper or ForwardAsGetFormHelper.", enabled = true, metatype = false, immediate = false)
-@Service(value = PostFormHelper.class)
-public class PostFormHelperImpl implements PostFormHelper {
+@Component(componentAbstract = true)
+public abstract class PostFormHelperImpl implements PostFormHelper {
     private static final Logger log = LoggerFactory.getLogger(PostFormHelperImpl.class);
     static final String[] FORM_INPUTS = { FORM_NAME_INPUT, FORM_RESOURCE_INPUT };
 
@@ -64,18 +63,15 @@ public class PostFormHelperImpl implements PostFormHelper {
      */
     private static final String DEFAULT_SUFFIX = "/submit/form";
     private String suffix = DEFAULT_SUFFIX;
-    @Property(label = "Suffix", description = "Forward-as-GET Request Suffix used to identify Forward-as-GET POST Request", value = DEFAULT_SUFFIX)
+    @Property(label = "Suffix",
+            description = "Forward-as-GET Request Suffix used to identify Forward-as-GET POST Request",
+            value = DEFAULT_SUFFIX)
     private static final String PROP_SUFFIX = "prop.form-suffix";
 
     @Override
-    public Form getForm(String formName, SlingHttpServletRequest request) {
-        throw new UnsupportedOperationException("Do not call AbstractFormHelper.getForm(..) direct. This is an abstract service.");
-    }
-
-    @Override
-	public String getFormInputsHTML(final Form form, final String... keys) {
+    public final String getFormInputsHTML(final Form form, final String... keys) {
         // The form objects data and errors should be xssProtected before being passed into this method
-		StringBuffer html = new StringBuffer();
+        StringBuffer html = new StringBuffer();
 
         html.append("<input type=\"hidden\" name=\"").append(FORM_NAME_INPUT).append("\" value=\"")
                 .append(xssApi.encodeForHTMLAttr(form.getName())).append("\"/>\n");
@@ -84,23 +80,23 @@ public class PostFormHelperImpl implements PostFormHelper {
         html.append("<input type=\"hidden\" name=\"").append(FORM_RESOURCE_INPUT).append("\" value=\"")
                 .append(xssApi.encodeForHTMLAttr(resourcePath)).append("\"/>\n");
 
-		for (final String key : keys) {
-			if (form.has(key)) {
-				html.append("<input type=\"hidden\" name=\"").append(key).append("\" value=\"")
-						.append(form.get(key)).append("\"/>\n");
-			}
-		}
+        for (final String key : keys) {
+            if (form.has(key)) {
+                html.append("<input type=\"hidden\" name=\"").append(key).append("\" value=\"")
+                        .append(form.get(key)).append("\"/>\n");
+            }
+        }
 
-		return html.toString();
-	}
+        return html.toString();
+    }
 
     @Override
-    public String getAction(final String path) {
+    public final String getAction(final String path) {
         return getAction(path, null);
     }
 
     @Override
-    public String getAction(final String path, final String formSelector) {
+    public final String getAction(final String path, final String formSelector) {
         String actionPath = path;
 
         ResourceResolver adminResourceResolver = null;
@@ -111,13 +107,13 @@ public class PostFormHelperImpl implements PostFormHelper {
             log.error("Could not attain an admin ResourceResolver to map the Form's Action URI");
             // Use the unmapped ActionPath
         } finally {
-            if(adminResourceResolver != null && adminResourceResolver.isLive()) {
+            if (adminResourceResolver != null && adminResourceResolver.isLive()) {
                 adminResourceResolver.close();
             }
         }
 
         actionPath += FormHelper.EXTENSION + this.getSuffix();
-        if(StringUtils.isNotBlank(formSelector)) {
+        if (StringUtils.isNotBlank(formSelector)) {
             actionPath += "/" + formSelector;
         }
 
@@ -125,57 +121,27 @@ public class PostFormHelperImpl implements PostFormHelper {
     }
 
     @Override
-    public void renderForm(Form form, String path, SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException, ServletException, JSONException {
-        throw new UnsupportedOperationException("Use a specific Forms implementation helper.");
-    }
-
-    @Override
-    public void renderForm(Form form, Page page, SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException, ServletException, JSONException {
-        throw new UnsupportedOperationException("Use a specific Forms implementation helper.");
-    }
-
-    @Override
-    public void renderForm(Form form, Resource resource, SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException, ServletException, JSONException {
-        throw new UnsupportedOperationException("Use a specific Forms implementation helper.");
-    }
-
-    @Override
-    public void renderOtherForm(Form form, String path, String selectors, SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException, ServletException, JSONException {
-        throw new UnsupportedOperationException("Use a specific Forms implementation helper.");
-    }
-
-    @Override
-    public void renderOtherForm(Form form, Page page, String selectors, SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException, ServletException, JSONException {
-        throw new UnsupportedOperationException("Use a specific Forms implementation helper.");
-    }
-
-    @Override
-    public void renderOtherForm(Form form, Resource resource, String selectors, SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException, ServletException, JSONException {
-        throw new UnsupportedOperationException("Use a specific Forms implementation helper.");
-    }
-
-    @Override
-    public String getAction(final Resource resource) {
+    public final String getAction(final Resource resource) {
         return getAction(resource.getPath());
     }
 
     @Override
-    public String getAction(final Resource resource, final String formSelector) {
+    public final String getAction(final Resource resource, final String formSelector) {
         return getAction(resource.getPath(), formSelector);
     }
 
     @Override
-    public String getAction(final Page page) {
+    public final String getAction(final Page page) {
         return getAction(page.getPath());
     }
 
     @Override
-    public String getAction(final Page page, final String formSelector) {
+    public final String getAction(final Page page, final String formSelector) {
         return getAction(page.getPath(), formSelector);
     }
 
     @Override
-    public String getSuffix() {
+    public final String getSuffix() {
         return this.suffix;
     }
 
@@ -187,7 +153,7 @@ public class PostFormHelperImpl implements PostFormHelper {
      * @return
      */
     protected boolean doHandlePost(final String formName, final SlingHttpServletRequest request) {
-        if(StringUtils.equalsIgnoreCase("POST", request.getMethod())) {
+        if (StringUtils.equalsIgnoreCase("POST", request.getMethod())) {
             // Form should have a hidden input with the name this.getLookupKey(..) and value formName
             return StringUtils.equals(formName, request.getParameter(this.getPostLookupKey(formName)));
         } else {
@@ -202,16 +168,16 @@ public class PostFormHelperImpl implements PostFormHelper {
      * @param request
      * @return
      */
-    protected Form getPostForm(final String formName,
-                            final SlingHttpServletRequest request) {
+    protected Form getPostForm(final String formName, final SlingHttpServletRequest request) {
         final Map<String, String> map = new HashMap<String, String>();
-
 
         final RequestParameterMap requestMap = request.getRequestParameterMap();
 
         for (final String key : requestMap.keySet()) {
             // POST LookupKey formName param does not matter
-            if(StringUtils.equals(key, this.getPostLookupKey(null))) { continue; }
+            if (StringUtils.equals(key, this.getPostLookupKey(null))) {
+                continue;
+            }
 
             final RequestParameter[] values = requestMap.getValues(key);
 
@@ -222,12 +188,12 @@ public class PostFormHelperImpl implements PostFormHelper {
                 map.put(key, values[0].getString());
             } else {
                 // TODO: Handle multi-value parameter values; Requires support for transporting them and re-writing them back into HTML Form on error
-                for(final RequestParameter value : values) {
+                for (final RequestParameter value : values) {
                     // Use the first non-blank value, or use the last value (which will be blank or not-blank)
                     final String tmp = value.toString();
                     map.put(key, tmp);
 
-                    if(StringUtils.isNotBlank(tmp)) {
+                    if (StringUtils.isNotBlank(tmp)) {
                         break;
                     }
                 }
@@ -258,8 +224,8 @@ public class PostFormHelperImpl implements PostFormHelper {
         final Map<String, String> map = form.getData();
         final Map<String, String> cleanedMap = new HashMap<String, String>();
 
-        for(final Map.Entry<String, String> entry : map.entrySet()) {
-            if(!ArrayUtils.contains(FORM_INPUTS, entry.getKey()) && StringUtils.isNotBlank(entry.getValue())) {
+        for (final Map.Entry<String, String> entry : map.entrySet()) {
+            if (!ArrayUtils.contains(FORM_INPUTS, entry.getKey()) && StringUtils.isNotBlank(entry.getValue())) {
                 cleanedMap.put(entry.getKey(), entry.getValue());
             }
         }
@@ -274,9 +240,7 @@ public class PostFormHelperImpl implements PostFormHelper {
      * @return
      */
     protected Form getProtectedForm(final Form form) {
-        return new Form(form.getName(),
-                form.getResourcePath(),
-                this.getProtectedData(form.getData()),
+        return new Form(form.getName(), form.getResourcePath(), this.getProtectedData(form.getData()),
                 this.getProtectedErrors(form.getErrors()));
     }
 
@@ -314,11 +278,10 @@ public class PostFormHelperImpl implements PostFormHelper {
         return protectedErrors;
     }
 
-
-    public boolean hasValidSuffix(final SlingHttpServletRequest slingRequest) {
+    public final boolean hasValidSuffix(final SlingHttpServletRequest slingRequest) {
         final String requestSuffix = slingRequest.getRequestPathInfo().getSuffix();
-        if(StringUtils.equals(requestSuffix, this.getSuffix()) ||
-                StringUtils.startsWith(requestSuffix, this.getSuffix() + "/")) {
+        if (StringUtils.equals(requestSuffix, this.getSuffix())
+                || StringUtils.startsWith(requestSuffix, this.getSuffix() + "/")) {
             return true;
         }
 
@@ -331,15 +294,15 @@ public class PostFormHelperImpl implements PostFormHelper {
      * @param slingRequest
      * @return
      */
-    public String getFormSelector(final SlingHttpServletRequest slingRequest) {
+    public final String getFormSelector(final SlingHttpServletRequest slingRequest) {
         final String requestSuffix = slingRequest.getRequestPathInfo().getSuffix();
-        if(StringUtils.equals(requestSuffix, this.getSuffix()) ||
-                !StringUtils.startsWith(requestSuffix, this.getSuffix() + "/")) {
+        if (StringUtils.equals(requestSuffix, this.getSuffix())
+                || !StringUtils.startsWith(requestSuffix, this.getSuffix() + "/")) {
             return null;
         }
 
         final int segments = StringUtils.split(this.getSuffix(), '/').length;
-        if(segments < 1) {
+        if (segments < 1) {
             return null;
         }
 
@@ -354,7 +317,7 @@ public class PostFormHelperImpl implements PostFormHelper {
      * @return
      */
     protected String encode(String unencoded) {
-        if(StringUtils.isBlank(unencoded)) {
+        if (StringUtils.isBlank(unencoded)) {
             return "";
         }
 
@@ -372,7 +335,7 @@ public class PostFormHelperImpl implements PostFormHelper {
      * @return
      */
     protected String decode(String encoded) {
-        if(StringUtils.isBlank(encoded)) {
+        if (StringUtils.isBlank(encoded)) {
             return "";
         }
 
@@ -386,7 +349,7 @@ public class PostFormHelperImpl implements PostFormHelper {
     @Activate
     protected void activate(final Map<String, String> properties) {
         this.suffix = PropertiesUtil.toString(properties.get(PROP_SUFFIX), DEFAULT_SUFFIX);
-        if(StringUtils.isBlank(this.suffix)) {
+        if (StringUtils.isBlank(this.suffix)) {
             // No whitespace please
             this.suffix = DEFAULT_SUFFIX;
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/forms/helpers/impl/PostRedirectGetFormHelperImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/forms/helpers/impl/PostRedirectGetFormHelperImpl.java
@@ -19,11 +19,13 @@
  */
 package com.adobe.acs.commons.forms.helpers.impl;
 
-import com.adobe.acs.commons.forms.Form;
-import com.adobe.acs.commons.forms.helpers.FormHelper;
-import com.adobe.acs.commons.forms.helpers.PostRedirectGetFormHelper;
-import com.adobe.acs.commons.util.TypeUtil;
-import com.day.cq.wcm.api.Page;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Service;
@@ -35,91 +37,107 @@ import org.apache.sling.commons.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.ServletException;
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
-import java.util.Map;
+import com.adobe.acs.commons.forms.Form;
+import com.adobe.acs.commons.forms.helpers.FormHelper;
+import com.adobe.acs.commons.forms.helpers.PostFormHelper;
+import com.adobe.acs.commons.forms.helpers.PostRedirectGetFormHelper;
+import com.adobe.acs.commons.util.TypeUtil;
+import com.day.cq.wcm.api.Page;
 
-@Component(label = "ACS AEM Commons - POST-Redirect-GET Form Helper", description = "POST-Redirect-GET Form Helper", enabled = true, metatype = false, immediate = false, inherit = true)
-@Service(value = { FormHelper.class, PostRedirectGetFormHelper.class })
-public class PostRedirectGetFormHelperImpl extends PostFormHelperImpl implements PostRedirectGetFormHelper {
+@Component(label = "ACS AEM Commons - POST-Redirect-GET Form Helper",
+        description = "POST-Redirect-GET Form Helper", enabled = true, metatype = false, immediate = false,
+        inherit = true)
+@Service
+public final class PostRedirectGetFormHelperImpl extends PostFormHelperImpl implements PostRedirectGetFormHelper, PostFormHelper, FormHelper {
     private static final Logger log = LoggerFactory.getLogger(PostRedirectGetFormHelperImpl.class);
 
     @Override
     public Form getForm(final String formName, final SlingHttpServletRequest request) {
-		if (this.doHandlePost(formName, request)) {
-			log.debug("Getting FORM [ {} ] from POST parameters", formName);
-			return this.getPostForm(formName, request);
-		} else if (this.doHandleGet(formName, request)) {
+        if (this.doHandlePost(formName, request)) {
+            log.debug("Getting FORM [ {} ] from POST parameters", formName);
+            return this.getPostForm(formName, request);
+        } else if (this.doHandleGet(formName, request)) {
             log.debug("Getting FORM [ {} ] from GET parameters", formName);
             return this.getGetForm(formName, request);
         }
 
         log.debug("Creating empty form for FORM [ {} ]", formName);
         return new Form(formName, request.getResource().getPath());
-	}
+    }
 
     @Override
-    public void sendRedirect(Form form, String path, SlingHttpServletResponse response) throws IOException, JSONException {
+    public void sendRedirect(Form form, String path, SlingHttpServletResponse response) throws IOException,
+            JSONException {
         this.sendRedirect(form, path, null, response);
     }
 
     @Override
-    public void sendRedirect(Form form, Page page, SlingHttpServletResponse response) throws IOException, JSONException {
+    public void sendRedirect(Form form, Page page, SlingHttpServletResponse response) throws IOException,
+            JSONException {
         this.sendRedirect(form, page, null, response);
     }
 
     @Override
-    public void sendRedirect(Form form, Resource resource, SlingHttpServletResponse response) throws IOException, JSONException {
+    public void sendRedirect(Form form, Resource resource, SlingHttpServletResponse response) throws IOException,
+            JSONException {
         this.sendRedirect(form, resource, null, response);
     }
 
     @Override
-    public void sendRedirect(Form form, String path, String formSelector, SlingHttpServletResponse response) throws IOException, JSONException {
+    public void sendRedirect(Form form, String path, String formSelector, SlingHttpServletResponse response)
+            throws IOException, JSONException {
         final String url = this.getRedirectPath(form, path, formSelector);
         response.sendRedirect(url);
     }
 
     @Override
-    public void sendRedirect(Form form, Page page, String formSelector, SlingHttpServletResponse response) throws IOException, JSONException {
+    public void sendRedirect(Form form, Page page, String formSelector, SlingHttpServletResponse response)
+            throws IOException, JSONException {
         final String url = this.getRedirectPath(form, page, formSelector);
         response.sendRedirect(url);
     }
 
     @Override
-    public void sendRedirect(Form form, Resource resource, String formSelector, SlingHttpServletResponse response) throws IOException, JSONException {
+    public void sendRedirect(Form form, Resource resource, String formSelector, SlingHttpServletResponse response)
+            throws IOException, JSONException {
         final String url = this.getRedirectPath(form, resource, formSelector);
         response.sendRedirect(url);
     }
 
     @Override
-    public void renderForm(final Form form, final Page page, final SlingHttpServletRequest request, final SlingHttpServletResponse response) throws IOException, ServletException, JSONException {
+    public void renderForm(final Form form, final Page page, final SlingHttpServletRequest request,
+            final SlingHttpServletResponse response) throws IOException, ServletException, JSONException {
         this.sendRedirect(form, page, this.getFormSelector(request), response);
     }
 
     @Override
-    public void renderForm(final Form form, final Resource resource, final SlingHttpServletRequest request, final SlingHttpServletResponse response) throws IOException, ServletException, JSONException {
+    public void renderForm(final Form form, final Resource resource, final SlingHttpServletRequest request,
+            final SlingHttpServletResponse response) throws IOException, ServletException, JSONException {
         this.sendRedirect(form, resource, this.getFormSelector(request), response);
     }
 
     @Override
-    public void renderForm(final Form form, final String path, final SlingHttpServletRequest request, final SlingHttpServletResponse response) throws IOException, ServletException, JSONException {
+    public void renderForm(final Form form, final String path, final SlingHttpServletRequest request,
+            final SlingHttpServletResponse response) throws IOException, ServletException, JSONException {
         this.sendRedirect(form, path, this.getFormSelector(request), response);
     }
 
     @Override
-    public void renderOtherForm(Form form, String path, String formSelector, SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException, ServletException, JSONException {
+    public void renderOtherForm(Form form, String path, String formSelector, SlingHttpServletRequest request,
+            SlingHttpServletResponse response) throws IOException, ServletException, JSONException {
         this.sendRedirect(form, path, formSelector, response);
     }
 
     @Override
-    public void renderOtherForm(Form form, Page page, String formSelector, SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException, ServletException, JSONException {
+    public void renderOtherForm(Form form, Page page, String formSelector, SlingHttpServletRequest request,
+            SlingHttpServletResponse response) throws IOException, ServletException, JSONException {
         this.sendRedirect(form, page, formSelector, response);
     }
 
     @Override
-    public void renderOtherForm(Form form, Resource resource, String formSelector, SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException, ServletException, JSONException {
+    public void renderOtherForm(Form form, Resource resource, String formSelector,
+            SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException,
+            ServletException, JSONException {
         this.sendRedirect(form, resource, formSelector, response);
     }
 
@@ -160,7 +178,7 @@ public class PostRedirectGetFormHelperImpl extends PostFormHelperImpl implements
      * @param request
      * @return
      */
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings({ "unchecked" })
     protected Form getGetForm(final String formName, final SlingHttpServletRequest request) {
         Map<String, String> data = new HashMap<String, String>();
         Map<String, String> errors = new HashMap<String, String>();
@@ -168,7 +186,7 @@ public class PostRedirectGetFormHelperImpl extends PostFormHelperImpl implements
         // Get the QP lookup for this form
         final String requestData = this.decode(request.getParameter(this.getGetLookupKey(formName)));
 
-        if(StringUtils.isBlank(requestData)) {
+        if (StringUtils.isBlank(requestData)) {
             return new Form(formName, request.getResource().getPath());
         }
 
@@ -178,16 +196,16 @@ public class PostRedirectGetFormHelperImpl extends PostFormHelperImpl implements
             final String incomingFormName = jsonData.optString(KEY_FORM_NAME);
 
             // Double-check the form names; only inject matching forms
-            if(StringUtils.equals(incomingFormName, formName)) {
+            if (StringUtils.equals(incomingFormName, formName)) {
                 final JSONObject incomingJsonForm = jsonData.optJSONObject(KEY_FORM);
-                if(incomingJsonForm != null) {
+                if (incomingJsonForm != null) {
                     data = TypeUtil.toMap(incomingJsonForm, String.class);
                     log.debug("Form data: {}", data);
                 }
 
                 final JSONObject incomingJsonErrors = jsonData.optJSONObject(KEY_ERRORS);
 
-                if(incomingJsonErrors != null) {
+                if (incomingJsonErrors != null) {
                     errors = TypeUtil.toMap(incomingJsonErrors, String.class);
                     log.debug("Form data: {}", errors);
                 }
@@ -197,9 +215,7 @@ public class PostRedirectGetFormHelperImpl extends PostFormHelperImpl implements
             return new Form(formName, request.getResource().getPath());
         }
 
-        return new Form(formName,
-                request.getResource().getPath(),
-                this.getProtectedData(data),
+        return new Form(formName, request.getResource().getPath(), this.getProtectedData(data),
                 this.getProtectedErrors(errors));
     }
 
@@ -222,8 +238,8 @@ public class PostRedirectGetFormHelperImpl extends PostFormHelperImpl implements
      * @throws org.apache.sling.commons.json.JSONException
      * @throws java.io.UnsupportedEncodingException
      */
-    protected String getRedirectPath(final Form form, final Page page, final String formSelector) throws JSONException,
-            UnsupportedEncodingException {
+    protected String getRedirectPath(final Form form, final Page page, final String formSelector)
+            throws JSONException, UnsupportedEncodingException {
         return getRedirectPath(form, page.adaptTo(Resource.class), formSelector);
     }
 
@@ -236,8 +252,8 @@ public class PostRedirectGetFormHelperImpl extends PostFormHelperImpl implements
      * @throws org.apache.sling.commons.json.JSONException
      * @throws java.io.UnsupportedEncodingException
      */
-    protected String getRedirectPath(final Form form, final Resource resource, final String formSelector) throws JSONException,
-            UnsupportedEncodingException {
+    protected String getRedirectPath(final Form form, final Resource resource, final String formSelector)
+            throws JSONException, UnsupportedEncodingException {
         return getRedirectPath(form, resource.getPath() + FormHelper.EXTENSION, formSelector);
     }
 
@@ -249,10 +265,11 @@ public class PostRedirectGetFormHelperImpl extends PostFormHelperImpl implements
      * @return
      * @throws org.apache.sling.commons.json.JSONException
      */
-    protected String getRedirectPath(final Form form, final String path, final String formSelector) throws JSONException {
+    protected String getRedirectPath(final Form form, final String path, final String formSelector)
+            throws JSONException {
         String redirectPath = path;
         redirectPath += this.getSuffix();
-        if(StringUtils.isNotBlank(formSelector)) {
+        if (StringUtils.isNotBlank(formSelector)) {
             redirectPath += "/" + formSelector;
         }
         redirectPath += "?";
@@ -277,19 +294,19 @@ public class PostRedirectGetFormHelperImpl extends PostFormHelperImpl implements
 
         jsonData.put(KEY_FORM_NAME, form.getName());
 
-        if(form.hasData()) {
+        if (form.hasData()) {
             final JSONObject jsonForm = new JSONObject(form.getData());
             jsonData.put(KEY_FORM, jsonForm);
             hasData = true;
         }
 
-        if(form.hasErrors()) {
+        if (form.hasErrors()) {
             final JSONObject jsonError = new JSONObject(form.getErrors());
             jsonData.put(KEY_ERRORS, jsonError);
             hasData = true;
         }
 
-        if(hasData) {
+        if (hasData) {
             params = this.getGetLookupKey(form.getName());
             params += "=";
             params += this.encode(jsonData.toString());


### PR DESCRIPTION
While looking at some of the Checkstyle errors, I noticed that PostFormHelperImpl had some UnsupportedOperationException methods, suggesting that it really should be abstract.
