### PR TITLE
Create a dialog conversion rule for handling multifield panel. fixes …

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -51,6 +51,7 @@
                         <Bundle-SymbolicName>com.adobe.acs.acs-aem-commons-bundle</Bundle-SymbolicName>
                         <Import-Package>
                             org.scribe*;version="[1.3.0,2)",
+                            com.adobe.cq.dialogconversion;resolution:=optional,
                             *
                         </Import-Package>
                     </instructions>
@@ -188,6 +189,12 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>1.0.13</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.cq</groupId>
+            <artifactId>cq-dialog-conversion</artifactId>
+            <version>1.0.2</version>
             <scope>provided</scope>
         </dependency>
         <!-- Test Dependencies -->

--- a/bundle/src/main/java/com/adobe/acs/commons/util/impl/MultifieldPanelDialogRewriteRule.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/impl/MultifieldPanelDialogRewriteRule.java
@@ -1,0 +1,89 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.util.impl;
+
+import java.util.Set;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.jackrabbit.JcrConstants;
+
+import com.adobe.cq.dialogconversion.AbstractDialogRewriteRule;
+import com.adobe.cq.dialogconversion.DialogRewriteException;
+import com.adobe.cq.dialogconversion.DialogRewriteUtils;
+
+/**
+ * DialogRewriteRule which handles rewriting of the 'multifieldpanel' xtype.
+ */
+@Component
+@Service
+public final class MultifieldPanelDialogRewriteRule extends AbstractDialogRewriteRule {
+
+    private static final String PN_NAME = "name";
+    private static final String PN_SLING_RESOURCE_TYPE = "sling:resourceType";
+    private static final String NN_ITEMS = "items";
+    private static final String XTYPE = "multifieldpanel";
+
+    @Override
+    public Node applyTo(final Node root, final Set<Node> finalNodes) throws DialogRewriteException, RepositoryException {
+        final Node parent = root.getParent();
+        final String name = root.getName();
+        DialogRewriteUtils.rename(root);
+
+        // add node for multifield
+        final Node newRoot = parent.addNode(name, JcrConstants.NT_UNSTRUCTURED);
+        finalNodes.add(newRoot);
+        DialogRewriteUtils.copyProperty(root, PN_NAME, newRoot, PN_NAME);
+
+        newRoot.setProperty(PN_SLING_RESOURCE_TYPE, "granite/ui/components/foundation/form/fieldset");
+        newRoot.setProperty("acs-commons-nested", "");
+
+        final Node layout = newRoot.addNode("layout", JcrConstants.NT_UNSTRUCTURED);
+        layout.setProperty(PN_SLING_RESOURCE_TYPE, "granite/ui/components/foundation/layouts/fixedcolumns");
+        layout.setProperty("method", "absolute");
+
+        final Node rootItems = newRoot.addNode(NN_ITEMS, JcrConstants.NT_UNSTRUCTURED);
+        final Node container = rootItems.addNode("column", JcrConstants.NT_UNSTRUCTURED);
+        container.setProperty(PN_SLING_RESOURCE_TYPE, "granite/ui/components/foundation/container");
+
+        final Node columnItems = container.addNode(NN_ITEMS, JcrConstants.NT_UNSTRUCTURED);
+
+        if (root.hasNode(NN_ITEMS)) {
+            for (final NodeIterator children = root.getNode(NN_ITEMS).getNodes(); children.hasNext();) {
+                final Node child = children.nextNode();
+                root.getSession().move(child.getPath(), columnItems.getPath() + "/" + child.getName());
+            }
+        }
+
+        finalNodes.add(newRoot);
+        root.remove();
+        return newRoot;
+    }
+
+    @Override
+    public boolean matches(final Node root) throws RepositoryException {
+        return DialogRewriteUtils.hasXtype(root, XTYPE);
+    }
+
+}

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/content/definition-list/_cq_dialog/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/content/definition-list/_cq_dialog/.content.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Definition List"
+    sling:resourceType="cq/gui/components/authoring/dialog">
+    <content
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/foundation/container">
+        <layout
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"/>
+        <items jcr:primaryType="nt:unstructured">
+            <columns
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/foundation/container">
+                <items jcr:primaryType="nt:unstructured">
+                    <definitions
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/foundation/form/multifield"
+                        fieldLabel="Definitions">
+                        <field
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="granite/ui/components/foundation/form/fieldset"
+                            acs-commons-nested=""
+                            name="./definitions">
+                            <layout
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"
+                                method="absolute"/>
+                            <items jcr:primaryType="nt:unstructured">
+                                <column
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/foundation/container">
+                                    <items jcr:primaryType="nt:unstructured">
+                                        <term
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/foundation/form/textfield"
+                                            name="./term"
+                                            fieldLabel="Term"/>
+                                        <definition
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/foundation/form/textarea"
+                                            name="./definition"
+                                            fieldLabel="Definition"/>
+                                    </items>
+                                </column>
+                            </items>
+                        </field>
+                    </definitions>
+                    <typehint
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/foundation/form/hidden"
+                        name="./definitions@TypeHint"
+                        value="String[]"/>
+                </items>
+            </columns>
+        </items>
+    </content>
+</jcr:root>


### PR DESCRIPTION
…#475. also includes a converted dialog for the definition list component.

Caveat - after conversion, the name properties need to be manually set to the value of the key property on the old widgets.