### PR TITLE
use md5sum instead of last mode date for versionedClientlibs

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -122,6 +122,11 @@
             <artifactId>org.apache.sling.jcr.api</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.5</version>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.4</version>

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactory.java
@@ -24,6 +24,7 @@ import com.day.cq.commons.PathInfo;
 import com.day.cq.widget.HtmlLibrary;
 import com.day.cq.widget.HtmlLibraryManager;
 import com.day.cq.widget.LibraryType;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Property;
@@ -39,7 +40,7 @@ import org.xml.sax.helpers.AttributesImpl;
 
 @Component(
         label = "ACS AEM Commons - Versioned Clientlibs (CSS/JS) Rewriter",
-        description = "Re-writes paths to CSS and JS clientlibs to include the last modified timestamp as a "
+        description = "Re-writes paths to CSS and JS clientlibs to include the md5 checksum as a "
                 + "selector; in the form: /path/to/clientlib.123456789.css")
 @Property(name = "pipeline.type",
         value = "versioned-clientlibs",
@@ -136,7 +137,7 @@ public final class VersionedClientlibsTransformerFactory implements TransformerF
                 if (selector != null) {
                     builder.append(selector).append(".");
                 }
-                builder.append(htmlLibrary.getLastModified());
+                builder.append(DigestUtils.md5Hex(htmlLibrary.getInputStream()));
                 builder.append(libraryType.extension);
 
                 return builder.toString();

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactoryTest.java
@@ -61,11 +61,13 @@ public class VersionedClientlibsTransformerFactoryTest {
     private Transformer transformer;
 
     private final String PATH = "/etc/clientlibs/test";
+    private final String FAKE_STREAM_CHECKSUM="fcadcfb01c1367e9e5b7f2e6d455ba8f";
 
     @Before
     public void setUp() throws Exception {
         when(htmlLibrary.getLibraryPath()).thenReturn(PATH);
-        when(htmlLibrary.getLastModified()).thenReturn(123L);
+        when(htmlLibrary.getInputStream()).thenReturn(new java.io.ByteArrayInputStream("I love strings".getBytes()));
+        //when(htmlLibrary.getLastModified()).thenReturn(123L);
 
         transformer = factory.createTransformer();
         transformer.setContentHandler(handler);
@@ -113,7 +115,7 @@ public class VersionedClientlibsTransformerFactoryTest {
         verify(handler, only()).startElement(isNull(String.class), eq("link"), isNull(String.class),
                 attributesCaptor.capture());
 
-        assertEquals(PATH + ".123.css", attributesCaptor.getValue().getValue(0));
+        assertEquals(PATH + "."+ FAKE_STREAM_CHECKSUM +".css", attributesCaptor.getValue().getValue(0));
     }
 
     @Test
@@ -133,7 +135,7 @@ public class VersionedClientlibsTransformerFactoryTest {
         verify(handler, only()).startElement(isNull(String.class), eq("link"), isNull(String.class),
                 attributesCaptor.capture());
 
-        assertEquals(PATH + ".min.123.css", attributesCaptor.getValue().getValue(0));
+        assertEquals(PATH + ".min."+ FAKE_STREAM_CHECKSUM +".css", attributesCaptor.getValue().getValue(0));
     }
 
     @Test
@@ -152,7 +154,7 @@ public class VersionedClientlibsTransformerFactoryTest {
         verify(handler, only()).startElement(isNull(String.class), eq("script"), isNull(String.class),
                 attributesCaptor.capture());
 
-        assertEquals(PATH + ".123.js", attributesCaptor.getValue().getValue(0));
+        assertEquals(PATH + "."+ FAKE_STREAM_CHECKSUM +".js", attributesCaptor.getValue().getValue(0));
     }
 
     @Test
@@ -171,7 +173,7 @@ public class VersionedClientlibsTransformerFactoryTest {
         verify(handler, only()).startElement(isNull(String.class), eq("script"), isNull(String.class),
                 attributesCaptor.capture());
 
-        assertEquals(PATH + ".min.123.js", attributesCaptor.getValue().getValue(0));
+        assertEquals(PATH + ".min."+ FAKE_STREAM_CHECKSUM +".js", attributesCaptor.getValue().getValue(0));
     }
 
     @Test


### PR DESCRIPTION
The last mod date of the client lib is used for the version string.  This date could change across publish instances.  Using the md5 sum based upon the contents of the client lib will enable a consist string across all instances.
