### PR TITLE
Fixing twitter bundle issue

### DIFF
--- a/bundle-twitter/pom.xml
+++ b/bundle-twitter/pom.xml
@@ -49,7 +49,8 @@
                 <configuration>
                     <instructions>
                         <Bundle-SymbolicName>com.adobe.acs.acs-aem-commons-bundle-twitter</Bundle-SymbolicName>
-                        <Import-Package>twitter4j*;version="[3.0.5,4)",*</Import-Package>
+                        <Import-Package>*;resolution:=optional</Import-Package>
+                        <Embed-Dependency>twitter4j-core;scope=compile|runtime</Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Importing twitter4j\* caused installed but not active bundle, twitter4j is an internal 3rd party library and not exported, so cannot be imported. The import caused unresolved dependencies. With embed-dependency it works fine.

When I use ACS content package with maven-vault-plugin as a sub package it causes serious side effects: uninstall my package, then reinstall it causes lots of ClassNotFound exception. Restarting CQ5 solved that, but it is not an option! Progressbar in package manager cannot disappear because of this issue.
