### PR TITLE
409 - ACL Packager Support for AEM6

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/ACLPackagerServletImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/ACLPackagerServletImpl.java
@@ -29,10 +29,8 @@ import com.day.jcr.vault.fs.filter.DefaultPathFilter;
 import com.day.jcr.vault.fs.io.AccessControlHandling;
 import com.day.jcr.vault.packaging.JcrPackage;
 import com.day.jcr.vault.packaging.JcrPackageDefinition;
-import org.apache.commons.lang.StringUtils;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
-import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.UserManager;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -357,11 +355,7 @@ public class ACLPackagerServletImpl extends SlingAllMethodsServlet {
         if (resource == null) {
             // Resource is null; so dont accept this
             return false;
-        }
-
-        final ValueMap properties = resource.adaptTo(ValueMap.class);
-        if (properties == null
-                || !StringUtils.equals("rep:ACL", properties.get(JcrConstants.JCR_PRIMARYTYPE, String.class))) {
+        } else if (!resource.isResourceType("rep:ACL")) {
             // ONLY accept the resource is a rep:ACL node
            return false;
         }

--- a/bundle/src/test/java/com/adobe/acs/commons/packaging/impl/ACLPackagerServletImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/packaging/impl/ACLPackagerServletImplTest.java
@@ -21,6 +21,7 @@
 package com.adobe.acs.commons.packaging.impl;
 
 import com.adobe.acs.commons.packaging.PackageHelper;
+import com.adobe.acs.commons.util.AemCapabilityHelper;
 import com.day.jcr.vault.packaging.JcrPackage;
 import com.day.jcr.vault.packaging.JcrPackageManager;
 import com.day.jcr.vault.packaging.Version;
@@ -76,9 +77,14 @@ public class ACLPackagerServletImplTest {
     @Mock
     PackageHelper packageHelper;
 
-    @Mock JcrPackage jcrPackage;
+    @Mock
+    JcrPackage jcrPackage;
 
-    @Mock Session session;
+    @Mock
+    AemCapabilityHelper aemCapabilityHelper;
+
+    @Mock
+    Session session;
 
     @InjectMocks
     ACLPackagerServletImpl aclPackagerServlet;
@@ -111,6 +117,8 @@ public class ACLPackagerServletImplTest {
         when(packageHelper.getSuccessJSON(any(JcrPackage.class))).thenReturn("{\"status\": \"success\"}");
         when(packageHelper.getErrorJSON(any(String.class))).thenReturn("{\"status\": \"error\"}");
         when(packageHelper.getPathFilterSetPreviewJSON(any(Collection.class))).thenReturn("{\"status\": \"preview\"}");
+
+        when(aemCapabilityHelper.isOak()).thenReturn(true);
     }
 
     @After


### PR DESCRIPTION
Fixes #409 

On CRX2 continues to use the `rep:ACL` based query; on Oak it uses `SELECT * FROM [rep:ACE] where [rep:principalName] is not null` in order to hit the OOTB `rep:principalName` oak index.

While this adjustment for AEM6 requires more "work" to complete it is negligible, and the perf increase using Oak indexes dominates the performance cost.

Explain Query screen for the AEM6 query
![explain_query___acs_aem_tools](https://cloud.githubusercontent.com/assets/1451868/5992492/2576b0ba-a9fa-11e4-999c-044289195883.png)
