### PR TITLE
Ajax Base Component - Query Parameter pass-through support

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/components/content/base/ajax/ajax.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/content/base/ajax/ajax.jsp
@@ -36,6 +36,8 @@
     final String CN_AJAX_SELECTOR = "ajaxSelectors";
     final String CN_AJAX_EXTENSION = "ajaxExtension";
     final String CN_AJAX_LOADING_INDICATOR = "ajaxLoadingIndicator";
+    final String CN_AJAX_PASS_QUERY_PARAMS = "ajaxPassQueryParameters";
+
 
     final WCMMode mode = WCMMode.fromRequest(slingRequest);
     final ValueMap componentProperties = component.getProperties();
@@ -43,6 +45,10 @@
     String ajaxLoadingIndicator =
             xssAPI.encodeForHTMLAttr(StringUtils.stripToEmpty(componentProperties.get(CN_AJAX_LOADING_INDICATOR, "")));
     boolean ajaxLoadingIndicatorEnabled = StringUtils.isNotBlank(ajaxLoadingIndicator);
+
+    String queryParams = StringUtils.stripToNull(slingRequest.getQueryString());
+    boolean passQueryParams = componentProperties.get(CN_AJAX_PASS_QUERY_PARAMS, false)
+            &&  StringUtils.isNotBlank(queryParams);
 
     String ajaxSelectors = StringUtils.stripToEmpty(componentProperties.get(CN_AJAX_SELECTOR, DEFAULT_SELECTOR));
     String ajaxExtension = StringUtils.stripToEmpty(componentProperties.get(CN_AJAX_EXTENSION, DEFAULT_EXTENSION));
@@ -52,7 +58,9 @@
     final String url = resourceResolver.map(slingRequest, resource.getPath()) + "." + ajaxSelectors + "." + ajaxExtension;
 
 %><% if(WCMMode.PREVIEW.equals(mode) || WCMMode.DISABLED.equals(mode)) { %>
-    <div data-ajax-component data-url="<%= url %>" class="acs-ajax-component">
+    <div data-ajax-component data-url="<%= url %>"
+         <%= passQueryParams ? "data-ajax-query-parameters=\"" + xssAPI.encodeForHTMLAttr(queryParams) + "\"" : "" %>
+         class="acs-ajax-component">
     	<% if (ajaxLoadingIndicatorEnabled) { %>
     		<div class="<%= ajaxLoadingIndicator %>"></div>
     	<% } %>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/content/base/ajax/clientlibs/js/ajax.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/content/base/ajax/clientlibs/js/ajax.js
@@ -20,9 +20,15 @@
 ;$(function() {
     $('[data-ajax-component]').each(function() {
         var $this = $(this),
-            url = $this.data('url');
+            url = $this.data('url'),
+            queryParams = $this.data('ajax-query-parameters');
 
         url += "?t=" + (new Date()).getTime();
+
+        if (queryParams) {
+            url += "&" + decodeURI(queryParams);
+        }
+
         $.get(url).success(function(data) {
             if(!data.match(/\sdata-ajax-component/)) {
                 $this.replaceWith(data);

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/content/base/ajax/clientlibs/js/ajax.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/content/base/ajax/clientlibs/js/ajax.js
@@ -26,7 +26,7 @@
         url += "?t=" + (new Date()).getTime();
 
         if (queryParams) {
-            url += "&" + decodeURI(queryParams);
+            url += "&" + queryParams;
         }
 
         $.get(url).success(function(data) {


### PR DESCRIPTION
JS-centric version of #479 

Setting  `[cq:Component]@ajaxPassQueryParameters = true` on the Ajax'ified component will persist the QPs from the page request into a data-* attribute, which the AJAX GET will pick up and apply to the XHR call to AJAX in the component.

@B-Johnson @ice1138 ... WDYT?  Can you double check the encoding in the JSP and the decoding the JS .. think it's right; encodings sometimes confuse me though.

Thanks!

![2015-07-26 at 10 00 pm](https://cloud.githubusercontent.com/assets/1451868/8897357/e146804c-33e1-11e5-836d-5b8149bdc66e.png)

