### PR TITLE
adding syslog appender

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -49,14 +49,17 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>com.adobe.acs.acs-aem-commons-bundle</Bundle-SymbolicName>
-                        <Import-Packages>org.scribe*;version="[1.3.0,2)",*</Import-Packages>
+                        <Import-Package>
+                            org.scribe*;version="[1.3.0,2)",
+                            ch.qos.logback.*;resolution:=optional,
+                            *</Import-Package>
                         <Include-Resource>
                             {maven-resources},
                             META-INF/wcmmode.tld=target/classes/META-INF/wcmmode.tld,
                             META-INF/audio.tld=target/classes/META-INF/audio.tld,
                             META-INF/dhlm.tld=target/classes/META-INF/dhlm.tld,
                             META-INF/xss.tld=target/classes/META-INF/xss.tld,
-                            META-INF/dam.tld=target/classes/META-INF/dam.tld,
+                            META-INF/dam.tld=target/classes/META-INF/dam.tld
                         </Include-Resource>
                     </instructions>
                 </configuration>
@@ -230,10 +233,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-        </dependency>
-        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>1.5.2</version>
@@ -320,6 +319,12 @@
             <groupId>org.scribe</groupId>
             <artifactId>scribe</artifactId>
             <version>1.3.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.0.13</version>
             <scope>provided</scope>
         </dependency>
 

--- a/bundle/src/main/java/com/adobe/acs/commons/logging/impl/SyslogAppender.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/logging/impl/SyslogAppender.java
@@ -1,0 +1,108 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.logging.impl;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Deactivate;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.PropertyUnbounded;
+import org.apache.sling.commons.osgi.PropertiesUtil;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.ComponentContext;
+
+import ch.qos.logback.core.Appender;
+
+@Component(metatype = true, configurationFactory = true,
+        label = "ACS AEM Commons - Syslog Appender",
+        description = "Logback appender to send messages using Syslog")
+public class SyslogAppender {
+
+    private static final String ROOT = "ROOT";
+
+    private static final int DEFAULT_PORT = -1;
+
+    private static final String DEFAULT_SUFFIX_PATTERN = "[%thread] %-5level %logger{36} - %msg%n";
+
+    @Property(label = "Host", description = "Host of Syslog server")
+    private static final String PROP_HOST = "host";
+
+    @Property(label = "Logger Names", description = "List of logger categories (ROOT for all)",
+            unbounded = PropertyUnbounded.ARRAY, value = ROOT)
+    private static final String PROP_LOGGERS = "loggers";
+
+    @Property(label = "Port", description = "Port of Syslog server", intValue = -1)
+    private static final String PROP_PORT = "port";
+
+    @Property(label = "Suffix Pattern", description = "Logback Pattern defining the message format.",
+            value = DEFAULT_SUFFIX_PATTERN)
+    private static final String PROP_SUFFIX_PATTERN = "suffix.pattern";
+
+    private ch.qos.logback.classic.net.SyslogAppender appender;
+
+    private ServiceRegistration appenderRegistration;
+
+    @Activate
+    protected void activate(ComponentContext ctx) {
+        final Dictionary<?, ?> properties = ctx.getProperties();
+        String[] loggers = PropertiesUtil.toStringArray(properties.get(PROP_LOGGERS), new String[] { ROOT });
+        String suffixPattern = PropertiesUtil
+                .toString(properties.get(PROP_SUFFIX_PATTERN), DEFAULT_SUFFIX_PATTERN);
+        int port = PropertiesUtil.toInteger(properties.get(PROP_PORT), DEFAULT_PORT);
+        String host = PropertiesUtil.toString(properties.get(PROP_HOST), null);
+
+        if (host == null || port == -1) {
+            throw new IllegalArgumentException(
+                    "Syslog Appender not configured correctly. Both host and port need to be provided.");
+        }
+
+        BundleContext bundleContext = ctx.getBundleContext();
+
+        appender = new ch.qos.logback.classic.net.SyslogAppender();
+
+        appender.setSyslogHost(host);
+        appender.setPort(port);
+
+        appender.setFacility("USER");
+        appender.setSuffixPattern(suffixPattern);
+
+        Dictionary<String, Object> props = new Hashtable<String, Object>();
+        props.put("loggers", loggers);
+        appenderRegistration = bundleContext.registerService(Appender.class.getName(), appender, props);
+    }
+
+    @Deactivate
+    protected void deactivate() {
+        if (appender != null) {
+            appender.stop();
+            appender = null;
+        }
+
+        if (appenderRegistration != null) {
+            appenderRegistration.unregister();
+            appenderRegistration = null;
+        }
+    }
+
+}


### PR DESCRIPTION
This adds support for Syslog as a log destination. You configure it using an OSGi configuration.

![syslog](https://f.cloud.github.com/assets/65906/2167652/9038e15c-951f-11e3-9b53-3811df7ebc49.png)

Tested primarily against https://papertrailapp.com/. When used with papertrail, I'd recommend using
`<appname>: [%thread] %-5level %logger{36} - %msg%n`
as the suffix pattern where `<appname>` is something like "load16" or "devserver". Papertrail gives the first token (up to 36 chars, no whitespace) special meaning.

NOTE: this requires AEM 6.0 Beta and a SNAPSHOT build of Sling Commons Logging, although I fully expect it to work with AEM 6.0 final. The packages are optionally imported, so this has no impact on ACS AEM Commons's usability on 5.6 or 5.6.1
