### PR TITLE
Fix for double quotes in richtext boxes

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
@@ -72,7 +72,7 @@ ACS.CQ.MultiFieldPanel = CQ.Ext.extend(CQ.Ext.Panel, {
                 return;
             }
 
-            pData[i.key] = i.getValue();
+            pData[i.key] = i.getValue().replace(/"/g, '&quot;');
         });
 
         return $.isEmptyObject(pData) ? "" : JSON.stringify(pData);

--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
@@ -18,7 +18,7 @@
  * #L%
  */
 /*global CQ: false, ACS: false */
-CQ.Ext.ns("ACS.CQ");
+CQ.Ext.ns("ACS.CQ"); 
 /**
  * @class ACS.CQ.MultiFieldPanel
  * @extends CQ.form.Panel
@@ -71,8 +71,12 @@ ACS.CQ.MultiFieldPanel = CQ.Ext.extend(CQ.Ext.Panel, {
             if(i.xtype === "label" || i.xtype === "hidden" || !i.hasOwnProperty("key")){
                 return;
             }
-
-            pData[i.key] = i.getValue().replace(/"/g, '&quot;');
+            var predata = i.getValue();
+            if(predata && (typeof predata=="string" || (typeof predata=="object" && predata.constructor===String))) {
+                pData[i.key] = predata.replace(/"/g, '&quot;'); 
+            } else {
+                pData[i.key] = predata;
+            }
         });
 
         return $.isEmptyObject(pData) ? "" : JSON.stringify(pData);


### PR DESCRIPTION
Richtexts in a multifield widget break when using double quotes.