### PR TITLE
JavaScript addition which allows for custom polling importers to be added to the Add... dialog in the Polling Importer UI

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -349,6 +349,12 @@
             <version>5.6.4</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.day.cq</groupId>
+            <artifactId>cq-polling-importer</artifactId>
+            <version>5.6.4</version>
+            <scope>provided</scope>
+        </dependency>
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.apache.sling</groupId>

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/CustomPollingImporterListServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/CustomPollingImporterListServlet.java
@@ -1,0 +1,105 @@
+/*
+ * #%L
+ * ACS AEM Tools Bundle
+ * %%
+ * Copyright (C) 2014 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.wcm.impl;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+
+import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Deactivate;
+import org.apache.felix.scr.annotations.sling.SlingServlet;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.apache.sling.commons.json.JSONArray;
+import org.apache.sling.commons.json.JSONException;
+import org.apache.sling.commons.json.JSONObject;
+import org.apache.sling.commons.osgi.PropertiesUtil;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.Filter;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.util.tracker.ServiceTracker;
+
+import com.adobe.granite.xss.XSSAPI;
+import com.day.cq.polling.importer.Importer;
+
+@SuppressWarnings("serial")
+@SlingServlet(paths = "/bin/acs-commons/custom-importers")
+public class CustomPollingImporterListServlet extends SlingSafeMethodsServlet {
+
+    private ServiceTracker tracker;
+
+    @Activate
+    protected void activate(ComponentContext ctx) throws InvalidSyntaxException {
+        BundleContext bundleContext = ctx.getBundleContext();
+        StringBuilder builder = new StringBuilder();
+        builder.append("(&(");
+        builder.append(Constants.OBJECTCLASS).append("=").append(Importer.SERVICE_NAME).append(")");
+        builder.append("(displayName=*))");
+        Filter filter = bundleContext.createFilter(builder.toString());
+        this.tracker = new ServiceTracker(bundleContext, filter, null);
+        this.tracker.open();
+    }
+
+    @Deactivate
+    protected void deactivate() {
+        this.tracker.close();
+    }
+
+    @Override
+    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response) throws ServletException,
+            IOException {
+        XSSAPI xssAPI = request.adaptTo(XSSAPI.class);
+        try {
+            JSONObject result = new JSONObject();
+            JSONArray list = new JSONArray();
+            result.put("list", list);
+
+            ServiceReference[] services = tracker.getServiceReferences();
+            if (services != null) {
+                for (ServiceReference service : services) {
+                    String displayName = PropertiesUtil.toString(service.getProperty("displayName"), null);
+                    String[] schemes = PropertiesUtil.toStringArray(service.getProperty(Importer.SCHEME_PROPERTY));
+                    if (displayName != null && schemes != null) {
+                        for (String scheme : schemes) {
+                            JSONObject obj = new JSONObject();
+                            obj.put("qtip", "");
+                            obj.put("text", displayName);
+                            obj.put("text_xss", xssAPI.encodeForJSString(displayName));
+                            obj.put("value", scheme);
+                            list.put(obj);
+                        }
+                    }
+                }
+            }
+
+            response.setCharacterEncoding("UTF-8");
+            response.setContentType("application/json");
+            result.write(response.getWriter());
+        } catch (JSONException e) {
+            throw new ServletException("Unable to generate importer list", e);
+        }
+    }
+
+}

--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/js.txt
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/js.txt
@@ -10,3 +10,4 @@ polyfill_composite_field_processParentRecord.js
 multipanel.js
 check_vanity_path.js
 validate_responsive_column_control_dialog.js
+add_dynamic_options_to_feed_importer.js

--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/add_dynamic_options_to_feed_importer.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/add_dynamic_options_to_feed_importer.js
@@ -1,0 +1,50 @@
+/*
+ * #%L
+ * ACS AEM Commons Package
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/*global CQ: false */
+(function() {
+    var Original = CQ.wcm.FeedImporter;
+
+    CQ.wcm.FeedImporter = function(config) {
+        var selections, selection, additions, parsedAdditions;
+
+        CQ.wcm.FeedImporter.prototype.constructor.call(this, config);
+
+        selections = this.newDialog.findBy(function() {
+                return this.xtype === 'selection' && this.name === 'feedType';
+            });
+        if (selections.length === 1) {
+            selection = selections[0];
+            additions = CQ.shared.HTTP.get("/bin/acs-commons/custom-importers.json");
+            if (additions && additions.body) {
+                parsedAdditions = CQ.Ext.util.JSON.decode(additions.body);
+                if (parsedAdditions.list) {
+                    $.each(parsedAdditions.list, function(idx, addition) {
+                        selection.options.push(addition);
+                    });
+                }
+            }
+            selection.setOptions(selection.options);
+        }
+    };
+    CQ.wcm.FeedImporter.prototype = Original.prototype;
+    CQ.wcm.FeedImporter.superclass = Original.superclass;
+
+    CQ.Ext.reg("feedimporter", CQ.wcm.FeedImporter);
+}());


### PR DESCRIPTION
One of the challenges with the Polling Importer UI is that it is non-trivial to add new options to Type field in the Add... dialog. The current options are hardcoded in the file `/libs/cq/ui/widgets/source/widgets/wcm/FeedImporter.js`

With this addition, any `Importer` service which has the special service property `displayName` will get dynamically added to the list.
