### PR TITLE
Reverting fix for #416 (double quotes issue in RTE?) to fix #469 (escaped quotes in multifield breaking everything)

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
@@ -84,13 +84,7 @@ ACS.CQ.MultiFieldPanel = CQ.Ext.extend(CQ.Ext.Panel, {
             if(i.xtype === "label" || i.xtype === "hidden" || !i.hasOwnProperty("key")){
                 return;
             }
-            var predata = i.getValue();
-            if(predata && (typeof predata === "string"
-                    || (typeof predata === "object" && predata.constructor === String))) {
-                pData[i.key] = predata.replace(/"/g, '&quot;'); 
-            } else {
-                pData[i.key] = predata;
-            }
+            pData[i.key] = i.getValue();
         });
 
         return $.isEmptyObject(pData) ? "" : JSON.stringify(pData);


### PR DESCRIPTION
This PR is essentially a rollback of #416 since that change seems to be causing all sorts of issues with the multifield component whereby double quotes " are universally escaped to &quot;

This  seems like an odd thing to do since JSON.stringify performs all the escaping necessary to store the values in JSON, and escaping to &quot; seems to assume some kind of XML/HTML representation - which JSON clearly is not.

I can't figure out what this change was trying to achieve since the original defect doesn't have any real detail about the issue or steps to reproduce it. I've tried reproducing it myself but can't find any issue with text or RTE fields in the multifield failing when quotes are present.

My best guess is that the output of the multifield was being used in a context where the quotes were invalid or breaking out of some kind of outer quoting. If that is the case then that's a downstream implementation problem (i.e the escaping should be done at render time for that use case) and not a decision that ought to be enforced globally in the component.

If anyone has further information about the original issue they can share which is relevant please do, otherwise I'd urge this PR to be merged in since the multifield is quite badly broken at present (HTML attributes become invalid in the RTE, quotes get double-escaped in Sightly, etc).