### PR TITLE
support the creation of generic lists in arbitrary locations

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/genericlists/impl/GenericListAdapterFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/genericlists/impl/GenericListAdapterFactory.java
@@ -29,7 +29,6 @@ import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.api.adapter.AdapterFactory;
 
 import com.adobe.acs.commons.genericlists.GenericList;
-import com.adobe.acs.commons.util.TemplateUtil;
 import com.day.cq.wcm.api.Page;
 
 @Component
@@ -52,8 +51,8 @@ public class GenericListAdapterFactory implements AdapterFactory {
             return null;
         }
         final Page page = (Page) obj;
-        if (TemplateUtil.hasTemplate(page, GenericListImpl.TMPL_GENERIC_LIST)
-                && page.getContentResource() != null
+        if (page.getContentResource() != null
+                && page.getContentResource().isResourceType(GenericListImpl.RT_GENERIC_LIST)
                 && page.getContentResource().getChild("list") != null) {
             return new GenericListImpl(page.getContentResource().getChild("list"));
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/genericlists/impl/GenericListImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/genericlists/impl/GenericListImpl.java
@@ -33,11 +33,10 @@ import org.apache.sling.api.resource.ValueMap;
 
 import com.adobe.acs.commons.genericlists.GenericList;
 import com.day.cq.wcm.api.NameConstants;
-import com.day.cq.wcm.commons.WCMUtils;
 
 public final class GenericListImpl implements GenericList {
 
-    static final String TMPL_GENERIC_LIST = "/apps/acs-commons/templates/utilities/genericlist";
+    static final String RT_GENERIC_LIST = "acs-commons/components/utilities/genericlist";
     static final String PN_VALUE = "value";
     static final String TITLE_PREFIX = NameConstants.PN_TITLE + ".";
 

--- a/bundle/src/test/java/com/adobe/acs/commons/genericlists/impl/GenericListAdapterFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/genericlists/impl/GenericListAdapterFactoryTest.java
@@ -65,18 +65,8 @@ public class GenericListAdapterFactoryTest {
 
     @Before
     public void setup() {
-        when(listPage.getProperties()).thenAnswer(new Answer<ValueMap>() {
-            @SuppressWarnings("serial")
-            public ValueMap answer(InvocationOnMock invocation) throws Throwable {
-                return new ValueMapDecorator(new HashMap<String, Object>() {
-                    {
-                        put(NameConstants.NN_TEMPLATE, GenericListImpl.TMPL_GENERIC_LIST);
-
-                    }
-                });
-            }
-        });
         when(listPage.getContentResource()).thenReturn(contentResource);
+        when(contentResource.isResourceType(GenericListImpl.RT_GENERIC_LIST)).thenReturn(true);
         when(contentResource.getChild("list")).thenReturn(listResource);
         when(listResource.listChildren()).thenReturn(Arrays.asList(resourceOne, resourceTwo).iterator());
 
@@ -111,7 +101,7 @@ public class GenericListAdapterFactoryTest {
     }
 
     @Test
-    public void test_that_adapting_page_with_correct_template_returns_directly() {
+    public void test_that_adapting_page_with_correct_resourceType_returns_directly() {
         GenericList list = adapterFactory.getAdapter(listPage, GenericList.class);
         assertNotNull(list);
         List<Item> items = list.getItems();
@@ -122,20 +112,12 @@ public class GenericListAdapterFactoryTest {
     }
 
     @Test
-    public void test_that_adapting_page_with_wrong_template_returns_null() {
+    public void test_that_adapting_page_with_wrong_resourceType_returns_null() {
         Page wrongPage = mock(Page.class);
+        Resource wrongContentResource = mock(Resource.class);
 
-        when(wrongPage.getProperties()).thenAnswer(new Answer<ValueMap>() {
-            @SuppressWarnings("serial")
-            public ValueMap answer(InvocationOnMock invocation) throws Throwable {
-                return new ValueMapDecorator(new HashMap<String, Object>() {
-                    {
-                        put(NameConstants.NN_TEMPLATE, "/wrong");
-
-                    }
-                });
-            }
-        });
+        when(wrongPage.getContentResource()).thenReturn(wrongContentResource);
+        when(wrongContentResource.isResourceType(GenericListImpl.RT_GENERIC_LIST)).thenReturn(false);
 
         GenericList section = adaptToGenericList(wrongPage);
         assertNull(section);

--- a/bundle/src/test/java/com/adobe/acs/commons/genericlists/impl/GenericListJsonResourceProviderTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/genericlists/impl/GenericListJsonResourceProviderTest.java
@@ -22,6 +22,8 @@ package com.adobe.acs.commons.genericlists.impl;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
+import java.util.Collections;
+
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.junit.Before;
@@ -56,16 +58,17 @@ public class GenericListJsonResourceProviderTest {
 
     private String goodMntPath = GenericListJsonResourceProvider.ROOT + "/good";
 
-    private String goodPagePath = GenericListJsonResourceProvider.LIST_ROOT + "/good";
+    private String goodPagePath = GenericListJsonResourceProvider.DEFAULT_LIST_ROOT + "/good";
 
     private String badMntPath = GenericListJsonResourceProvider.ROOT + "/bad";
 
-    private String badPagePath = GenericListJsonResourceProvider.LIST_ROOT + "/bad";
+    private String badPagePath = GenericListJsonResourceProvider.DEFAULT_LIST_ROOT + "/bad";
 
     private String nonExisting = GenericListJsonResourceProvider.ROOT + "/non-existing";
 
     @Before
     public void setup() {
+        provider.activate(Collections.<String, String>emptyMap());
         when(resourceResolver.adaptTo(PageManager.class)).thenReturn(pageManager);
         when(pageManager.getPage(goodPagePath)).thenReturn(validPage);
         when(pageManager.getPage(badPagePath)).thenReturn(invalidPage);


### PR DESCRIPTION
In order to do this, the test in the adapter factory needs to be based on the resource type, not the template. In addition, the JsonResourceProvider needs to be configurable for the root path. Note that this still would only support a single root path for lists per deployment.