### PR TITLE
Using path placeholder like $PATH in multifieldpanel doesnt work

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
@@ -64,6 +64,19 @@ ACS.CQ.MultiFieldPanel = CQ.Ext.extend(CQ.Ext.Panel, {
         },this);
     },
 
+    afterRender : function(){
+        ACS.CQ.MultiFieldPanel.superclass.afterRender.call(this);
+
+        this.items.each(function(){
+            if(!this.contentBasedOptionsURL
+                || this.contentBasedOptionsURL.indexOf(CQ.form.Selection.PATH_PLACEHOLDER) < 0){
+                return;
+            }
+
+            this.processPath(this.findParentByType('dialog').path);
+        });
+    },
+
     getValue: function() {
         var pData = {};
 


### PR DESCRIPTION
@justinedelson Using CQ.form.Selection.PATH_PLACEHOLDER like $PATH/countries.options.json, doesn't load options of a selection drop down in multifieldpanel

a blog visitor reported this bug
