### PR TITLE
Parameterized (De)Activate Workflow Steps

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd ">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd ">
     <modelVersion>4.0.0</modelVersion>
     <!-- ====================================================================== -->
     <!-- P A R E N T P R O J E C T D E S C R I P T I O N -->
@@ -81,9 +78,9 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <systemPropertyVariables>
-                        <artifactPath>${project.artifact.file.absolutePath}</artifactPath>
-                    </systemPropertyVariables>
+                   <systemPropertyVariables>
+                       <artifactPath>${project.artifact.file.absolutePath}</artifactPath>
+                   </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>
@@ -215,7 +212,7 @@
         <dependency>
             <groupId>com.day.cq.wcm</groupId>
             <artifactId>cq-wcm-workflow</artifactId>
-            <version>5.6.4</version>
+            <version>5.7.8</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -273,6 +270,8 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.commons.json</artifactId>
+            <version>2.0.6</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.day.cq</groupId>
@@ -337,6 +336,8 @@
         <dependency>
             <groupId>com.adobe.granite</groupId>
             <artifactId>com.adobe.granite.replication.core</artifactId>
+            <version>5.5.8</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.scribe</groupId>
@@ -368,9 +369,9 @@
             <version>5.6.4</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr</artifactId>
+        <dependency> 
+            <groupId>org.apache.felix</groupId> 
+            <artifactId>org.apache.felix.scr</artifactId> 
             <version>1.6.2</version>
             <scope>provided</scope>
         </dependency>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -205,14 +205,14 @@
         <dependency>
             <groupId>com.day.cq.wcm</groupId>
             <artifactId>cq-wcm-workflow-api</artifactId>
-            <version>5.7.2</version>
+            <version>5.3.0</version>
             <scope>provided</scope>
             <type>bundle</type>
         </dependency>
         <dependency>
             <groupId>com.day.cq.wcm</groupId>
             <artifactId>cq-wcm-workflow</artifactId>
-            <version>5.7.6</version>
+            <version>5.6.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -212,7 +212,7 @@
         <dependency>
             <groupId>com.day.cq.wcm</groupId>
             <artifactId>cq-wcm-workflow</artifactId>
-            <version>5.7.8</version>
+            <version>5.7.6</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd ">
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd ">
     <modelVersion>4.0.0</modelVersion>
     <!-- ====================================================================== -->
     <!-- P A R E N T P R O J E C T D E S C R I P T I O N -->
@@ -78,9 +81,9 @@
                     </execution>
                 </executions>
                 <configuration>
-                   <systemPropertyVariables>
-                       <artifactPath>${project.artifact.file.absolutePath}</artifactPath>
-                   </systemPropertyVariables>
+                    <systemPropertyVariables>
+                        <artifactPath>${project.artifact.file.absolutePath}</artifactPath>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>
@@ -203,6 +206,19 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.day.cq.wcm</groupId>
+            <artifactId>cq-wcm-workflow-api</artifactId>
+            <version>5.7.2</version>
+            <scope>provided</scope>
+            <type>bundle</type>
+        </dependency>
+        <dependency>
+            <groupId>com.day.cq.wcm</groupId>
+            <artifactId>cq-wcm-workflow</artifactId>
+            <version>5.6.4</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.commons.mime</artifactId>
             <version>2.1.4</version>
@@ -257,8 +273,6 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.commons.json</artifactId>
-            <version>2.0.6</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.day.cq</groupId>
@@ -323,8 +337,6 @@
         <dependency>
             <groupId>com.adobe.granite</groupId>
             <artifactId>com.adobe.granite.replication.core</artifactId>
-            <version>5.5.8</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.scribe</groupId>
@@ -356,9 +368,9 @@
             <version>5.6.4</version>
             <scope>provided</scope>
         </dependency>
-        <dependency> 
-            <groupId>org.apache.felix</groupId> 
-            <artifactId>org.apache.felix.scr</artifactId> 
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr</artifactId>
             <version>1.6.2</version>
             <scope>provided</scope>
         </dependency>

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/process/ParameterizedActivatePageProcess.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/process/ParameterizedActivatePageProcess.java
@@ -24,7 +24,6 @@ import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Properties;
 import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Service;
-import org.osgi.framework.Constants;
 
 import com.day.cq.replication.Agent;
 import com.day.cq.replication.AgentFilter;
@@ -53,35 +52,35 @@ import com.day.cq.workflow.metadata.MetaDataMap;
 //@formatter:on
 public class ParameterizedActivatePageProcess extends ActivatePageProcess {
 
-	private static final String AGENT_ARG = "replicationAgent";
-	
-	private transient ThreadLocal<String[]>	agentId = new ThreadLocal<String[]>();
+    private static final String AGENT_ARG = "replicationAgent";
 
-	@Override
-	public void execute(WorkItem workItem, WorkflowSession workflowSession, MetaDataMap args) throws WorkflowException {
-		agentId.set(args.get(AGENT_ARG, new String[]{}));
-		super.execute(workItem, workflowSession, args);
+    private transient ThreadLocal<String[]> agentId = new ThreadLocal<String[]>();
 
-	}
+    @Override
+    public void execute(WorkItem workItem, WorkflowSession workflowSession, MetaDataMap args) throws WorkflowException {
+        agentId.set(args.get(AGENT_ARG, new String[] {}));
+        super.execute(workItem, workflowSession, args);
 
-	@Override
-	protected ReplicationOptions prepareOptions(ReplicationOptions opts) {
+    }
 
-		if (opts == null) {
-			opts = new ReplicationOptions();
-		}
-		opts.setFilter(new AgentFilter() {
+    @Override
+    protected ReplicationOptions prepareOptions(ReplicationOptions opts) {
 
-			@Override
-			public boolean isIncluded(Agent agent) {
-				
-				if (ArrayUtils.isEmpty(agentId.get())) {
-					return false;
-				}
-				return ArrayUtils.contains(agentId.get(), agent.getId());
-			}
-		});
-		return opts;
-	}
+        if (opts == null) {
+            opts = new ReplicationOptions();
+        }
+        opts.setFilter(new AgentFilter() {
+
+            @Override
+            public boolean isIncluded(Agent agent) {
+
+                if (ArrayUtils.isEmpty(agentId.get())) {
+                    return false;
+                }
+                return ArrayUtils.contains(agentId.get(), agent.getId());
+            }
+        });
+        return opts;
+    }
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/process/ParameterizedActivatePageProcess.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/process/ParameterizedActivatePageProcess.java
@@ -1,0 +1,87 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 - 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.workflow.process;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Service;
+import org.osgi.framework.Constants;
+
+import com.day.cq.replication.Agent;
+import com.day.cq.replication.AgentFilter;
+import com.day.cq.replication.ReplicationOptions;
+import com.day.cq.wcm.workflow.process.ActivatePageProcess;
+import com.day.cq.workflow.WorkflowException;
+import com.day.cq.workflow.WorkflowSession;
+import com.day.cq.workflow.exec.WorkItem;
+import com.day.cq.workflow.metadata.MetaDataMap;
+
+//@formatter:off
+@Component(
+      metatype = true,
+      label = "ACS AEM Commons - Workflow Process - Parameterized Activate Resource",
+      description = "Triggers an activation replication event, but only to specifically configured agents."
+)
+@Properties({
+      @Property(
+              label = "Workflow Label",
+              name = "process.label", 
+              value = "Parameterized Activate Resource Process",
+              description = "Triggers an activation replication event, but only to specifically configured agents."
+      )
+})
+@Service
+//@formatter:on
+public class ParameterizedActivatePageProcess extends ActivatePageProcess {
+
+	private static final String AGENT_ARG = "replicationAgent";
+	
+	private transient ThreadLocal<String[]>	agentId = new ThreadLocal<String[]>();
+
+	@Override
+	public void execute(WorkItem workItem, WorkflowSession workflowSession, MetaDataMap args) throws WorkflowException {
+		agentId.set(args.get(AGENT_ARG, new String[]{}));
+		super.execute(workItem, workflowSession, args);
+
+	}
+
+	@Override
+	protected ReplicationOptions prepareOptions(ReplicationOptions opts) {
+
+		if (opts == null) {
+			opts = new ReplicationOptions();
+		}
+		opts.setFilter(new AgentFilter() {
+
+			@Override
+			public boolean isIncluded(Agent agent) {
+				
+				if (ArrayUtils.isEmpty(agentId.get())) {
+					return false;
+				}
+				return ArrayUtils.contains(agentId.get(), agent.getId());
+			}
+		});
+		return opts;
+	}
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/process/ParameterizedDeactivatePageProcess.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/process/ParameterizedDeactivatePageProcess.java
@@ -24,12 +24,10 @@ import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Properties;
 import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Service;
-import org.osgi.framework.Constants;
 
 import com.day.cq.replication.Agent;
 import com.day.cq.replication.AgentFilter;
 import com.day.cq.replication.ReplicationOptions;
-import com.day.cq.wcm.workflow.process.ActivatePageProcess;
 import com.day.cq.wcm.workflow.process.DeactivatePageProcess;
 import com.day.cq.workflow.WorkflowException;
 import com.day.cq.workflow.WorkflowSession;

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/process/ParameterizedDeactivatePageProcess.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/process/ParameterizedDeactivatePageProcess.java
@@ -1,0 +1,88 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 - 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.workflow.process;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Service;
+import org.osgi.framework.Constants;
+
+import com.day.cq.replication.Agent;
+import com.day.cq.replication.AgentFilter;
+import com.day.cq.replication.ReplicationOptions;
+import com.day.cq.wcm.workflow.process.ActivatePageProcess;
+import com.day.cq.wcm.workflow.process.DeactivatePageProcess;
+import com.day.cq.workflow.WorkflowException;
+import com.day.cq.workflow.WorkflowSession;
+import com.day.cq.workflow.exec.WorkItem;
+import com.day.cq.workflow.metadata.MetaDataMap;
+
+//@formatter:off
+@Component(
+        metatype = true,
+        label = "ACS AEM Commons - Workflow Process - Parameterized Deactivate Resource",
+        description = "Triggers a deactivation replication event, but only to specifically configured agents."
+)
+@Properties({
+        @Property(
+                label = "Workflow Label",
+                name = "process.label", 
+                value = "Parameterized Deactivate Resource Process",
+                description = "Triggers a deactivation replication event, but only to specifically configured agents."
+        )
+})
+@Service
+//@formatter:on
+public class ParameterizedDeactivatePageProcess extends DeactivatePageProcess {
+
+    private static final String AGENT_ARG = "replicationAgent";
+
+    private transient ThreadLocal<String[]> agentId = new ThreadLocal<String[]>();
+
+    @Override
+    public void execute(WorkItem workItem, WorkflowSession workflowSession, MetaDataMap args) throws WorkflowException {
+        agentId.set(args.get(AGENT_ARG, new String[] {}));
+        super.execute(workItem, workflowSession, args);
+
+    }
+
+    @Override
+    protected ReplicationOptions prepareOptions(ReplicationOptions opts) {
+
+        if (opts == null) {
+            opts = new ReplicationOptions();
+        }
+        opts.setFilter(new AgentFilter() {
+
+            @Override
+            public boolean isIncluded(Agent agent) {
+
+                if (ArrayUtils.isEmpty(agentId.get())) {
+                    return false;
+                }
+                return ArrayUtils.contains(agentId.get(), agent.getId());
+            }
+        });
+        return opts;
+    }
+
+}

--- a/content/pom.xml
+++ b/content/pom.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <!-- ====================================================================== -->
     <!-- P A R E N T P R O J E C T D E S C R I P T I O N -->
     <!-- ====================================================================== -->
@@ -64,7 +68,7 @@
                     <targetURL>http://${crx.host}:${crx.port}/crx/packmgr/service.jsp</targetURL>
                 </configuration>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jslint-maven-plugin</artifactId>
@@ -228,6 +232,15 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.commons.json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.granite</groupId>
+            <artifactId>com.adobe.granite.replication.core</artifactId>
+        </dependency>
+
     </dependencies>
     <profiles>
         <profile>

--- a/content/pom.xml
+++ b/content/pom.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <!-- ====================================================================== -->
     <!-- P A R E N T P R O J E C T D E S C R I P T I O N -->
     <!-- ====================================================================== -->
@@ -68,7 +64,7 @@
                     <targetURL>http://${crx.host}:${crx.port}/crx/packmgr/service.jsp</targetURL>
                 </configuration>
             </plugin>
-
+            
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jslint-maven-plugin</artifactId>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+    jcr:primaryType="sling:Folder"/>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    allowedparents="*/parsys"
+    componentGroup=".hidden"
+    jcr:primaryType="cq:Component"
+    sling:resourceSuperType="cq/workflow/components/model/process">
+    
+</jcr:root>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/activate/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/activate/.content.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    allowedparents="*/parsys"
+    componentGroup="ACS Commons Workflow"
+    jcr:description="A process to activate a resource, specifying the agent(s) to trigger."
+    jcr:primaryType="cq:Component"
+    jcr:title="Selective Activate Page/Asset" 
+    sling:resourceSuperType="/apps/acs-commons/components/workflow/select-agent">
+    
+</jcr:root>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/activate/_cq_editConfig.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/activate/_cq_editConfig.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:dialogMode="floating"
+    jcr:primaryType="cq:EditConfig">
+    <cq:formParameters
+    	jcr:primaryType="nt:unstructured"
+    	PROCESS="com.adobe.acs.commons.workflow.process.ParameterizedActivatePageProcess"
+    	PROCESS_AUTO_ADVANCE="true"
+    	jcr:description="A process to activate a page or asset; specifying the agent(s) to trigger."
+    	jcr:title="Selective Activate Page/Asset"
+        isCacheInvalidate="false"/>
+   	<cq:listeners
+   		jcr:primaryType="cq:EditListenersConfig"
+  		afterMove="CQ.flow.Step.afterMove"
+  		afterdelete="CQ.flow.Step.afterDelete"
+  		afteredit="CQ.flow.Step.afterEdit"
+  		afterinsert="CQ.workflow.flow.Step.afterInsert" />
+</jcr:root>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/agentoptions.json.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/agentoptions.json.jsp
@@ -1,0 +1,55 @@
+<%--
+  #%L
+  ACS AEM Commons Package
+  %%
+  Copyright (C) 2013 - 2015 Adobe
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  --%>
+<%@ include file="/libs/foundation/global.jsp"%>
+
+<%@page
+    import="java.util.Map, java.util.List, java.util.ArrayList, java.util.Collections, org.apache.commons.lang3.StringUtils,
+			org.apache.sling.commons.json.JSONObject, org.apache.sling.commons.json.JSONArray,
+			com.day.cq.replication.AgentManager, com.day.cq.replication.Agent"%>
+
+<%
+    response.setContentType("application/json");
+
+    boolean isCacheInvalidate = properties.get("metaData/isCacheInvalidate", false);
+
+    JSONArray options = new JSONArray();
+    try {
+        AgentManager agentManager = sling.getService(AgentManager.class);
+        Map<String, Agent> agents = agentManager.getAgents();
+        List<String> keys = new ArrayList<String>(agents.keySet());
+
+        Collections.sort(keys);
+
+        for (String key : keys) {
+            Agent agent = agents.get(key);
+
+            if (agent.isValid() && agent.isEnabled() && agent.isCacheInvalidator() == isCacheInvalidate) {
+                JSONObject entry = new JSONObject();
+                entry.put("value", key);
+                entry.put("text", agent.getConfiguration().getName());
+                options.put(entry);
+            }
+        }
+    } catch (Exception ex) {
+        log.error("Unable to create list of agents.", ex);
+    }
+%>
+<%=options.toString()%>
+

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/cache-invalidate/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/cache-invalidate/.content.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    allowedparents="*/parsys"
+    componentGroup="ACS Commons Workflow"
+    jcr:description="A process to flush the cache of a resource, specifying the agent(s) to trigger."
+    jcr:primaryType="cq:Component"
+    jcr:title="Selective Cache Invalidate Page/Asset" 
+    sling:resourceSuperType="/apps/acs-commons/components/workflow/select-agent">
+    
+</jcr:root>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/cache-invalidate/_cq_editConfig.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/cache-invalidate/_cq_editConfig.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:dialogMode="floating"
+    jcr:primaryType="cq:EditConfig">
+    <cq:formParameters
+    	jcr:primaryType="nt:unstructured"
+    	PROCESS="com.adobe.acs.commons.workflow.process.ParameterizedActivatePageProcess"
+    	PROCESS_AUTO_ADVANCE="true"
+    	jcr:description="A process to flush the cache of a resource; specifying the agent(s) to trigger."
+    	jcr:title="Selective Cache Invalidate Page/Asset"
+        isCacheInvalidate="true" />
+   	<cq:listeners
+   		jcr:primaryType="cq:EditListenersConfig"
+  		afterMove="CQ.flow.Step.afterMove"
+  		afterdelete="CQ.flow.Step.afterDelete"
+  		afteredit="CQ.flow.Step.afterEdit"
+  		afterinsert="CQ.workflow.flow.Step.afterInsert" />
+</jcr:root>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/deactivate/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/deactivate/.content.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    allowedparents="*/parsys"
+    componentGroup="ACS Commons Workflow"
+    jcr:description="A process to deactivate a resource, specifying the agent(s) to trigger."
+    jcr:primaryType="cq:Component"
+    jcr:title="Selective Deactivate Page/Asset" 
+    sling:resourceSuperType="/apps/acs-commons/components/workflow/select-agent">
+    
+</jcr:root>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/deactivate/_cq_editConfig.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/deactivate/_cq_editConfig.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:dialogMode="floating"
+    jcr:primaryType="cq:EditConfig">
+    <cq:formParameters
+    	jcr:primaryType="nt:unstructured"
+    	PROCESS="com.adobe.acs.commons.workflow.process.ParameterizedDeactivatePageProcess"
+    	PROCESS_AUTO_ADVANCE="true"
+    	jcr:description="A process to deactivate a page or asset; specifying the agent(s) to trigger."
+    	jcr:title="Selective Dectivate Page/Asset"
+        isCacheInvalidate="false"/>
+   	<cq:listeners
+   		jcr:primaryType="cq:EditListenersConfig"
+  		afterMove="CQ.flow.Step.afterMove"
+  		afterdelete="CQ.flow.Step.afterDelete"
+  		afteredit="CQ.flow.Step.afterEdit"
+  		afterinsert="CQ.workflow.flow.Step.afterInsert" />
+</jcr:root>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/dialog.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/dialog.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0"
+    xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Dialog"
+    jcr:title="Selective Replicate Page/Asset - Step Properties"
+    xtype="dialog">
+    <items jcr:primaryType="cq:WidgetCollection">
+        <tabs
+            jcr:primaryType="cq:Dialog"
+            xtype="tabpanel">
+            <items jcr:primaryType="cq:WidgetCollection">
+                <processcommon
+                    jcr:primaryType="cq:Widget"
+                    path="/libs/cq/workflow/components/model/process/process_head.infinity.json"
+                    xtype="cqinclude" />
+                <processargs
+                    jcr:primaryType="cq:Widget"
+                    path="/apps/acs-commons/components/workflow/select-agent/processargs.infinity.json"
+                    xtype="cqinclude" />
+            </items>
+        </tabs>
+    </items>
+</jcr:root>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/processargs.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/workflow/select-agent/processargs.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0"
+    xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Panel"
+    jcr:title="Arguments"
+    xtype="panel">
+    <items jcr:primaryType="cq:WidgetCollection">
+        <arguments
+            jcr:primaryType="cq:Dialog"
+            title="Process Arguments"
+            xtype="dialogfieldset"
+            collapsed="false"
+            callapsible="false">
+            <items jcr:primaryType="cq:WidgetCollection">
+                <agentToUse
+                    jcr:primaryType="cq:Widget"
+                    fieldDescription="Select the agent(s) which should be triggered for the replication request."
+                    fieldLabel="Replication Agents"
+                    name="./metaData/replicationAgent"
+                    type="checkbox"
+                    xtype="selection"
+                    options="$PATH.agentoptions.json" />
+            </items>
+        </arguments>
+    </items>
+</jcr:root>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <!-- ====================================================================== -->
     <!-- P A R E N T P R O J E C T D E S C R I P T I O N -->
@@ -17,13 +20,13 @@
     <inceptionYear>2013</inceptionYear>
     <licenses>
         <license>
-          <name>The Apache Software License, Version 2.0</name>
+            <name>The Apache Software License, Version 2.0</name>
             <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
     <organization>
-      <name>Adobe</name>
-      <url>http://www.adobe.com/</url>
+        <name>Adobe</name>
+        <url>http://www.adobe.com/</url>
     </organization>
     
     <prerequisites>
@@ -174,35 +177,34 @@
                     <artifactId>license-maven-plugin</artifactId>
                     <version>1.5</version>
                 </plugin>
-                 <plugin>
-                     <artifactId>maven-release-plugin</artifactId>
-                     <version>3.0-r1585899</version>
-                     <configuration>
-                         <autoVersionSubmodules>true</autoVersionSubmodules>
-                         <projectVersionPolicyId>OddEvenVersionPolicy</projectVersionPolicyId>
-                     </configuration>
-                     <dependencies>
-                         <dependency>
-                             <groupId>org.apache.maven.release</groupId>
-                             <artifactId>maven-release-oddeven-policy</artifactId>
-                             <version>3.0-r1585899</version>
-                         </dependency>
-                     </dependencies>
-                 </plugin>
-                 <plugin>
-                     <groupId>org.apache.maven.plugins</groupId>
-                     <artifactId>maven-failsafe-plugin</artifactId>
-                     <version>2.17</version>
-                  </plugin>
+                <plugin>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>3.0-r1585899</version>
+                    <configuration>
+                        <autoVersionSubmodules>true</autoVersionSubmodules>
+                        <projectVersionPolicyId>OddEvenVersionPolicy</projectVersionPolicyId>
+                    </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.release</groupId>
+                            <artifactId>maven-release-oddeven-policy</artifactId>
+                            <version>3.0-r1585899</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.17</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
 
     <scm>
         <developerConnection>scm:git:git@github.com:Adobe-Consulting-Services/acs-aem-commons.git</developerConnection>
-      <tag>HEAD</tag>
-  </scm>
-
+        <tag>HEAD</tag>
+    </scm>
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -319,6 +321,18 @@
                 <version>5.6.2</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>org.apache.sling.commons.json</artifactId>
+                <version>2.0.6</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.adobe.granite</groupId>
+                <artifactId>com.adobe.granite.replication.core</artifactId>
+                <version>5.5.8</version>
+                <scope>provided</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -355,7 +369,7 @@
                                     <goal>pmd</goal>
                                     <goal>cpd</goal>
                                     <!-- build will fail on warnings -->
-                                    <goal>check</goal> 
+                                    <goal>check</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <!-- ====================================================================== -->
     <!-- P A R E N T P R O J E C T D E S C R I P T I O N -->
@@ -20,13 +17,13 @@
     <inceptionYear>2013</inceptionYear>
     <licenses>
         <license>
-            <name>The Apache Software License, Version 2.0</name>
+          <name>The Apache Software License, Version 2.0</name>
             <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
     <organization>
-        <name>Adobe</name>
-        <url>http://www.adobe.com/</url>
+      <name>Adobe</name>
+      <url>http://www.adobe.com/</url>
     </organization>
     
     <prerequisites>
@@ -177,34 +174,35 @@
                     <artifactId>license-maven-plugin</artifactId>
                     <version>1.5</version>
                 </plugin>
-                <plugin>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>3.0-r1585899</version>
-                    <configuration>
-                        <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <projectVersionPolicyId>OddEvenVersionPolicy</projectVersionPolicyId>
-                    </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.maven.release</groupId>
-                            <artifactId>maven-release-oddeven-policy</artifactId>
-                            <version>3.0-r1585899</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.17</version>
-                </plugin>
+                 <plugin>
+                     <artifactId>maven-release-plugin</artifactId>
+                     <version>3.0-r1585899</version>
+                     <configuration>
+                         <autoVersionSubmodules>true</autoVersionSubmodules>
+                         <projectVersionPolicyId>OddEvenVersionPolicy</projectVersionPolicyId>
+                     </configuration>
+                     <dependencies>
+                         <dependency>
+                             <groupId>org.apache.maven.release</groupId>
+                             <artifactId>maven-release-oddeven-policy</artifactId>
+                             <version>3.0-r1585899</version>
+                         </dependency>
+                     </dependencies>
+                 </plugin>
+                 <plugin>
+                     <groupId>org.apache.maven.plugins</groupId>
+                     <artifactId>maven-failsafe-plugin</artifactId>
+                     <version>2.17</version>
+                  </plugin>
             </plugins>
         </pluginManagement>
     </build>
 
     <scm>
         <developerConnection>scm:git:git@github.com:Adobe-Consulting-Services/acs-aem-commons.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
+      <tag>HEAD</tag>
+  </scm>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -330,7 +328,7 @@
             <dependency>
                 <groupId>com.adobe.granite</groupId>
                 <artifactId>com.adobe.granite.replication.core</artifactId>
-                <version>5.5.8</version>
+                <version>5.16.20</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>
@@ -369,7 +367,7 @@
                                     <goal>pmd</goal>
                                     <goal>cpd</goal>
                                     <!-- build will fail on warnings -->
-                                    <goal>check</goal>
+                                    <goal>check</goal> 
                                 </goals>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -328,7 +328,7 @@
             <dependency>
                 <groupId>com.adobe.granite</groupId>
                 <artifactId>com.adobe.granite.replication.core</artifactId>
-                <version>5.16.20</version>
+                <version>5.12.2</version>
                 <scope>provided</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Adding new feature for parameterized workflow activation steps; Giving the ability to select replication agents instead of triggering a mass activation processes.

We've seen the use case where clients have a preview environment which needs content replication without triggering a default agent. These allow the workflows to have a subset of replication agents be triggered, and subsequent approval step executed, before triggering another subset of agents (this time for the production publish systems).

It's possible to get the arguments correct, on a normal WF process step. But to make life easier for WF editors, i included three custom WF Components. 

* Activate
* Flush
* Deactivate

The Activate/Deactivate only show those replication agents which are *not* cache invalidators. Of course the flush will only list agents which *are* invalidators.

I used an inheritance model to manage not doing a CPD on the dialog, JSON generation; but that means that the dialog titles and other attributes aren't unique to the different types. Let me know if you think it's better to be explicit.

The thread local variables are use because I am pretty sure that the processes can be used by multiple threads; and I needed to keep state (which agents were selected).

Here's some screen shots:

![capture](https://cloud.githubusercontent.com/assets/6520270/6723653/0484fb54-cdb9-11e4-8e01-66541ad6fc08.PNG)


![capture](https://cloud.githubusercontent.com/assets/6520270/6723644/ed167830-cdb8-11e4-96a0-16858007c894.PNG)


If it's accepted, i'll write up the documentation and do a PR on that repo.
