### PR TITLE
Submit the auto resized image component.

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/components/content/image/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/content/image/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="Auto Resized Image"
+    sling:resourceSuperType="foundation/components/image"
+    allowedParents="[*/parsys]"
+    componentGroup="General"/>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/content/image/img.GET.java
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/content/image/img.GET.java
@@ -1,0 +1,144 @@
+package apps.acs_002dcommons.components.content.image;
+
+import java.awt.Rectangle;
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+
+import com.day.cq.commons.ImageResource;
+import com.day.cq.wcm.commons.AbstractImageServlet;
+import com.day.cq.wcm.foundation.Image;
+import com.day.image.Layer;
+
+/**
+ * Image render servlet to process the required image resource.
+ */
+
+public class img_GET extends AbstractImageServlet {
+
+    private static final long serialVersionUID = 2954340003021517742L;
+    private static final int MAX_HEIGHT = 1024;
+    private static final int MAX_WIDTH = 1024;
+    private static final int MIN_SELECTOR_LENGTH = 3;
+
+    protected final Layer createLayer(ImageContext c)
+    throws RepositoryException, IOException {
+        // don't create the later yet. handle everything later
+        return null;
+    }
+
+    @Override
+    protected final ImageResource createImageResource(Resource resource) {
+        return new Image(resource);
+    }
+
+    protected final void writeLayer(SlingHttpServletRequest req, SlingHttpServletResponse resp, ImageContext c,
+                                     Layer layer) throws IOException, RepositoryException {
+        boolean modified = false;
+        double selectorWidth = 0.0, selectorHeight = 0.0;
+
+        Image image = new Image(c.resource);
+
+        if (!image.hasContent()) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        String[] selectors = null;
+        if (req.getRequestPathInfo().getSelectors() != null) {
+            selectors = req.getRequestPathInfo().getSelectors();
+            if (selectors.length >= MIN_SELECTOR_LENGTH) {
+                selectorWidth = Integer.parseInt(selectors[1]);
+                selectorHeight = Integer.parseInt(selectors[2]);
+
+            }
+
+            if (selectorWidth > MAX_WIDTH || selectorHeight > MAX_HEIGHT) {
+                resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+                resp.getWriter().write("The sclaed size is too big.");
+                return;
+            }
+        } else {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+            resp.getWriter().write("NO selector found.");
+            return;
+        }
+
+        image.loadStyleData(c.style);
+
+        layer = image.getLayer(false, false, false);
+
+        if (layer == null) {
+            resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+            resp.getWriter().write("Can not get Layer.");
+            return;
+        }
+
+        if (layer != null) {
+            if (selectors.length < MIN_SELECTOR_LENGTH) {
+                selectorWidth = layer.getWidth();
+                selectorHeight = layer.getHeight();
+            }
+
+            modified = image.crop(layer) != null;
+
+            modified |= image.rotate(layer) != null;
+
+            modified |= image.resize(layer) != null;
+
+            modified |= applyDiff(layer, c);
+
+            modified |= autoResizeImage(selectorWidth, selectorHeight, layer) != null;
+       }
+
+      if (modified) {
+          resp.setContentType("image/png");
+          layer.write("image/png", 1.0, resp.getOutputStream());
+      } else {
+          Property data = image.getData();
+          InputStream in = data.getStream();
+          resp.setContentLength((int) data.getLength());
+          resp.setContentType(image.getMimeType());
+          IOUtils.copy(in, resp.getOutputStream());
+          in.close();
+      }
+        resp.flushBuffer();
+    }
+
+    private Layer autoResizeImage(double selectorWidth, double selectorHeight, Layer layer) {
+        double actualImageWidth = layer.getWidth();
+        double actualImageHeight = layer.getHeight();
+
+        double widthNum = (selectorWidth / actualImageWidth);
+        double heigthNum = (selectorHeight / actualImageHeight);
+
+        double resizedWidth = actualImageWidth;
+        double resizedHeight = actualImageHeight;
+
+        resizedWidth = actualImageWidth * ((heigthNum > widthNum) ? heigthNum : widthNum);
+        resizedHeight = actualImageHeight * ((heigthNum > widthNum) ? heigthNum : widthNum);
+
+        layer.resize((int) resizedWidth, (int) resizedHeight);
+
+        selectorWidth = (int) selectorWidth == 0 ? resizedWidth : selectorWidth;
+        selectorHeight = (int) selectorHeight == 0 ? resizedHeight : selectorHeight;
+
+        int diffHeight = (int) (resizedHeight - selectorHeight);
+        int newHeight = (int) (resizedHeight - diffHeight);
+
+        int diffWidth = (int) (resizedWidth - selectorWidth);
+        int newWidth = (int) (resizedWidth - diffWidth);
+
+        layer.crop(new Rectangle(diffWidth / 2, diffHeight / 2, newWidth, newHeight));
+
+        return layer;
+    }
+}


### PR DESCRIPTION
Auto Scaled Image is a component that can easily resize/rescale an image using Sling request selectors while preserving the origin aspect ratio.
There are 2 possible ways to use it.
1.  Inheriting this component or using it as your image component instead of using /libs/foundation/components/image component.
2.  If your image component does not want to inherit this component, you can copy the img_GET.java file to your component.
Note: 1) If using the 2nd way above,you need modified the first line of img_GET.java file to change class package to the component path. 
         2). If you need to render large image (width or height > 1024), Please modify the constants MAX_HEIGHT/MAX_WIDTH in the img_GET.java file.

How to Refer to an resized image
In short, using’.img.XXX.YYY.’as the image request selectors where XXX represents new width number and YYY represents new height ones. For example,
There are an image node in /content/geometrixx-outdoors/en/men/shirts/ashanti/jcr:content/par/product/image, whose sling:resourceType is ‘acs-commons/components/content/image’.

![image](https://f.cloud.github.com/assets/4326886/1907230/ff6b440c-7cc4-11e3-8de6-3244578b4676.png)
The node referred to winter.jpg image whose original size is 926x386.
a) If using content/geometrixx-outdoors/en/men/shirts/ashanti/jcr:content/par/product/image.img.200.200.jpg to address the image, the response is as below:

![image](https://f.cloud.github.com/assets/4326886/1907231/0e6d5972-7cc5-11e3-81bd-c0483963e0d0.png)

The image is first resized to 480x200 and then cropped to a 200x200 square at the center, and keeping the original aspect ratio.
b) If using content/geometrixx-outdoors/en/men/shirts/ashanti/jcr:content/par/product/image.img.0.200.jpg or content/geometrixx-outdoors/en/men/shirts/ashanti/jcr:content/par/product/image.img.480.0.jpg to address the image, the response is as below:
![image](https://f.cloud.github.com/assets/4326886/1907233/223deae8-7cc5-11e3-97dc-ba5fe1e078ca.png)
The image is resized to 480x200 with the aspect ratio kept.

c) If no size selectors are specified, the original image is rendered.
/content/geometrixxoutdoors/en/men/shirts/ashanti/jcr:content/par/product/image.img.jpg
![image](https://f.cloud.github.com/assets/4326886/1907236/362f5d70-7cc5-11e3-8cb4-e1ddc1d403f4.png)
