### PR TITLE
implementation of a BindingsValuesProvider to inject QueryBuilder

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -315,6 +315,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.scripting.api</artifactId>
+            <version>2.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.scripting.jsp</artifactId>
             <version>2.0.28</version>
             <scope>provided</scope>

--- a/bundle/src/main/java/com/adobe/acs/commons/scripting/impl/QueryBuilderBindingsValuesProvider.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/scripting/impl/QueryBuilderBindingsValuesProvider.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * ACS AEM Content Bundle
+ * %%
+ * Copyright (C) 2014 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.scripting.impl;
+
+import javax.script.Bindings;
+
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.scripting.api.BindingsValuesProvider;
+
+import com.day.cq.search.QueryBuilder;
+
+@Component
+@Service
+public class QueryBuilderBindingsValuesProvider implements BindingsValuesProvider {
+
+    @Reference
+    private QueryBuilder queryBuilder;
+
+    @Override
+    public void addBindings(Bindings bindings) {
+        bindings.put("queryBuilder", queryBuilder);
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/scripting/impl/QueryBuilderBindingsValuesProviderTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/scripting/impl/QueryBuilderBindingsValuesProviderTest.java
@@ -1,0 +1,45 @@
+/*
+ * #%L
+ * ACS AEM Tools Content
+ * %%
+ * Copyright (C) 2014 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.scripting.impl;
+
+import static org.mockito.Mockito.*;
+
+import javax.script.Bindings;
+
+import junitx.util.PrivateAccessor;
+
+import org.junit.Test;
+
+import com.day.cq.search.QueryBuilder;
+
+public class QueryBuilderBindingsValuesProviderTest {
+
+    @Test
+    public void test() throws Exception {
+        QueryBuilderBindingsValuesProvider provider = new QueryBuilderBindingsValuesProvider();
+        QueryBuilder qb = mock(QueryBuilder.class);
+        PrivateAccessor.setField(provider, "queryBuilder", qb);
+
+        Bindings bindings = mock(Bindings.class);
+        provider.addBindings(bindings);
+        verify(bindings).put("queryBuilder", qb);
+    }
+
+}


### PR DESCRIPTION
Inspired by one of the sessions at Circuit Conf, I threw together this trivial BindingsValuesProvider which adds `queryBuilder` as a scripting variable.

NOTE - this, like BVPs in general, are of limited practical use in JSPs because of limitations of the JSP script engine (basically, the list of scripting variables can not be dynamic). In a JSP, you need to do something like this:

```
QueryBuilder qb = (QueryBuilder) bindings.get("queryBuilder");
```

But in other scripting languages which don't have this limitation, this is a bit of syntatic sugar.
