### PR TITLE
Package Replication Status Updater - NodeType hierarchy support

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/PackageHelperImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/PackageHelperImpl.java
@@ -63,7 +63,7 @@ import java.util.Map;
 )
 @Service
 public final class PackageHelperImpl implements PackageHelper {
-    private static final Logger log = LoggerFactory.getLogger(ACLPackagerServletImpl.class);
+    private static final Logger log = LoggerFactory.getLogger(PackageHelperImpl.class);
 
     private static final String NN_THUMBNAIL = "thumbnail.png";
 

--- a/bundle/src/test/java/com/adobe/acs/commons/replication/status/impl/JcrPackageReplicationStatusEventHandlerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/replication/status/impl/JcrPackageReplicationStatusEventHandlerTest.java
@@ -69,6 +69,7 @@ public class JcrPackageReplicationStatusEventHandlerTest {
         final List<String> contentPaths = new ArrayList<String>();
         contentPaths.add("/content/foo");
         contentPaths.add("/content/bar");
+        contentPaths.add("/content/dam/folder/jcr:content");
 
         final String packagePath = "/etc/packages/acs-commons/test.zip";
         final Resource packageResource = mock(Resource.class);
@@ -80,8 +81,13 @@ public class JcrPackageReplicationStatusEventHandlerTest {
 
         final Resource contentResource1 = mock(Resource.class);
         final Resource contentResource2 = mock(Resource.class);
+        final Resource contentResource3 = mock(Resource.class);
+        final Resource contentResource3parent = mock(Resource.class);
+
         final Node contentNode1 = mock(Node.class);
         final Node contentNode2 = mock(Node.class);
+        final Node contentNode3 = mock(Node.class);
+        final Node contentNode3parent = mock(Node.class);
 
         final String[] paths = new String[] { packagePath };
 
@@ -112,6 +118,14 @@ public class JcrPackageReplicationStatusEventHandlerTest {
         when(contentResource2.adaptTo(Node.class)).thenReturn(contentNode2);
         when(contentNode2.isNodeType("dam:AssetContent")).thenReturn(true);
 
+        when(adminResourceResolver.getResource("/content/dam/folder/jcr:content")).thenReturn(contentResource3);
+        when(contentResource3.adaptTo(Node.class)).thenReturn(contentNode3);
+        when(contentNode3.isNodeType("nt:unstructured")).thenReturn(true);
+
+        when(contentResource3.getParent()).thenReturn(contentResource3parent);
+        when(contentResource3parent.adaptTo(Node.class)).thenReturn(contentNode3parent);
+        when(contentNode3parent.isNodeType("sling:OrderedFolder")).thenReturn(true);
+
         jcrPackageReplicationStatusEventHandler.process(event);
 
         verify(replicationStatusManager, times(1)).setReplicationStatus(
@@ -119,6 +133,6 @@ public class JcrPackageReplicationStatusEventHandlerTest {
                 eq("Package Replication"),
                 eq(calendar),
                 eq(ReplicationStatusManager.Status.ACTIVATED),
-                eq(contentResource1), eq(contentResource2));
+                eq(contentResource1), eq(contentResource2), eq(contentResource3));
     }
 }


### PR DESCRIPTION
Fixed Issue #355 

DAM Folders were not being updated during Package Activation because the replication state must be tracked on the `[sling:OrderedFolder]/jcr:content` node which is of type `nt:unstructured`, and `nt:unstructured` is not (and should not) be a candidate type as its far too broad.

Added support to to the "allowed" `node-types` to support a nodeType hierarchy. For example

`node-types=[sling:OrderedFolder/nt:unstructured]`

This will accept any resource that is of type `nt:unstructured` and whose parent is of node type `sling:OrderedFolder`

I've added `sling:OrderedFolder/nt:unstructured` to the default node types config.

![aem_assets___products](https://cloud.githubusercontent.com/assets/1451868/5054714/4126d9e6-6c26-11e4-8134-cc3e5dcd6a86.png)

/cc @ncordeiro
