### PR TITLE
Defect/acl packager tokens

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/packaging/PackageHelper.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/packaging/PackageHelper.java
@@ -31,9 +31,9 @@ import org.apache.sling.commons.json.JSONException;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Helper interface for dynamic package creation.
@@ -116,7 +116,7 @@ public interface PackageHelper {
      * @throws IOException
      * @throws RepositoryException
      */
-    JcrPackage createPackage(final List<PathFilterSet> pathFilterSets, final Session session,
+    JcrPackage createPackageFromPathFilterSets(final Collection<PathFilterSet> pathFilterSets, final Session session,
                              final String groupName, final String name, String version,
                              final ConflictResolution conflictResolution,
                              final Map<String, String> packageDefinitionProperties)
@@ -136,7 +136,7 @@ public interface PackageHelper {
      * @throws IOException
      * @throws RepositoryException
      */
-    JcrPackage createPackage(final Set<Resource> resources, final Session session,
+    JcrPackage createPackage(final Collection<Resource> resources, final Session session,
                                      final String groupName, final String name, String version,
                                      final ConflictResolution conflictResolution,
                                      final Map<String, String> packageDefinitionProperties)
@@ -167,7 +167,7 @@ public interface PackageHelper {
      * @return a string representation of JSON to write to response
      * @throws JSONException
      */
-    String getPreviewJSON(final Set<Resource> resources) throws JSONException;
+    String getPreviewJSON(final Collection<Resource> resources) throws JSONException;
 
 
     /**
@@ -177,7 +177,7 @@ public interface PackageHelper {
      * @return a string representation of JSON to write to response
      * @throws JSONException
      */
-    String getPreviewJSON(final List<PathFilterSet> pathFilterSets) throws JSONException;
+    String getPathFilterSetPreviewJSON(final Collection<PathFilterSet> pathFilterSets) throws JSONException;
 
 
     /**

--- a/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/JcrPackageCoverageProgressListener.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/JcrPackageCoverageProgressListener.java
@@ -26,19 +26,19 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class JcrPackageCoverageProgressListener implements ProgressTrackerListener {
-    final List<String> coverage = new ArrayList<String>();
+    private final List<String> coverage = new ArrayList<String>();
 
     @Override
-    public void onMessage(final Mode mode, final String action, final String path) {
+    public final void onMessage(final Mode mode, final String action, final String path) {
         coverage.add(path);
     }
 
     @Override
-    public void onError(final Mode mode, final String path, final Exception e) {
+    public final void onError(final Mode mode, final String path, final Exception e) {
 
     }
 
-    final public List<String> getCoverage() {
+    public final List<String> getCoverage() {
         return coverage;
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/packaging/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/packaging/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Dispatcher utilities.
  */
-@aQute.bnd.annotation.Version("1.7.4")
+@aQute.bnd.annotation.Version("1.8.4")
 package com.adobe.acs.commons.packaging;

--- a/bundle/src/test/java/com/adobe/acs/commons/packaging/impl/ACLPackagerServletImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/packaging/impl/ACLPackagerServletImplTest.java
@@ -24,7 +24,7 @@ import com.adobe.acs.commons.packaging.PackageHelper;
 import com.day.jcr.vault.packaging.JcrPackage;
 import com.day.jcr.vault.packaging.JcrPackageManager;
 import com.day.jcr.vault.packaging.Version;
-
+import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
@@ -43,7 +43,7 @@ import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import javax.jcr.Session;
-
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -110,7 +110,7 @@ public class ACLPackagerServletImplTest {
 
         when(packageHelper.getSuccessJSON(any(JcrPackage.class))).thenReturn("{\"status\": \"success\"}");
         when(packageHelper.getErrorJSON(any(String.class))).thenReturn("{\"status\": \"error\"}");
-        when(packageHelper.getPreviewJSON(any(Set.class))).thenReturn("{\"status\": \"preview\"}");
+        when(packageHelper.getPathFilterSetPreviewJSON(any(Collection.class))).thenReturn("{\"status\": \"preview\"}");
     }
 
     @After
@@ -161,7 +161,10 @@ public class ACLPackagerServletImplTest {
         request.setResource(contentResource);
 
         aclPackagerServlet.doPost(request, response);
-        final JSONObject actual = new JSONObject(response.getOutput().toString());
+        String tmp = response.getOutput().toString();
+        System.out.println(tmp);
+        final JSONObject actual = new JSONObject(tmp);
+
         assertEquals("preview", actual.optString("status", "error"));
     }
 
@@ -215,8 +218,38 @@ public class ACLPackagerServletImplTest {
             this.addResource(new MockResource(this, "/home/groups/authors/rep:policy/allow0", ""));
         }
 
+        @Override
+        public Iterable<Resource> getChildren(final Resource resource) {
+            return null;
+        }
+
         public Iterator<Resource> findResources(String query, String language) {
             return this.results.iterator();
+        }
+
+        @Override
+        public void delete(final Resource resource) throws PersistenceException {
+
+        }
+
+        @Override
+        public Resource create(final Resource resource, final String s, final Map<String, Object> stringObjectMap) throws PersistenceException {
+            return null;
+        }
+
+        @Override
+        public void revert() {
+
+        }
+
+        @Override
+        public void commit() throws PersistenceException {
+
+        }
+
+        @Override
+        public boolean hasChanges() {
+            return false;
         }
 
         @SuppressWarnings("unchecked")
@@ -243,8 +276,38 @@ public class ACLPackagerServletImplTest {
             }
         }
 
+        @Override
+        public Iterable<Resource> getChildren(final Resource resource) {
+            return null;
+        }
+
         public Iterator<Resource> findResources(String query, String language) {
             return this.results.iterator();
+        }
+
+        @Override
+        public void delete(final Resource resource) throws PersistenceException {
+
+        }
+
+        @Override
+        public Resource create(final Resource resource, final String s, final Map<String, Object> stringObjectMap) throws PersistenceException {
+            return null;
+        }
+
+        @Override
+        public void revert() {
+
+        }
+
+        @Override
+        public void commit() throws PersistenceException {
+
+        }
+
+        @Override
+        public boolean hasChanges() {
+            return false;
         }
 
         @SuppressWarnings("unchecked")

--- a/bundle/src/test/java/com/adobe/acs/commons/packaging/impl/PackageHelperImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/packaging/impl/PackageHelperImplTest.java
@@ -279,7 +279,7 @@ public class PackageHelperImplTest {
     }
 
     @Test
-    public void testCreatePackage() throws Exception {
+         public void testCreatePackage() throws Exception {
 
         Map<String, String> properties = new HashMap<String, String>();
         Set<Resource> resources = new HashSet<Resource>();
@@ -292,6 +292,26 @@ public class PackageHelperImplTest {
         // Verify the session was saved, creating the package
         verify(session, times(1)).save();
     }
+
+
+    @Test
+    public void testCreatePackageFromPathFilterSets() throws Exception {
+        Map<String, String> properties = new HashMap<String, String>();
+
+        final List<PathFilterSet> pathFilterSets = new ArrayList<PathFilterSet>();
+        pathFilterSets.add(new PathFilterSet("/a/b/c"));
+        pathFilterSets.add(new PathFilterSet("/d/e/f"));
+        pathFilterSets.add(new PathFilterSet("/g/h/i"));
+
+        when(jcrPackageManager.create(packageGroup, packageName, packageOneVersion)).thenReturn(packageOne);
+
+        packageHelper.createPackageFromPathFilterSets(pathFilterSets, session, packageGroup, packageName, packageOneVersion,
+                PackageHelper.ConflictResolution.None, properties);
+
+        // Verify the session was saved, creating the package
+        verify(session, times(1)).save();
+    }
+
 
     @Test
     public void testGetSuccessJSON() throws Exception {
@@ -329,6 +349,36 @@ public class PackageHelperImplTest {
 
 
         final String actual = packageHelper.getPreviewJSON(resources);
+        final JSONObject json = new JSONObject(actual);
+
+        assertEquals("preview", json.getString("status"));
+        assertEquals("Not applicable (Preview)", json.getString("path"));
+
+        final String[] expectedFilterSets = new String[]{
+                "/a/b/c",
+                "/d/e/f",
+                "/g/h/i"
+        };
+
+        JSONArray actualArray = json.getJSONArray("filterSets");
+        for(int i = 0; i < actualArray.length(); i++) {
+            JSONObject tmp = actualArray.getJSONObject(i);
+            assertTrue(ArrayUtils.contains(expectedFilterSets, tmp.get("rootPath")));
+        }
+
+        assertEquals(expectedFilterSets.length, actualArray.length());
+    }
+
+
+
+    @Test
+    public void testGetPathFilterSetPreviewJSON() throws Exception {
+        final List<PathFilterSet> pathFilterSets = new ArrayList<PathFilterSet>();
+        pathFilterSets.add(new PathFilterSet("/a/b/c"));
+        pathFilterSets.add(new PathFilterSet("/d/e/f"));
+        pathFilterSets.add(new PathFilterSet("/g/h/i"));
+
+        final String actual = packageHelper.getPathFilterSetPreviewJSON(pathFilterSets);
         final JSONObject json = new JSONObject(actual);
 
         assertEquals("preview", json.getString("status"));


### PR DESCRIPTION
In AEM6/Oak Packages of Principals that contains .tokens nodes fail during package install.

Tokens should not be included as part of the these packages anyhow as they should remain env/system specific.

This PR excludes `<path-to-principal>/.tokens` nodes from being packaged when "Include Principals" is selected.

Addresses #320 
