### PR TITLE
add support for QueryBuilder-map based queries in Query Packager

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/util/OsgiPropertyUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/OsgiPropertyUtil.java
@@ -88,6 +88,27 @@ public class OsgiPropertyUtil {
      */
     public static Map<String, String> toMap(final String[] values, final String separator,
                                             final boolean allowValuelessKeys, final String defaultValue) {
+        return toMap(values, separator, allowValuelessKeys, defaultValue, false);
+    }
+
+    /**
+     * Util for parsing Arrays of Service properties in the form &gt;value&lt;&gt;separator&lt;&gt;value&lt;
+     *
+     * If a value is missing from a key/value pair, the entry is rejected only if allowValuelessKyes is false.
+     * To keep the valueless keys pass in allowValuelessKeys => true
+     *
+     * *
+     * @param values Array of key/value pairs in the format => [ a<separator>b, x<separator>y ] ... ex. ["dog:woof", "cat:meow"]
+     * @param separator separator between the values
+     * @param allowValuelessKeys true is keys are allowed without associated values
+     * @param defaultValue default value to use if a value for a key is not present and allowValuelessKeys is true
+     * @param allowMultipleSeparators if true, multiple separators are allowed per entry in which case only the first is considered.
+     *                                If false, entries with multiple separators are considered invalid
+     * @return
+     */
+    public static Map<String, String> toMap(final String[] values, final String separator,
+                                            final boolean allowValuelessKeys, final String defaultValue,
+                                            final boolean allowMultipleSeparators) {
 
         final Map<String, String> map = new LinkedHashMap<String, String>();
 
@@ -96,7 +117,7 @@ public class OsgiPropertyUtil {
         }
 
         for (final String value : values) {
-            final String[] tmp = StringUtils.split(value, separator);
+            final String[] tmp = StringUtils.split(value, separator, allowMultipleSeparators ? 2 : -1);
 
             if(tmp.length == 1 && allowValuelessKeys) {
                 if(StringUtils.startsWith(value, separator)) {

--- a/bundle/src/main/java/com/adobe/acs/commons/util/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/package-info.java
@@ -20,7 +20,7 @@
 /**
  * Miscellaneous Utilities.
  */
-@Version("1.1.2")
+@Version("1.2.0")
 package com.adobe.acs.commons.util;
 
 import aQute.bnd.annotation.Version;

--- a/bundle/src/test/java/com/adobe/acs/commons/util/OsgiPropertyUtilTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/OsgiPropertyUtilTest.java
@@ -135,6 +135,19 @@ public class OsgiPropertyUtilTest {
     }
 
     @Test
+    public void testToMapWithMultipleSeparatorsAllowed() {
+        String[] values = {"key1:value1", "key2:val:ue2", "key3:value3"};
+        String separator = ":";
+        Map<String, String> expResult = new HashMap<String, String>();
+        expResult.put("key1", "value1");
+        expResult.put("key2", "val:ue2");
+        expResult.put("key3", "value3");
+
+        Map<String, String> result = OsgiPropertyUtil.toMap(values, separator, false, null, true);
+        assertEquals(expResult, result);
+    }
+
+    @Test
     public void testToMapWithOnlyKey1() {
         String[] values = {"key1:value1", "key2:", "key3:value3"};
         String separator = ":";

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/packager/query-packager/configuration/dialog.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/packager/query-packager/configuration/dialog.xml
@@ -124,6 +124,10 @@
                                 jcr:primaryType="nt:unstructured"
                                 text="JCR-SQL2"
                                 value="JCR-SQL2"/>
+                        <queryBuilder
+                                jcr:primaryType="nt:unstructured"
+                                text="QueryBuilder"
+                                value="queryBuilder"/>
                     </options>
                 </query-language>
                 <query


### PR DESCRIPTION
This is a fairly minor change which adds support to the Query Packager for QueryBuilder queries in key=value form. The key advantage of this is that QueryBuilder supports relative date range predicates (via http://docs.adobe.com/docs/en/cq/5-6-1/javadoc/com/day/cq/search/eval/RelativeDateRangePredicateEvaluator.html) something which if done just with XPath or SQL-2 would require constant updating of the query.