### PR TITLE
Downgrade maven-scr-plugin to ensure inclusion of the TLD files.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-scr-plugin</artifactId>
-                    <version>1.20.0</version>
+                    <version>1.17.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Downgrade to last known working version.
