### PR TITLE
Dispatcher Flush Rules - Multi-Flush Path delimiter fix

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlushRulesImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlushRulesImpl.java
@@ -265,7 +265,7 @@ public class DispatcherFlushRulesImpl implements Preprocessor {
 
         for (final Map.Entry<String, String> entry : configuredRules.entrySet()) {
             final Pattern pattern = Pattern.compile(entry.getKey());
-            rules.put(pattern, entry.getValue().split(","));
+            rules.put(pattern, entry.getValue().split("&"));
         }
 
         return rules;

--- a/bundle/src/test/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlushRulesImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlushRulesImplTest.java
@@ -116,7 +116,7 @@ public class DispatcherFlushRulesImplTest {
         validFlushRules.put("/a/.*", "/b");
         validFlushRules.put("/b/.*", "/c");
         validFlushRules.put("/c/d/.*", "/e/f");
-        validFlushRules.put("/c/a/.*", "/e/f,/g/h");
+        validFlushRules.put("/c/a/.*", "/e/f&/g/h");
 
         final Map<Pattern, String[]> expected = new LinkedHashMap<Pattern, String[]>();
         expected.put(Pattern.compile("/a/.*"), new String[] { "/b" });
@@ -431,5 +431,4 @@ public class DispatcherFlushRulesImplTest {
 
         verifyNoMoreInteractions(dispatcherFlusher);
     }
-
 }


### PR DESCRIPTION
Fixes #375 
Changes the delimiter from a command to an ampersand (, -> &)
