### PR TITLE
adding i18n title capability for generic lists

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/genericlists/GenericList.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/genericlists/GenericList.java
@@ -20,6 +20,7 @@
 package com.adobe.acs.commons.genericlists;
 
 import java.util.List;
+import java.util.Locale;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -47,6 +48,16 @@ public interface GenericList {
     String lookupTitle(String value);
 
     /**
+     * Get an item's localized title by its value.
+     * 
+     * @param value the list item's value
+     * @param locale the locale for localization
+     * @return the title or null
+     */
+    @CheckForNull
+    String lookupTitle(String value, Locale locale);
+
+    /**
      * A generic item/value pair within a list.
      *
      */
@@ -59,6 +70,16 @@ public interface GenericList {
          */
         @Nonnull
         String getTitle();
+
+        /**
+         * Get the item's localized title.
+         * 
+         * @param locale the locale for localization
+         * 
+         * @return the title
+         */
+        @Nonnull
+        String getTitle(Locale locale);
 
         /**
          * Get the item's value.

--- a/bundle/src/test/java/com/adobe/acs/commons/genericlists/impl/GenericListAdapterFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/genericlists/impl/GenericListAdapterFactoryTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.*;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.sling.api.adapter.AdapterFactory;
 import org.apache.sling.api.resource.Resource;
@@ -98,6 +99,8 @@ public class GenericListAdapterFactoryTest {
                     {
                         put(NameConstants.PN_TITLE, "titletwo");
                         put(GenericListImpl.PN_VALUE, "valuetwo");
+                        put(NameConstants.PN_TITLE + "." + "fr", "french_title");
+                        put(NameConstants.PN_TITLE + "." + "fr_ch", "swiss_french_title");
 
                     }
                 });
@@ -153,5 +156,24 @@ public class GenericListAdapterFactoryTest {
 
         GenericList section = adaptToGenericList(wrongPage);
         assertNull(section);
+    }
+
+    @Test
+    public void test_i18n_titles() {
+        Locale french = new Locale("fr");
+        Locale swissFrench = new Locale("fr", "ch");
+        Locale franceFrench = new Locale("fr", "fr");
+        
+        GenericList list = adapterFactory.getAdapter(listPage, GenericList.class);
+        assertNotNull(list);
+        List<Item> items = list.getItems();
+        assertNotNull(items);
+        assertEquals(2, items.size());
+        assertEquals("titleone", items.get(0).getTitle(french));
+        assertEquals("titleone", items.get(0).getTitle(swissFrench));
+        assertEquals("titleone", items.get(0).getTitle(franceFrench));
+        assertEquals("french_title", items.get(1).getTitle(french));
+        assertEquals("swiss_french_title", items.get(1).getTitle(swissFrench));
+        assertEquals("french_title", items.get(1).getTitle(franceFrench));
     }
 }

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/genericlist/item/dialog.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/genericlist/item/dialog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Dialog"
     title="Generic List Item"
     xtype="panel">
@@ -17,4 +17,7 @@
             name="./value"
             xtype="textfield"/>
     </items>
+    <listeners
+        jcr:primaryType="nt:unstructured"
+        afterrender="function() { ACS.CQ.GenericListItem.addTitleFields(this); }"/>
 </jcr:root>

--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/js.txt
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/js.txt
@@ -11,3 +11,4 @@ multipanel.js
 check_vanity_path.js
 validate_responsive_column_control_dialog.js
 add_dynamic_options_to_feed_importer.js
+add_language_titles_to_item_dialog.js

--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/add_language_titles_to_item_dialog.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/add_language_titles_to_item_dialog.js
@@ -1,0 +1,54 @@
+/*
+ * #%L
+ * ACS AEM Commons Package
+ * %%
+ * Copyright (C) 2014 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/*global CQ: false, ACS: false */
+CQ.Ext.ns("ACS.CQ.GenericListItem");
+
+ACS.CQ.GenericListItem.addTitleFields = function(panel) {
+    CQ.HTTP.get("/etc/tags.json", function(options, success, response) {
+        var obj, fieldset, allLanguages = CQ.I18n.getLanguages();
+        if (success) {
+            obj = CQ.Ext.util.JSON.decode(response.responseText);
+            if (obj.languages) {
+                fieldset = {
+                    xtype: 'fieldset',
+                    title: 'Localization',
+                    defaultType: 'textfield',
+                    collapsible: true,
+                    defaults: {
+                        anchor: '-20'
+                    },
+                    items:[]
+                };
+                CQ.Ext.each(obj.languages, function(lang) {
+                    var langInfo = allLanguages[lang];
+                    if (langInfo) {
+                        fieldset.items.push({
+                            fieldLabel : langInfo.title,
+                            name : './jcr:title.' + lang
+                        });
+                    }
+                });
+                if (!CQ.Ext.isEmpty(fieldset.items)) {
+                    panel.add(fieldset);
+                }
+            }
+        }
+    });
+};


### PR DESCRIPTION
Currently, Generic Lists only allow for a single title. This pull request adds fields to the dialog for localized titles. It is heavily based on the Tag i18n capability. So much so that it seems to me that we don't need a separate configuration location for the locale list to drive the dialog - it should be reused from /etc/tags@languages.

Here's what the dialog looks like once the languages are loaded:
![test1](https://cloud.githubusercontent.com/assets/65906/3883196/ebd4f76a-219e-11e4-9519-b71bf83eaee9.png)
