### PR TITLE
Added profile for building without twitter bundle, fixes #184

### DIFF
--- a/content/pom.xml
+++ b/content/pom.xml
@@ -129,5 +129,25 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>noTwitterBundle</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.day.jcr.vault</groupId>
+                        <artifactId>content-package-maven-plugin</artifactId>
+                        <configuration>
+                            <embeddeds>
+                                <embedded>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>acs-aem-commons-bundle</artifactId>
+                                    <target>/apps/acs-commons/install</target>
+                                </embedded>
+                            </embeddeds>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Added a maven profile that builds commons without the twitter bundle.  Therefore avoiding an un-started bundle and errors in log file.  Perhaps a build classifier should be added to distinguish between builds in maven repository?  The maven-jar-plugin has this, but this may not be available for the maven-content-package-plugin.
