### PR TITLE
CQInclude Property Namespace Servlet

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/json/AbstractJSONObjectVisitor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/json/AbstractJSONObjectVisitor.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.json;
 
 import org.apache.sling.commons.json.JSONArray;

--- a/bundle/src/main/java/com/adobe/acs/commons/json/AbstractJSONObjectVisitor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/json/AbstractJSONObjectVisitor.java
@@ -1,0 +1,86 @@
+package com.adobe.acs.commons.json;
+
+import org.apache.sling.commons.json.JSONArray;
+import org.apache.sling.commons.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Iterator;
+
+public abstract class AbstractJSONObjectVisitor {
+    private static final Logger log = LoggerFactory.getLogger(AbstractJSONObjectVisitor.class);
+
+    /**
+     * Visit the given JSON Object and all its descendants.
+     *
+     * @param jsonObject The JSON Object
+     */
+    public void accept(final JSONObject jsonObject) {
+        if (jsonObject != null) {
+            this.visit(jsonObject);
+            this.traverseJSONObject(jsonObject);
+        }
+    }
+
+    /**
+     * Visit the given JSON Array and all its descendants.
+     *
+     * @param jsonArray The JSON Object
+     */
+    public void accept(final JSONArray jsonArray) {
+        if (jsonArray != null) {
+            this.traverseJSONArray(jsonArray);
+        }
+    }
+
+    /**
+     * Visit each JSON Object in the JSON Array.
+     *
+     * @param jsonObject The JSON Array
+     */
+    protected final void traverseJSONObject(final JSONObject jsonObject) {
+        if (jsonObject == null) {
+            return;
+        }
+
+        final Iterator<String> keys = jsonObject.keys();
+
+        while (keys.hasNext()) {
+            final String key = keys.next();
+
+            if (jsonObject.optJSONObject(key) != null) {
+                this.accept(jsonObject.optJSONObject(key));
+            } else if (jsonObject.optJSONArray(key) != null) {
+                this.accept(jsonObject.optJSONArray(key));
+            }
+        }
+    }
+
+    /**
+     * Visit each JSON Object in the JSON Array.
+     *
+     * @param jsonArray The JSON Array
+     */
+    protected final void traverseJSONArray(final JSONArray jsonArray) {
+        if (jsonArray == null) {
+            return;
+        }
+
+        for (int i = 0; i < jsonArray.length(); i++) {
+
+            if (jsonArray.optJSONObject(i) != null) {
+                this.accept(jsonArray.optJSONObject(i));
+            } else if (jsonArray.optJSONArray(i) != null) {
+                this.accept(jsonArray.optJSONArray(i));
+            }
+        }
+    }
+
+    /**
+     * Implement this method to do actual work on the JSON Object.
+     *
+     * @param jsonObject The JSON Object
+     */
+    protected abstract void visit(final JSONObject jsonObject);
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/CQIncludeNamePropertyPrefixingServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/CQIncludeNamePropertyPrefixingServlet.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.wcm.impl;
 
 import com.adobe.acs.commons.json.AbstractJSONObjectVisitor;

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/CQIncludeNamePropertyPrefixingServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/CQIncludeNamePropertyPrefixingServlet.java
@@ -1,0 +1,117 @@
+package com.adobe.acs.commons.wcm.impl;
+
+import com.adobe.acs.commons.json.AbstractJSONObjectVisitor;
+import com.adobe.acs.commons.util.BufferingResponse;
+import com.adobe.acs.commons.util.PathInfoUtil;
+import com.day.cq.commons.jcr.JcrConstants;
+import org.apache.commons.lang.StringUtils;
+import org.apache.felix.scr.annotations.sling.SlingServlet;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.request.RequestDispatcherOptions;
+import org.apache.sling.api.request.RequestUtil;
+import org.apache.sling.api.servlets.OptingServlet;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.apache.sling.commons.json.JSONException;
+import org.apache.sling.commons.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.net.URLDecoder;
+
+@SuppressWarnings("serial")
+@SlingServlet(
+        selectors = "overlay.cqinclude.name-prefix",
+        extensions = "json",
+        resourceTypes = "sling/servlet/default")
+public final class CQIncludeNamePropertyPrefixingServlet extends SlingSafeMethodsServlet implements OptingServlet {
+    private static final Logger log = LoggerFactory.getLogger(CQIncludeNamePropertyPrefixingServlet.class);
+
+    private static final String REQ_ATTR = CQIncludeNamePropertyPrefixingServlet.class.getName() + ".processed";
+
+    private static final String AEM_CQ_INCLUDE_SELECTORS = "overlay.infinity";
+
+    private static final int NAME_PROPERTY_SELECTOR_INDEX = 3;
+
+    @Override
+    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
+            throws ServletException, IOException {
+
+        RequestUtil.setRequestAttribute(request, REQ_ATTR, true);
+
+        final String prefix =
+                URLDecoder.decode(PathInfoUtil.getSelector(request, NAME_PROPERTY_SELECTOR_INDEX), "UTF-8");
+
+        final RequestDispatcherOptions options = new RequestDispatcherOptions();
+        options.setReplaceSelectors(AEM_CQ_INCLUDE_SELECTORS);
+
+        final BufferingResponse bufferingResponse = new BufferingResponse(response);
+        request.getRequestDispatcher(request.getResource(), options).forward(request, bufferingResponse);
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        try {
+            final JSONObject json = new JSONObject(bufferingResponse.getContents());
+            final NamePropertyUpdater namePropertyUpdater = new NamePropertyUpdater(prefix);
+
+            namePropertyUpdater.accept(json);
+            response.getWriter().write(json.toString());
+
+        } catch (JSONException e) {
+            log.error("Error composing the cqinclude JSON representation of the widget overlay for [ {} ]",
+                    request.getRequestURI(), e);
+
+            response.setStatus(SlingHttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.getWriter().write(new JSONObject().toString());
+        }
+    }
+
+    @Override
+    public boolean accepts(SlingHttpServletRequest request) {
+        if (request.getAttribute(REQ_ATTR) != null) {
+            // Cyclic loop
+            return false;
+        }
+
+        for (int i = 0; i < NAME_PROPERTY_SELECTOR_INDEX; i++) {
+            if (StringUtils.isBlank(PathInfoUtil.getSelector(request, i))) {
+                // Missing selectors
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private class NamePropertyUpdater extends AbstractJSONObjectVisitor {
+        private final Logger log = LoggerFactory.getLogger(NamePropertyUpdater.class);
+
+        private static final String PN_NAME = "name";
+        private static final String NT_CQ_WIDGET = "cq:Widget";
+
+        private final String namePrefix;
+
+        public NamePropertyUpdater(final String namePrefix) {
+            this.namePrefix = namePrefix;
+        }
+
+        @Override
+        protected void visit(JSONObject jsonObject) {
+
+            if (StringUtils.equals(jsonObject.optString(JcrConstants.JCR_PRIMARYTYPE), NT_CQ_WIDGET)) {
+                final String nameValue = jsonObject.optString(PN_NAME);
+
+                if (StringUtils.isNotBlank(nameValue)) {
+                    try {
+                        jsonObject.put(PN_NAME, "./" + namePrefix + "/" + nameValue);
+                    } catch (final JSONException e) {
+                        log.error("Error updating the Name property of the JSON object", e);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/CQIncludePropertyNamespaceServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/CQIncludePropertyNamespaceServlet.java
@@ -43,13 +43,13 @@ import java.net.URLDecoder;
 
 @SuppressWarnings("serial")
 @SlingServlet(
-        selectors = "overlay.cqinclude.name-prefix",
+        selectors = "overlay.cqinclude.namespace",
         extensions = "json",
         resourceTypes = "sling/servlet/default")
-public final class CQIncludeNamePropertyPrefixingServlet extends SlingSafeMethodsServlet implements OptingServlet {
-    private static final Logger log = LoggerFactory.getLogger(CQIncludeNamePropertyPrefixingServlet.class);
+public final class CQIncludePropertyNamespaceServlet extends SlingSafeMethodsServlet implements OptingServlet {
+    private static final Logger log = LoggerFactory.getLogger(CQIncludePropertyNamespaceServlet.class);
 
-    private static final String REQ_ATTR = CQIncludeNamePropertyPrefixingServlet.class.getName() + ".processed";
+    private static final String REQ_ATTR = CQIncludePropertyNamespaceServlet.class.getName() + ".processed";
 
     private static final String AEM_CQ_INCLUDE_SELECTORS = "overlay.infinity";
 
@@ -112,10 +112,10 @@ public final class CQIncludeNamePropertyPrefixingServlet extends SlingSafeMethod
         private static final String PN_NAME = "name";
         private static final String NT_CQ_WIDGET = "cq:Widget";
 
-        private final String namePrefix;
+        private final String namespace;
 
-        public NamePropertyUpdater(final String namePrefix) {
-            this.namePrefix = namePrefix;
+        public NamePropertyUpdater(final String namespace) {
+            this.namespace = namespace;
         }
 
         @Override
@@ -126,7 +126,7 @@ public final class CQIncludeNamePropertyPrefixingServlet extends SlingSafeMethod
 
                 if (StringUtils.isNotBlank(nameValue)) {
                     try {
-                        jsonObject.put(PN_NAME, "./" + namePrefix + "/" + nameValue);
+                        jsonObject.put(PN_NAME, "./" + namespace + "/" + nameValue);
                     } catch (final JSONException e) {
                         log.error("Error updating the Name property of the JSON object", e);
                     }


### PR DESCRIPTION
the cqinclude xtype allows for re-use of other dialogs. This supports a nice pattern of composition when creating components; Larger components cant be composed of smaller components, and their editing UI can be centralized into the dialog of the parent component.

OOTB cqinclude is "dumb" (in that it just proxies the data through, and doesnt apply any transformations, etc.) in that renders the sub-component's dialog JSON exactly as it is defined on the sub component. This is problematic when a Component is composed of multiple smaller sub-components and each sub-component uses the same name properties.

For Example a Feature component that is composed of a Title Component, Text Component and Button component. Both the Title component and Button component may store the label value to the property name "./jcr:title". Since both components save to the same property, this is problematic.

This CQ Include Name-Prefixing Servlet allows a "prefixing" node name to be provided during the cqinclude. This servlet is invoked by the addition of the selectors

```
cqinclude.namespace.<namespace>
```

The include for Title component dialog may look like
```
jcr:primaryType=cq:Widget
path=/apps/acme/components/title/dialog/items/tab.cqinclude.namespace.title.json
xtype=cqinclude
```

The include for Button component dialog may look like
```
jcr:primaryType=cq:Widget
path=/apps/acme/components/button/dialog/items/tab.cqinclude.namespace.button.json
xtype=cqinclude
```

The dialog would then read/save the jcr:title from the respective includes as follows

```
./title/./jcr:title
./button/./jcr:title
```

cleanly separating the two.