### PR TITLE
Component Error Handler - Collision w Error Page Handler in WCMMode Disabled

### DIFF
--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/ComponentErrorHandlerImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/ComponentErrorHandlerImplTest.java
@@ -181,4 +181,34 @@ public class ComponentErrorHandlerImplTest {
         verify(responseWriter, times(1)).print(any(String.class));
         verifyNoMoreInteractions(responseWriter);
     }
+
+
+
+    @Test(expected = ServletException.class)
+    public void testDisabledError_NotPreviouslyProcessedRequest() throws Exception {
+        // This should not invoke ComponentErrorHandling
+        when(request.getAttribute(ComponentErrorHandlerImpl.REQ_ATTR_PREVIOUSLY_PROCESSED)).thenReturn(null);
+        when(componentHelper.isDisabledMode(request)).thenReturn(true);
+
+        doThrow(new ServletException()).when(chain).doFilter(request, response);
+
+        handler.doFilter(request, response, chain);
+        verify(responseWriter, never()).print(any(String.class));
+        verifyNoMoreInteractions(responseWriter);
+
+    }
+
+    @Test(expected = ServletException.class)
+    public void testDisabledError_PreviouslyProcessedRequest() throws Exception {
+        // This should not invoke ComponentErrorHandling
+        when(request.getAttribute(ComponentErrorHandlerImpl.REQ_ATTR_PREVIOUSLY_PROCESSED)).thenReturn(true);
+        when(componentHelper.isDisabledMode(request)).thenReturn(true);
+
+        doThrow(new ServletException()).when(chain).doFilter(request, response);
+
+        handler.doFilter(request, response, chain);
+
+        verify(responseWriter, times(1)).print(any(String.class));
+        verifyNoMoreInteractions(responseWriter);
+    }
 }


### PR DESCRIPTION
Added check to ignore component error handling if an error occurs on the first filter chain inclusion. This fix only  affects WCMMode disabled as the original check seems to work on Edit and Preview modes.
