### PR TITLE
Check if property 'unique' exists, before trying to remove.

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsurePropertyIndex.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsurePropertyIndex.java
@@ -110,7 +110,9 @@ public class EnsurePropertyIndex {
         if (def.unique) {
             indexNode.setProperty(PN_UNIQUE, true);
         } else if (indexNode.hasProperty(PN_ASYNC)) {
-            indexNode.getProperty(PN_UNIQUE).remove();
+        	if(indexNode.hasNode(PN_UNIQUE)){
+        		indexNode.getProperty(PN_UNIQUE).remove();	
+        	}
         }
         if (def.declaringNodeTypes != null && def.declaringNodeTypes.length > 0) {
             Value[] values = new Value[def.declaringNodeTypes.length];


### PR DESCRIPTION
To avoid an exception, just checking the "unique" property before trying to remove it. 
