### PR TITLE
Change check on node instead of property

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsurePropertyIndex.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsurePropertyIndex.java
@@ -110,7 +110,7 @@ public class EnsurePropertyIndex {
         if (def.unique) {
             indexNode.setProperty(PN_UNIQUE, true);
         } else if (indexNode.hasProperty(PN_ASYNC)) {
-        	if(indexNode.hasNode(PN_UNIQUE)){
+        	if(indexNode.hasProperty(PN_UNIQUE)){
         		indexNode.getProperty(PN_UNIQUE).remove();	
         	}
         }


### PR DESCRIPTION
Corrected check before removing "unique" property to actually check for existing property instead of node. 
