### PR TITLE
adding a utility class to reduce boilerplate when working with TCCL

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/util/ThreadContextClassLoaderTaskExecutor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/ThreadContextClassLoaderTaskExecutor.java
@@ -1,0 +1,48 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.util;
+
+import java.util.concurrent.Callable;
+
+/**
+ * Utility class for executing a particular task with a set Thread Context Class Loader.
+ */
+public final class ThreadContextClassLoaderTaskExecutor {
+
+    /**
+     * Execute the task while the Thread Context Class Loader is set to the provided
+     * Class Loader.
+     * 
+     * @param classLoader the requested class loader
+     * @param task the task
+     * @return the return value
+     * @throws Exception the exception throw, if any, by the task
+     */
+    public static <V> V doWithTccl(ClassLoader classLoader, Callable<V> task) throws Exception {
+        ClassLoader oldClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(classLoader);
+        try {
+            return task.call();
+        } finally {
+            Thread.currentThread().setContextClassLoader(oldClassLoader);
+        }
+    }
+
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/util/ThreadContextClassLoaderTaskExecutorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/ThreadContextClassLoaderTaskExecutorTest.java
@@ -1,0 +1,86 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.util;
+
+import static org.junit.Assert.*;
+
+import java.util.concurrent.Callable;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Test;
+
+public class ThreadContextClassLoaderTaskExecutorTest {
+
+    @Test
+    public void test_with_normal_execution() throws Exception {
+        final String expectedResult = RandomStringUtils.randomAlphanumeric(10);
+        final ClassLoader parent = getClass().getClassLoader();
+
+        final ClassLoader innerLoader = new DummyClassLoader(parent);
+
+        //set the TCCL to something different
+        ClassLoader outerLoader = new DummyClassLoader(parent);
+        Thread.currentThread().setContextClassLoader(outerLoader);
+
+        String actual = ThreadContextClassLoaderTaskExecutor.doWithTccl(innerLoader, new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                assertEquals(innerLoader, Thread.currentThread().getContextClassLoader());
+                return expectedResult;
+            }
+        });
+        assertEquals(expectedResult, actual);
+        assertEquals(outerLoader, Thread.currentThread().getContextClassLoader());
+    }
+
+    @Test
+    public void test_with_exception_in_task() throws Exception {
+        final ClassLoader parent = getClass().getClassLoader();
+
+        final ClassLoader innerLoader = new DummyClassLoader(parent);
+
+        //set the TCCL to something different
+        ClassLoader outerLoader = new DummyClassLoader(parent);
+        Thread.currentThread().setContextClassLoader(outerLoader);
+
+        boolean thrown = false;
+
+        try {
+           ThreadContextClassLoaderTaskExecutor.doWithTccl(innerLoader, new Callable<String>() {
+                @Override
+                public String call() throws Exception {
+                    assertEquals(innerLoader, Thread.currentThread().getContextClassLoader());
+                    throw new Exception();
+                }
+            });
+        } catch (Exception e) {
+            thrown = true;
+        }
+        assertTrue(thrown);
+        assertEquals(outerLoader, Thread.currentThread().getContextClassLoader());
+    }
+
+    private class DummyClassLoader extends ClassLoader {
+        public DummyClassLoader(ClassLoader parent) {
+            super(parent);
+        }
+    }
+
+}


### PR DESCRIPTION
Here's a little utilty class to help working with the Thread Context Class Loader. It basically lets you pass in a task (using the Callable interface) and get that wrapped in the proper calls to set the TCCL.

Can't wait for lambdas....
