### PR TITLE
Feature - Multiply Blend Image Transformer

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/images/transformers/impl/MultiplyBlendImageTransformerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/images/transformers/impl/MultiplyBlendImageTransformerImpl.java
@@ -23,8 +23,6 @@ package com.adobe.acs.commons.images.transformers.impl;
 import java.awt.AlphaComposite;
 import java.awt.Color;
 import java.awt.Graphics2D;
-import java.awt.Image;
-import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 
 import org.apache.felix.scr.annotations.Component;
@@ -39,8 +37,9 @@ import com.adobe.acs.commons.images.ImageTransformer;
 import com.adobe.acs.commons.images.transformers.impl.composites.MultiplyBlendComposite;
 import com.day.image.Layer;
 
+//@formatter:off
 @Component(
-        label = "ACS AEM Commons - Image Transformer - Color Filter"
+        label = "ACS AEM Commons - Image Transformer - Multiply Color Blend"
 )
 @Properties({
         @Property(
@@ -50,120 +49,117 @@ import com.day.image.Layer;
         )
 })
 @Service
+//@formatter:on
 public class MultiplyBlendImageTransformerImpl implements ImageTransformer {
     private static final Logger log = LoggerFactory.getLogger(MultiplyBlendImageTransformerImpl.class);
 
     static final String TYPE = "multiply";
-    
+
     private static final String KEY_ALPHA = "alpha";
     private static final String KEY_ALPHA_ALIAS = "a";
-    
+
     private static final String KEY_COLOR = "color";
     private static final String KEY_COLOR_ALIAS = "c";
-    
+
     private static final String KEY_RED = "red";
     private static final String KEY_RED_ALIAS = "r";
-    
+
     private static final String KEY_GREEN = "green";
     private static final String KEY_GREEN_ALIAS = "g";
 
     private static final String KEY_BLUE = "blue";
     private static final String KEY_BLUE_ALIAS = "b";
-    
+
+    private static final int DEFAULT_COLOR_VALUE = 255;
+
     @Override
     public final Layer transform(final Layer layer, final ValueMap properties) {
-    
-		if (properties == null || properties.isEmpty()) {
-		    log.warn("Transform [ {} ] requires parameters.", TYPE);
-		    return layer;
-		}
 
-		log.debug("Transforming with [ {} ]", TYPE);
+        if (properties == null || properties.isEmpty()) {
+            log.warn("Transform [ {} ] requires parameters.", TYPE);
+            return layer;
+        }
 
-    	
-		float alpha = normalizeAlpha(properties.get(KEY_ALPHA, properties.get(KEY_ALPHA_ALIAS, 0.0)).floatValue());
-    	
-    	Color color = getColor(properties);
+        log.debug("Transforming with [ {} ]", TYPE);
+
+        float alpha = normalizeAlpha(properties.get(KEY_ALPHA, properties.get(KEY_ALPHA_ALIAS, 0.0)).floatValue());
+
+        Color color = getColor(properties);
         Layer filter = new Layer(layer.getWidth(), layer.getHeight(), color);
-    
+
         BufferedImage image = merge(layer.getImage(), filter.getImage(), alpha);
         Layer result = new Layer(image);
         return result;
     }
-    
-    private BufferedImage merge(final BufferedImage original, final BufferedImage colorBlend, float alpha) {
-    	BufferedImage image = new BufferedImage(original.getWidth(), original.getHeight(), BufferedImage.TYPE_INT_ARGB);
-    	
-    	// Create the background
-    	Graphics2D graphics = image.createGraphics();
-    	graphics.setComposite(AlphaComposite.Clear);
-    	graphics.fillRect(0, 0, original.getWidth(), original.getHeight());
-    	
-    	
-    	// Add the original image
-    	graphics.setComposite(AlphaComposite.Src);
-    	graphics.drawImage(original, 0, 0, null);
-    	
-    	// Merge in the color filter
-    	graphics.setComposite(new MultiplyBlendComposite(alpha));
-    	graphics.drawImage(colorBlend, 0, 0, null);
-    	graphics.dispose();
 
-    	return image;
+    private BufferedImage merge(final BufferedImage original, final BufferedImage colorBlend, float alpha) {
+        BufferedImage image = new BufferedImage(original.getWidth(), original.getHeight(), BufferedImage.TYPE_INT_ARGB);
+
+        // Create the background
+        Graphics2D graphics = image.createGraphics();
+        graphics.setComposite(AlphaComposite.Clear);
+        graphics.fillRect(0, 0, original.getWidth(), original.getHeight());
+
+        // Add the original image
+        graphics.setComposite(AlphaComposite.Src);
+        graphics.drawImage(original, 0, 0, null);
+
+        // Merge in the color filter
+        graphics.setComposite(new MultiplyBlendComposite(alpha));
+        graphics.drawImage(colorBlend, 0, 0, null);
+        graphics.dispose();
+
+        return image;
     }
 
-    
-	private Color getColor(final ValueMap properties) {
-		Color color = getHexColor(properties);
-        
+    private Color getColor(final ValueMap properties) {
+        Color color = getHexColor(properties);
+
         if (color == null) {
-        	color = getRGBColor(properties);
+            color = getRGBColor(properties);
         }
-		return color;
-	}
+        return color;
+    }
 
-
-	private Color getHexColor(final ValueMap properties) {
-		String hexcolor = properties.get(KEY_COLOR, properties.get(KEY_COLOR_ALIAS, String.class));
-        Color color =  null;
+    private Color getHexColor(final ValueMap properties) {
+        String hexcolor = properties.get(KEY_COLOR, properties.get(KEY_COLOR_ALIAS, String.class));
+        Color color = null;
         if (hexcolor != null) {
-        	try {
-        		color = Color.decode("0x" + hexcolor);
-        	} catch (NumberFormatException ex) { 
-        		log.warn("Invalid hex color specified: {}", hexcolor);
-        	}
+            try {
+                color = Color.decode("0x" + hexcolor);
+            } catch (NumberFormatException ex) {
+                log.warn("Invalid hex color specified: {}", hexcolor);
+            }
         }
-		return color;
-	}
-	
+        return color;
+    }
 
-	private Color getRGBColor(final ValueMap properties) {
-		Color color;
-		int red = normalizeRGB(properties.get(KEY_RED, properties.get(KEY_RED_ALIAS, 255)));
-		int green =normalizeRGB(properties.get(KEY_GREEN, properties.get(KEY_GREEN_ALIAS, 255)));
-		int blue = normalizeRGB(properties.get(KEY_BLUE, properties.get(KEY_BLUE_ALIAS, 255)));
-		color = new Color(red, green, blue);
-		return color;
-	}
+    private Color getRGBColor(final ValueMap properties) {
+        Color color;
+        int red = normalizeRGB(properties.get(KEY_RED, properties.get(KEY_RED_ALIAS, DEFAULT_COLOR_VALUE)));
+        int green = normalizeRGB(properties.get(KEY_GREEN, properties.get(KEY_GREEN_ALIAS, DEFAULT_COLOR_VALUE)));
+        int blue = normalizeRGB(properties.get(KEY_BLUE, properties.get(KEY_BLUE_ALIAS, DEFAULT_COLOR_VALUE)));
+        color = new Color(red, green, blue);
+        return color;
+    }
 
-	private float normalizeAlpha(float alpha) {
-		if (alpha > 1) {
-			alpha = 1f;
-		} else if (alpha < 0) {
-			alpha = 0f;
-		}
-		
-		return alpha;
-	}
+    private float normalizeAlpha(float alpha) {
+        if (alpha > 1) {
+            alpha = 1f;
+        } else if (alpha < 0) {
+            alpha = 0f;
+        }
 
-	private int normalizeRGB(int rgbValue) {
-		if (rgbValue > 255) {
-			rgbValue = 255;
-		} else if (rgbValue < 0) {
-			rgbValue = 0;
-		}
-		return rgbValue;
-	}
+        return alpha;
+    }
 
+    private int normalizeRGB(int rgbValue) {
+        if (rgbValue > DEFAULT_COLOR_VALUE) {
+            rgbValue = DEFAULT_COLOR_VALUE;
+        } else if (rgbValue < 0) {
+            rgbValue = 0;
+        }
+        return rgbValue;
+    }
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/images/transformers/impl/composites/MultiplyBlendComposite.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/images/transformers/impl/composites/MultiplyBlendComposite.java
@@ -30,47 +30,45 @@ import com.adobe.acs.commons.images.transformers.impl.composites.contexts.Multip
 
 /**
  * Applies a multiply blend to the models.
- *
- * Follows the rules defined here: http://helpx.adobe.com/after-effects/using/blending-modes-layer-styles.html#Multiply
- *
- * Based on http://www.java2s.com/Code/Java/2D-Graphics-GUI/BlendCompositeDemo.htm    
+ * 
+ * Follows the rules defined here:
+ * http://helpx.adobe.com/after-effects/using/blending
+ * -modes-layer-styles.html#Multiply
+ * 
+ * Based on
+ * http://www.java2s.com/Code/Java/2D-Graphics-GUI/BlendCompositeDemo.htm
  */
 public class MultiplyBlendComposite implements Composite {
 
-	
-	private static final DirectColorModel colorModel = (DirectColorModel) ColorModel.getRGBdefault();
-	
+    private static final DirectColorModel COLOR_MODEL = (DirectColorModel) ColorModel.getRGBdefault();
+
     private final float alpha;
-    
+
     public MultiplyBlendComposite(float alpha) {
         this.alpha = alpha;
     }
-    
+
     @Override
     public CompositeContext createContext(ColorModel srcColorModel, ColorModel dstColorModel, RenderingHints hints) {
-        
-    	if (!isValidColorModel(srcColorModel) || !isValidColorModel(dstColorModel)) {
-    		throw new RasterFormatException("Invalid color model provided.");
-    	}
-    	
+
+        if (!isValidColorModel(srcColorModel) || !isValidColorModel(dstColorModel)) {
+            throw new RasterFormatException("Invalid color model provided.");
+        }
+
         return new MultiplyCompositeContext(alpha);
-        
+
     }
 
-    
     private static boolean isValidColorModel(ColorModel cm) {
-    	
-    	if (!(cm instanceof DirectColorModel)) {
-    		return false;
-    	}
-    	
-    	DirectColorModel dcm = (DirectColorModel) cm;
-    	
-    	return (dcm.getAlphaMask() == colorModel.getAlphaMask() &&
-    			dcm.getRedMask() == colorModel.getRedMask() &&
-    			dcm.getGreenMask() == colorModel.getGreenMask() &&
-    			dcm.getBlueMask() == colorModel.getBlueMask());
+
+        if (!(cm instanceof DirectColorModel)) {
+            return false;
+        }
+
+        DirectColorModel dcm = (DirectColorModel) cm;
+
+        return (dcm.getAlphaMask() == COLOR_MODEL.getAlphaMask() && dcm.getRedMask() == COLOR_MODEL.getRedMask()
+                && dcm.getGreenMask() == COLOR_MODEL.getGreenMask() && dcm.getBlueMask() == COLOR_MODEL.getBlueMask());
     }
 
-    
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/images/transformers/impl/composites/contexts/ColorMask.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/images/transformers/impl/composites/contexts/ColorMask.java
@@ -20,22 +20,40 @@
 
 package com.adobe.acs.commons.images.transformers.impl.composites.contexts;
 
+/**
+ * Represents a Color bitmask for making calculations.
+ * 
+ */
 public enum ColorMask {
 
-	RED(16),
-	GREEN(8),
-	BLUE(0);
+    /**
+     * Red Color Mask.
+     */
+    RED(16),
 
-	public static int MAX_DEPTH = 0xFF;
-	
-	private int	mask;
+    /**
+     * Green Color Mask.
+     */
+    GREEN(8),
 
-	ColorMask(int mask) {
-		this.mask = mask;
-	}
+    /**
+     * Blue Color Mask.
+     */
+    BLUE(0);
 
-	int getMask() {
-		return mask;
-	}
+    /**
+     * Maximum value a single RGB value is allowed.
+     */
+    public static final int MAX_DEPTH = 0xFF;
+
+    private int mask;
+
+    ColorMask(int mask) {
+        this.mask = mask;
+    }
+
+    int getMask() {
+        return mask;
+    }
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/images/transformers/impl/composites/contexts/MultiplyCompositeContext.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/images/transformers/impl/composites/contexts/MultiplyCompositeContext.java
@@ -23,31 +23,31 @@ import java.awt.CompositeContext;
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 
-
 /**
  * Applies a multiply blend to the models.
- *
- * Follows the rules defined here: http://helpx.adobe.com/after-effects/using/blending-modes-layer-styles.html#Multiply
- *
- * Based on http://www.java2s.com/Code/Java/2D-Graphics-GUI/BlendCompositeDemo.htm    
+ * 
+ * Follows the rules defined here:
+ * http://helpx.adobe.com/after-effects/using/blending
+ * -modes-layer-styles.html#Multiply
+ * 
+ * Based on
+ * http://www.java2s.com/Code/Java/2D-Graphics-GUI/BlendCompositeDemo.htm
  */
 public class MultiplyCompositeContext implements CompositeContext {
-    
-    
-	private static final int ALPHA_MASK = 24;
+
+    private static final int ALPHA_MASK = 24;
     private static final int BLEND_SHIFT = 8;
-    
+
     private final float alpha;
-    
-    
+
     public MultiplyCompositeContext(float alpha) {
-    	this.alpha = alpha;
+        this.alpha = alpha;
     }
-    
+
     @Override
     public void compose(Raster src, Raster destIn, WritableRaster dstOut) {
 
-    	int width = Math.min(src.getWidth(), destIn.getWidth());
+        int width = Math.min(src.getWidth(), destIn.getWidth());
         int height = Math.min(src.getHeight(), destIn.getHeight());
 
         int[] srcPixels = new int[width];
@@ -57,7 +57,7 @@ public class MultiplyCompositeContext implements CompositeContext {
         for (int y = 0; y < height; y++) {
             src.getDataElements(0, y, width, 1, srcPixels);
             destIn.getDataElements(0, y, width, 1, destPixels);
-            
+
             // Each pixel in the row
             for (int x = 0; x < width; x++) {
 
@@ -66,20 +66,20 @@ public class MultiplyCompositeContext implements CompositeContext {
                 int destPixel = destPixels[x];
                 int result = 0;
                 int tmp = 0;
-                
+
                 for (ColorMask mask : ColorMask.values()) {
 
-                	int srcColor = (srcPixel >> mask.getMask()) & ColorMask.MAX_DEPTH;
-                	int destColor = (destPixel >> mask.getMask()) & ColorMask.MAX_DEPTH;
-                	tmp = blendColor(srcColor, destColor);
-                	
-                	tmp = processColorOpacity(tmp, destColor);
-                	result = result | (tmp << mask.getMask());
+                    int srcColor = (srcPixel >> mask.getMask()) & ColorMask.MAX_DEPTH;
+                    int destColor = (destPixel >> mask.getMask()) & ColorMask.MAX_DEPTH;
+                    tmp = blendColor(srcColor, destColor);
+
+                    tmp = processColorOpacity(tmp, destColor);
+                    result = result | (tmp << mask.getMask());
                 }
-                
+
                 int srcAlpha = (srcPixel >> ALPHA_MASK) & ColorMask.MAX_DEPTH;
                 int destAlpha = (destPixel >> ALPHA_MASK) & ColorMask.MAX_DEPTH;
-                
+
                 tmp = blendAlpha(srcAlpha, destAlpha);
                 tmp = processAlphaOpacity(tmp, destAlpha);
                 result = result | (tmp << ALPHA_MASK);
@@ -87,46 +87,44 @@ public class MultiplyCompositeContext implements CompositeContext {
             }
             dstOut.setDataElements(0, y, width, 1, destPixels);
         }
-        
+
     }
 
     private int blendColor(int src, int dest) {
-    	return (src * dest) >> BLEND_SHIFT;
-        
+        return (src * dest) >> BLEND_SHIFT;
+
     }
-    
+
     private int processColorOpacity(int blended, int dest) {
-    	int tmp = blended - dest;
-    	tmp = (int) (tmp * alpha);
-    	tmp = dest + tmp;
-    	tmp = tmp & ColorMask.MAX_DEPTH;
-    	return tmp;
+        int tmp = blended - dest;
+        tmp = (int) (tmp * alpha);
+        tmp = dest + tmp;
+        tmp = tmp & ColorMask.MAX_DEPTH;
+        return tmp;
     }
-    
+
     private int blendAlpha(int src, int dest) {
-    	int tmp = (src * dest) / 255;
-    	tmp = src + dest - tmp;
-    	return Math.min(255, tmp);
+        int tmp = (src * dest) / ColorMask.MAX_DEPTH;
+        tmp = src + dest - tmp;
+        return Math.min(ColorMask.MAX_DEPTH, tmp);
     }
-    
+
     private int processAlphaOpacity(int blended, int dest) {
-    	
-    	int tmp = blended - dest;
-    	tmp = (int) (tmp * alpha);
-    	tmp = dest - tmp;
-    	tmp = tmp & ColorMask.MAX_DEPTH;
-    	return tmp;
-    	
-    	
+
+        int tmp = blended - dest;
+        tmp = (int) (tmp * alpha);
+        tmp = dest - tmp;
+        tmp = tmp & ColorMask.MAX_DEPTH;
+        return tmp;
+
     }
-    
+
     @Override
     public void dispose() {
-        
+
     }
-    
+
     public float getAlpha() {
-    	return alpha;
+        return alpha;
     }
 }
-

--- a/bundle/src/test/java/com/adobe/acs/commons/images/transformers/impl/composites/MultiplyBlendCompositeTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/images/transformers/impl/composites/MultiplyBlendCompositeTest.java
@@ -38,135 +38,134 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-
 @RunWith(PowerMockRunner.class)
-@PrepareForTest( { ColorModel.class, DirectColorModel.class } )
+@PrepareForTest({ ColorModel.class, DirectColorModel.class })
 public class MultiplyBlendCompositeTest {
 
-	private static final float ALPHA = 0.75f;
+    private static final float ALPHA = 0.75f;
 
-	@Mock
-	ColorModel notDirect;
-	
-	@Spy
-	DirectColorModel srcColorModel = (DirectColorModel) DirectColorModel.getRGBdefault();
-	
-	@Spy
-	DirectColorModel destColorModel = (DirectColorModel) DirectColorModel.getRGBdefault();
-	
-	@Mock
-	RenderingHints hints;
-	
-	MultiplyBlendComposite composite = new MultiplyBlendComposite(ALPHA);
-	
+    @Mock
+    ColorModel notDirect;
+
+    @Spy
+    DirectColorModel srcColorModel = (DirectColorModel) DirectColorModel.getRGBdefault();
+
+    @Spy
+    DirectColorModel destColorModel = (DirectColorModel) DirectColorModel.getRGBdefault();
+
+    @Mock
+    RenderingHints hints;
+
+    MultiplyBlendComposite composite = new MultiplyBlendComposite(ALPHA);
+
     @Before
     public void setUp() throws Exception {
-    	
+
     }
 
     @After
     public void tearDown() throws Exception {
-    	reset(notDirect, hints);
+        reset(notDirect, hints);
     }
-    
+
     @Test
     public void testCreateContext() throws Exception {
 
-    	CompositeContext ctx = composite.createContext(srcColorModel, destColorModel, hints);
-    	assertNotNull(ctx);
-    	verifyZeroInteractions(srcColorModel, destColorModel, hints);
+        CompositeContext ctx = composite.createContext(srcColorModel, destColorModel, hints);
+        assertNotNull(ctx);
+        verifyZeroInteractions(srcColorModel, destColorModel, hints);
     }
 
     @Test(expected = RasterFormatException.class)
     public void testCreateContextInvalidSrc() throws Exception {
-    	composite.createContext(notDirect, destColorModel, hints);
+        composite.createContext(notDirect, destColorModel, hints);
         verifyZeroInteractions(notDirect, destColorModel, hints);
-    	
+
     }
 
     @Test(expected = RasterFormatException.class)
     public void testCreateContextInvalidDest() throws Exception {
-    	composite.createContext(srcColorModel, notDirect, hints);
+        composite.createContext(srcColorModel, notDirect, hints);
         verifyZeroInteractions(notDirect, srcColorModel, hints);
     }
-    
+
     @Test(expected = RasterFormatException.class)
     public void testCreateContextInvalidSrcAlphaMask() throws Exception {
-    	
-    	srcColorModel = new DirectColorModel(Integer.SIZE, srcColorModel.getRedMask(), srcColorModel.getGreenMask(), 
-    			srcColorModel.getBlueMask(), 0);
-    	composite.createContext(srcColorModel, destColorModel, hints);
-    	PowerMockito.verifyNoMoreInteractions(srcColorModel, destColorModel);
-    	verifyZeroInteractions(hints);
+
+        srcColorModel = new DirectColorModel(Integer.SIZE, srcColorModel.getRedMask(), srcColorModel.getGreenMask(),
+                srcColorModel.getBlueMask(), 0);
+        composite.createContext(srcColorModel, destColorModel, hints);
+        PowerMockito.verifyNoMoreInteractions(srcColorModel, destColorModel);
+        verifyZeroInteractions(hints);
     }
-    
+
     @Test(expected = RasterFormatException.class)
     public void testCreateContextInvalidSrcRedMask() throws Exception {
-    	
-    	srcColorModel = new DirectColorModel(Integer.SIZE, 0, srcColorModel.getGreenMask(), 
-    			srcColorModel.getBlueMask(), srcColorModel.getAlphaMask());
-    	composite.createContext(srcColorModel, destColorModel, hints);
-    	PowerMockito.verifyNoMoreInteractions(srcColorModel, destColorModel);
-    	verifyZeroInteractions(hints);    	
+
+        srcColorModel = new DirectColorModel(Integer.SIZE, 0, srcColorModel.getGreenMask(),
+                srcColorModel.getBlueMask(), srcColorModel.getAlphaMask());
+        composite.createContext(srcColorModel, destColorModel, hints);
+        PowerMockito.verifyNoMoreInteractions(srcColorModel, destColorModel);
+        verifyZeroInteractions(hints);
     }
 
     @Test(expected = RasterFormatException.class)
     public void testCreateContextInvalidSrcGreenMask() throws Exception {
-    	
-    	srcColorModel = new DirectColorModel(Integer.SIZE, srcColorModel.getRedMask(), 0, 
-    			srcColorModel.getBlueMask(), srcColorModel.getAlphaMask());
-    	composite.createContext(srcColorModel, destColorModel, hints);
-    	PowerMockito.verifyNoMoreInteractions(srcColorModel, destColorModel);
-    	verifyZeroInteractions(hints);    	
+
+        srcColorModel = new DirectColorModel(Integer.SIZE, srcColorModel.getRedMask(), 0, srcColorModel.getBlueMask(),
+                srcColorModel.getAlphaMask());
+        composite.createContext(srcColorModel, destColorModel, hints);
+        PowerMockito.verifyNoMoreInteractions(srcColorModel, destColorModel);
+        verifyZeroInteractions(hints);
     }
 
     @Test(expected = RasterFormatException.class)
     public void testCreateContextInvalidSrcBlueMask() throws Exception {
-    	
-    	srcColorModel = new DirectColorModel(Integer.SIZE, srcColorModel.getRedMask(), srcColorModel.getGreenMask(), 
-    			0, srcColorModel.getAlphaMask());
-    	composite.createContext(srcColorModel, destColorModel, hints);
-    	PowerMockito.verifyNoMoreInteractions(srcColorModel, destColorModel);
-    	verifyZeroInteractions(hints);    	
+
+        srcColorModel = new DirectColorModel(Integer.SIZE, srcColorModel.getRedMask(), srcColorModel.getGreenMask(), 0,
+                srcColorModel.getAlphaMask());
+        composite.createContext(srcColorModel, destColorModel, hints);
+        PowerMockito.verifyNoMoreInteractions(srcColorModel, destColorModel);
+        verifyZeroInteractions(hints);
     }
 
     @Test(expected = RasterFormatException.class)
     public void testCreateContextInvalidDestAlphaMask() throws Exception {
-    	
-    	destColorModel = new DirectColorModel(Integer.SIZE, destColorModel.getRedMask(), destColorModel.getGreenMask(), 
-    			destColorModel.getBlueMask(), 0);
-    	composite.createContext(srcColorModel, destColorModel, hints);
-    	PowerMockito.verifyNoMoreInteractions(srcColorModel, destColorModel);
-    	verifyZeroInteractions(hints);
+
+        destColorModel = new DirectColorModel(Integer.SIZE, destColorModel.getRedMask(), destColorModel.getGreenMask(),
+                destColorModel.getBlueMask(), 0);
+        composite.createContext(srcColorModel, destColorModel, hints);
+        PowerMockito.verifyNoMoreInteractions(srcColorModel, destColorModel);
+        verifyZeroInteractions(hints);
     }
-    
+
     @Test(expected = RasterFormatException.class)
     public void testCreateContextInvalidDestRedMask() throws Exception {
-    	
-    	destColorModel = new DirectColorModel(Integer.SIZE, 0, destColorModel.getGreenMask(), 
-    			destColorModel.getBlueMask(), destColorModel.getAlphaMask());
-    	composite.createContext(srcColorModel, destColorModel, hints);
-    	PowerMockito.verifyNoMoreInteractions(srcColorModel, destColorModel);
-    	verifyZeroInteractions(hints);    	
+
+        destColorModel = new DirectColorModel(Integer.SIZE, 0, destColorModel.getGreenMask(),
+                destColorModel.getBlueMask(), destColorModel.getAlphaMask());
+        composite.createContext(srcColorModel, destColorModel, hints);
+        PowerMockito.verifyNoMoreInteractions(srcColorModel, destColorModel);
+        verifyZeroInteractions(hints);
     }
 
     @Test(expected = RasterFormatException.class)
     public void testCreateContextInvalidDestGreenMask() throws Exception {
-    	
-    	destColorModel = new DirectColorModel(Integer.SIZE, destColorModel.getRedMask(), 0, 
-    			destColorModel.getBlueMask(), destColorModel.getAlphaMask());
-    	composite.createContext(srcColorModel, destColorModel, hints);
-    	PowerMockito.verifyNoMoreInteractions(srcColorModel, destColorModel);
-    	verifyZeroInteractions(hints);    	
+
+        destColorModel = new DirectColorModel(Integer.SIZE, destColorModel.getRedMask(), 0,
+                destColorModel.getBlueMask(), destColorModel.getAlphaMask());
+        composite.createContext(srcColorModel, destColorModel, hints);
+        PowerMockito.verifyNoMoreInteractions(srcColorModel, destColorModel);
+        verifyZeroInteractions(hints);
     }
 
     @Test(expected = RasterFormatException.class)
     public void testCreateContextInvalidDestBlueMask() throws Exception {
-    	
-    	destColorModel = new DirectColorModel(Integer.SIZE, destColorModel.getRedMask(), destColorModel.getGreenMask(), 
-    			0, destColorModel.getAlphaMask());
-    	composite.createContext(srcColorModel, destColorModel, hints);
-    	PowerMockito.verifyNoMoreInteractions(srcColorModel, destColorModel);
-    	verifyZeroInteractions(hints);    	
+
+        destColorModel = new DirectColorModel(Integer.SIZE, destColorModel.getRedMask(), destColorModel.getGreenMask(),
+                0, destColorModel.getAlphaMask());
+        composite.createContext(srcColorModel, destColorModel, hints);
+        PowerMockito.verifyNoMoreInteractions(srcColorModel, destColorModel);
+        verifyZeroInteractions(hints);
     }
 }


### PR DESCRIPTION
This feature allows supports configurable image transformer to overlay a multiplier color on an image. The effect intended to replicate this feature in Photoshop.

http://www.photoshopessentials.com/photo-editing/layer-blend-modes/multiply/

The logic is based on this demo: 

http://www.java2s.com/Code/Java/2D-Graphics-GUI/BlendCompositeDemo.htm

The effect is to take an image such as:

![transformergreyscale](https://cloud.githubusercontent.com/assets/6520270/3622777/fe0410de-0e3d-11e4-8730-a14c80e4ac6a.jpg)

And apply a color (00b3b4) overlay:

![transformermultiply](https://cloud.githubusercontent.com/assets/6520270/3622788/4f349a14-0e3e-11e4-91e2-4e47f5383395.jpg)

Additionally you can modify the alpha (transparency intensity) and change the effect (half of previous alpha):

![halftransformermultiply](https://cloud.githubusercontent.com/assets/6520270/3622789/83d8b958-0e3e-11e4-97c7-7113fefbecc0.jpg)
