### PR TITLE
Named Image Transforms - Quality

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/images/transformers/impl/QualityImageTransformerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/images/transformers/impl/QualityImageTransformerImpl.java
@@ -1,0 +1,94 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.images.transformers.impl;
+
+import com.adobe.acs.commons.images.ImageTransformer;
+import com.day.image.Layer;
+import org.apache.commons.lang.StringUtils;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.resource.ValueMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+@Component(
+        label = "ACS AEM Commons - Image Transformer - Quality"
+)
+@Properties({
+        @Property(
+                name = ImageTransformer.PROP_TYPE,
+                value = QualityImageTransformerImpl.TYPE,
+                propertyPrivate = true
+        )
+})
+@Service
+public class QualityImageTransformerImpl implements ImageTransformer {
+    private static final Logger log = LoggerFactory.getLogger(QualityImageTransformerImpl.class);
+
+    static final String TYPE = "quality";
+
+    private static final String KEY_QUALITY = "quality";
+
+    private static final int MAX_QUALITY = 100;
+
+    private static final int MIN_QUALITY = 0;
+
+    private static final String MIME_TYPE_GIF = "image/gif";
+
+    private static final float IMAGE_GIF_MAX_QUALITY = 255;
+
+    @Override
+    public final Layer transform(final Layer layer, final ValueMap properties) {
+        log.debug("Transforming with [ {} ]", TYPE);
+
+        int quality = properties.get(KEY_QUALITY, MAX_QUALITY);
+
+        if (quality >= MAX_QUALITY) {
+            // Quality be being requested is max aka original layer quality, so do nothing.
+            return layer;
+        } else if (quality < MIN_QUALITY) {
+            quality = MIN_QUALITY;
+        }
+
+        double convertedQuality = quality / 100f;
+
+        if (StringUtils.equals(MIME_TYPE_GIF, layer.getMimeType())) {
+            convertedQuality = convertedQuality * IMAGE_GIF_MAX_QUALITY;
+        }
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        try {
+            layer.write(layer.getMimeType(), convertedQuality, baos);
+            return new Layer(new ByteArrayInputStream(baos.toByteArray()));
+        } catch (IOException e) {
+            log.warn("Could not collect image as an OutputStream to adjust Image quality.");
+        }
+
+        return layer;
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/images/transformers/impl/QualityImageTransformerImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/images/transformers/impl/QualityImageTransformerImplTest.java
@@ -1,0 +1,130 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.images.transformers.impl;
+
+import com.day.image.Layer;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QualityImageTransformerImplTest {
+
+    QualityImageTransformerImpl transformer;
+
+    @Mock
+    Layer layer;
+
+    Map<String, Object> map = null;
+
+    @Before
+    public void setUp() throws Exception {
+        map = new HashMap<String, Object>();
+        transformer = new QualityImageTransformerImpl();
+    }
+
+    @Test
+    public void testTransform() throws Exception {
+        when(layer.getMimeType()).thenReturn("image/png");
+
+        map.put("quality", 50);
+        ValueMap properties = new ValueMapDecorator(map);
+
+        transformer.transform(layer, properties);
+
+        verify(layer, times(1)).write(eq("image/png"), eq(0.5d), any(OutputStream.class));
+    }
+
+    @Test
+    public void testTransform_Min() throws Exception {
+        when(layer.getMimeType()).thenReturn("image/png");
+
+        map.put("quality", 0);
+        ValueMap properties = new ValueMapDecorator(map);
+
+        transformer.transform(layer, properties);
+
+        verify(layer, times(1)).write(eq("image/png"), eq(0d), any(OutputStream.class));
+    }
+
+    @Test
+    public void testTransform_UnderMin() throws Exception {
+        when(layer.getMimeType()).thenReturn("image/png");
+
+        map.put("quality", -20);
+        ValueMap properties = new ValueMapDecorator(map);
+
+        transformer.transform(layer, properties);
+
+        verify(layer, times(1)).write(eq("image/png"), eq(0d), any(OutputStream.class));
+    }
+
+    @Test
+    public void testTransform_Max() throws Exception {
+        when(layer.getMimeType()).thenReturn("image/png");
+
+        map.put("quality", 100);
+        ValueMap properties = new ValueMapDecorator(map);
+
+        transformer.transform(layer, properties);
+
+        verifyNoMoreInteractions(layer);
+    }
+
+    @Test
+    public void testTransform_OverMax() throws Exception {
+        when(layer.getMimeType()).thenReturn("image/png");
+
+        map.put("quality", 101);
+        ValueMap properties = new ValueMapDecorator(map);
+
+        transformer.transform(layer, properties);
+
+        verifyNoMoreInteractions(layer);
+    }
+
+    @Test
+    public void testTransform_GIF() throws Exception {
+        when(layer.getMimeType()).thenReturn("image/gif");
+
+        map.put("quality", 50);
+        ValueMap properties = new ValueMapDecorator(map);
+
+        transformer.transform(layer, properties);
+
+        verify(layer, times(1)).write(eq("image/gif"), eq(.5 * 255d), any(OutputStream.class));
+    }
+}


### PR DESCRIPTION
All Image Quality to be specified per Named Transform

quality values range from: 0 - 100 [ low - original layer quality ]

Transform params are in the format:  `quality:quality=50`

Example quality reduction to "5"

![image_png__640x438_](https://cloud.githubusercontent.com/assets/1451868/4930522/8914ce60-6565-11e4-8122-ccf0d253bf1a.png)

This PR is a different approach on #347 
