### PR TITLE
Renaming of OsgiPropertyUtil to ParameterUtil

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/images/impl/NamedImageTransformerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/images/impl/NamedImageTransformerImpl.java
@@ -22,7 +22,7 @@ package com.adobe.acs.commons.images.impl;
 
 import com.adobe.acs.commons.images.ImageTransformer;
 import com.adobe.acs.commons.images.NamedImageTransformer;
-import com.adobe.acs.commons.util.OsgiPropertyUtil;
+import com.adobe.acs.commons.util.ParameterUtil;
 import com.adobe.acs.commons.util.TypeUtil;
 import com.adobe.acs.commons.wcm.ComponentHelper;
 import com.day.image.Layer;
@@ -124,13 +124,13 @@ public class NamedImageTransformerImpl implements NamedImageTransformer {
 
         log.info("Registering Named Image Transformer: {}", this.transformName);
 
-        final Map<String, String> map = OsgiPropertyUtil.toMap(PropertiesUtil.toStringArray(
+        final Map<String, String> map = ParameterUtil.toMap(PropertiesUtil.toStringArray(
                 properties.get(PROP_TRANSFORMS), new String[]{}), ":", true, null);
 
 
         for (final Map.Entry<String, String> entry : map.entrySet()) {
             final String[] params = StringUtils.split(entry.getValue(), "&");
-            final Map<String, String> values = OsgiPropertyUtil.toMap(params, "=", true, null);
+            final Map<String, String> values = ParameterUtil.toMap(params, "=", true, null);
 
             log.debug("ImageTransform params for [ {} ] ~> {}", entry.getKey(), values);
 

--- a/bundle/src/main/java/com/adobe/acs/commons/json/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/json/package-info.java
@@ -20,5 +20,5 @@
 /**
  * JSON Utilities
  */
-@aQute.bnd.annotation.Version("1.10.2")
+@aQute.bnd.annotation.Version("1.10.4")
 package com.adobe.acs.commons.json;

--- a/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/QueryPackagerServletImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/QueryPackagerServletImpl.java
@@ -21,7 +21,7 @@
 package com.adobe.acs.commons.packaging.impl;
 
 import com.adobe.acs.commons.packaging.PackageHelper;
-import com.adobe.acs.commons.util.OsgiPropertyUtil;
+import com.adobe.acs.commons.util.ParameterUtil;
 import com.day.cq.search.PredicateGroup;
 import com.day.cq.search.QueryBuilder;
 import com.day.cq.search.result.Hit;
@@ -203,7 +203,7 @@ public class QueryPackagerServletImpl extends SlingAllMethodsServlet {
 
         if (language.equals(QUERY_BUILDER)) {
             final String[] lines = StringUtils.split(statement, '\n');
-            final Map<String, String> params = OsgiPropertyUtil.toMap(lines, "=", false, null, true);
+            final Map<String, String> params = ParameterUtil.toMap(lines, "=", false, null, true);
 
             // ensure all results are returned
             params.put("p.limit", "-1");

--- a/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlushRulesImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlushRulesImpl.java
@@ -23,7 +23,7 @@ package com.adobe.acs.commons.replication.dispatcher.impl;
 import com.adobe.acs.commons.replication.dispatcher.DispatcherFlushFilter;
 import com.adobe.acs.commons.replication.dispatcher.DispatcherFlusher;
 import com.adobe.acs.commons.replication.dispatcher.DispatcherFlushFilter.FlushType;
-import com.adobe.acs.commons.util.OsgiPropertyUtil;
+import com.adobe.acs.commons.util.ParameterUtil;
 import com.day.cq.replication.AgentManager;
 import com.day.cq.replication.Preprocessor;
 import com.day.cq.replication.ReplicationAction;
@@ -239,14 +239,14 @@ public class DispatcherFlushRulesImpl implements Preprocessor {
                         DEFAULT_REPLICATION_ACTION_TYPE_NAME));
 
         /* Flush Rules */
-        this.hierarchicalFlushRules = this.configureFlushRules(OsgiPropertyUtil.toMap(
+        this.hierarchicalFlushRules = this.configureFlushRules(ParameterUtil.toMap(
                 PropertiesUtil.toStringArray(properties.get(PROP_FLUSH_RULES),
                         DEFAULT_HIERARCHICAL_FLUSH_RULES), "="));
 
         log.debug("Hierarchical flush rules: " + this.hierarchicalFlushRules);
 
         /* ResourceOnly Flush Rules */
-        this.resourceOnlyFlushRules = this.configureFlushRules(OsgiPropertyUtil.toMap(
+        this.resourceOnlyFlushRules = this.configureFlushRules(ParameterUtil.toMap(
                 PropertiesUtil.toStringArray(properties.get(PROP_RESOURCE_ONLY_FLUSH_RULES),
                         DEFAULT_RESOURCE_ONLY_FLUSH_RULES), "="));
 

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/StaticReferenceRewriteTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/StaticReferenceRewriteTransformerFactory.java
@@ -38,7 +38,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
 
 import com.adobe.acs.commons.rewriter.AbstractTransformer;
-import com.adobe.acs.commons.util.OsgiPropertyUtil;
+import com.adobe.acs.commons.util.ParameterUtil;
 
 /**
  * Rewriter pipeline component which rewrites static references.
@@ -175,7 +175,7 @@ public final class StaticReferenceRewriteTransformerFactory implements Transform
 
         final String[] attrProp = PropertiesUtil
                 .toStringArray(properties.get(PROP_ATTRIBUTES), DEFAULT_ATTRIBUTES);
-        this.attributes = OsgiPropertyUtil.toMap(attrProp, ":", ",");
+        this.attributes = ParameterUtil.toMap(attrProp, ":", ",");
 
         this.prefixes = PropertiesUtil.toStringArray(properties.get(PROP_PREFIXES), new String[0]);
         this.staticHostPattern = PropertiesUtil.toString(properties.get(PROP_HOST_NAME_PATTERN), null);

--- a/bundle/src/main/java/com/adobe/acs/commons/util/ParameterUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/ParameterUtil.java
@@ -2,14 +2,14 @@
  * #%L
  * ACS AEM Commons Bundle
  * %%
- * Copyright (C) 2015 Adobe
+ * Copyright (C) 2013 Adobe
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,22 +19,22 @@
  */
 package com.adobe.acs.commons.util;
 
-import aQute.bnd.annotation.ProviderType;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import aQute.bnd.annotation.ProviderType;
 
 import java.util.AbstractMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-@Deprecated
 @ProviderType
-public class OsgiPropertyUtil {
+public class ParameterUtil {
     @SuppressWarnings("unused")
-    private static final Logger log = LoggerFactory.getLogger(OsgiPropertyUtil.class);
+    private static final Logger log = LoggerFactory.getLogger(ParameterUtil.class);
 
-    private OsgiPropertyUtil() {
+    private ParameterUtil() {
 
     }
 
@@ -45,9 +45,18 @@ public class OsgiPropertyUtil {
      * @param separator separator between the values
      * @return Returns a SimpleEntry representing the key/value pair
      */
-    @Deprecated
     public static AbstractMap.SimpleEntry<String, String> toSimpleEntry(final String value, final String separator) {
-        return ParameterUtil.toSimpleEntry(value, separator);
+        final String[] tmp = StringUtils.split(value, separator);
+
+        if (tmp == null) {
+            return null;
+        }
+
+        if (tmp.length == 2) {
+            return new AbstractMap.SimpleEntry<String, String>(tmp[0], tmp[1]);
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -60,9 +69,8 @@ public class OsgiPropertyUtil {
      * @param separator separator between the values
      * @return Map of key/value pairs; map.get("dog") => "woof", map.get("cat") => "meow"
      */
-    @Deprecated
     public static Map<String, String> toMap(final String[] values, final String separator) {
-        return ParameterUtil.toMap(values, separator, false, null);
+        return toMap(values, separator, false, null);
     }
 
     /**
@@ -78,10 +86,9 @@ public class OsgiPropertyUtil {
      * @param defaultValue default value to use if a value for a key is not present and allowValuelessKeys is true
      * @return
      */
-    @Deprecated
     public static Map<String, String> toMap(final String[] values, final String separator,
                                             final boolean allowValuelessKeys, final String defaultValue) {
-        return ParameterUtil.toMap(values, separator, allowValuelessKeys, defaultValue, false);
+        return toMap(values, separator, allowValuelessKeys, defaultValue, false);
     }
 
     /**
@@ -99,14 +106,32 @@ public class OsgiPropertyUtil {
      *                                If false, entries with multiple separators are considered invalid
      * @return
      */
-    @Deprecated
-    public static Map<String, String> toMap(final String[] values, 
-                                            final String separator,
-                                            final boolean allowValuelessKeys, 
-                                            final String defaultValue,
+    public static Map<String, String> toMap(final String[] values, final String separator,
+                                            final boolean allowValuelessKeys, final String defaultValue,
                                             final boolean allowMultipleSeparators) {
 
-       return ParameterUtil.toMap(values, separator, allowValuelessKeys, defaultValue, allowMultipleSeparators);
+        final Map<String, String> map = new LinkedHashMap<String, String>();
+
+        if (values == null || values.length < 1) {
+            return map;
+        }
+
+        for (final String value : values) {
+            final String[] tmp = StringUtils.split(value, separator, allowMultipleSeparators ? 2 : -1);
+
+            if(tmp.length == 1 && allowValuelessKeys) {
+                if(StringUtils.startsWith(value, separator)) {
+                    // Skip keyless values
+                    continue;
+                }
+
+                map.put(tmp[0], defaultValue);
+            } else if (tmp.length == 2) {
+                map.put(tmp[0], tmp[1]);
+            }
+        }
+
+        return map;
     }
 
     /**
@@ -117,10 +142,12 @@ public class OsgiPropertyUtil {
      * @param listSeparator separator between the values in each list
      * @return Map of key/value pairs; map.get("dog") => "woof", map.get("cat") => "meow"
      */
-    @Deprecated
-    public static Map<String, String[]> toMap(final String[] values, 
-                                              final String mapSeparator, 
-                                              final String listSeparator) {
-        return ParameterUtil.toMap(values, mapSeparator, listSeparator);
+    public static Map<String, String[]> toMap(final String[] values, final String mapSeparator, final String listSeparator) {
+        final Map<String, String> map = toMap(values, mapSeparator);
+        final Map<String, String[]> result = new LinkedHashMap<String, String[]>(map.size());
+        for (final Map.Entry<String, String> entry : map.entrySet()) {
+            result.put(entry.getKey(), StringUtils.split(entry.getValue(), listSeparator));
+        }
+        return result;
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/util/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/package-info.java
@@ -20,7 +20,7 @@
 /**
  * Miscellaneous Utilities.
  */
-@Version("2.0.0")
+@Version("2.1.0")
 package com.adobe.acs.commons.util;
 
 import aQute.bnd.annotation.Version;

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/views/impl/WCMViewsServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/views/impl/WCMViewsServlet.java
@@ -20,7 +20,7 @@
 
 package com.adobe.acs.commons.wcm.views.impl;
 
-import com.adobe.acs.commons.util.OsgiPropertyUtil;
+import com.adobe.acs.commons.util.ParameterUtil;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
 import com.day.cq.wcm.api.WCMMode;
@@ -154,6 +154,6 @@ public class WCMViewsServlet extends SlingSafeMethodsServlet {
     @Activate
     protected final void activate(final Map<String, String> config) {
         final String[] tmp = PropertiesUtil.toStringArray(config.get(PROP_DEFAULT_VIEWS), DEFAULT_VIEWS);
-        this.defaultViews = OsgiPropertyUtil.toMap(tmp, "=", ";");
+        this.defaultViews = ParameterUtil.toMap(tmp, "=", ";");
     }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/util/ParameterUtilTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/ParameterUtilTest.java
@@ -27,9 +27,9 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
-public class OsgiPropertyUtilTest {
+public class ParameterUtilTest {
 
-    public OsgiPropertyUtilTest() {
+    public ParameterUtilTest() {
     }
 
     @BeforeClass
@@ -56,7 +56,7 @@ public class OsgiPropertyUtilTest {
         String value = "key:value";
         String separator = ":";
         SimpleEntry<String, String> expResult = new SimpleEntry<String, String>("key", "value");
-        SimpleEntry<String, String> result = OsgiPropertyUtil.toSimpleEntry(value, separator);
+        SimpleEntry<String, String> result = ParameterUtil.toSimpleEntry(value, separator);
         assertEquals(expResult, result);
     }
 
@@ -65,7 +65,7 @@ public class OsgiPropertyUtilTest {
         String value = "key:";
         String separator = ":";
         SimpleEntry<String, String> expResult = null;
-        SimpleEntry<String, String> result = OsgiPropertyUtil.toSimpleEntry(value, separator);
+        SimpleEntry<String, String> result = ParameterUtil.toSimpleEntry(value, separator);
         assertEquals(expResult, result);
     }
 
@@ -74,7 +74,7 @@ public class OsgiPropertyUtilTest {
         String value = "key";
         String separator = ":";
         SimpleEntry<String, String> expResult = null;
-        SimpleEntry<String, String> result = OsgiPropertyUtil.toSimpleEntry(value, separator);
+        SimpleEntry<String, String> result = ParameterUtil.toSimpleEntry(value, separator);
         assertEquals(expResult, result);
     }
 
@@ -83,7 +83,7 @@ public class OsgiPropertyUtilTest {
         String value = ":value";
         String separator = ":";
         SimpleEntry<String, String> expResult = null;
-        SimpleEntry<String, String> result = OsgiPropertyUtil.toSimpleEntry(value, separator);
+        SimpleEntry<String, String> result = ParameterUtil.toSimpleEntry(value, separator);
         assertEquals(expResult, result);
     }
 
@@ -92,7 +92,7 @@ public class OsgiPropertyUtilTest {
         String value = "key:val:ue";
         String separator = ":";
         SimpleEntry<String, String> expResult = null;
-        SimpleEntry<String, String> result = OsgiPropertyUtil.toSimpleEntry(value, separator);
+        SimpleEntry<String, String> result = ParameterUtil.toSimpleEntry(value, separator);
         assertEquals(expResult, result);
     }
 
@@ -101,7 +101,7 @@ public class OsgiPropertyUtilTest {
         String value = "key:value";
         String separator = "-";
         SimpleEntry<String, String> expResult = null;
-        SimpleEntry<String, String> result = OsgiPropertyUtil.toSimpleEntry(value, separator);
+        SimpleEntry<String, String> result = ParameterUtil.toSimpleEntry(value, separator);
         assertEquals(expResult, result);
     }
 
@@ -118,7 +118,7 @@ public class OsgiPropertyUtilTest {
         expResult.put("key2", "value2");
         expResult.put("key3", "value3");
 
-        Map<String, String> result = OsgiPropertyUtil.toMap(values, separator);
+        Map<String, String> result = ParameterUtil.toMap(values, separator);
         assertEquals(expResult, result);
     }
 
@@ -130,7 +130,7 @@ public class OsgiPropertyUtilTest {
         expResult.put("key1", "value1");
         expResult.put("key3", "value3");
 
-        Map<String, String> result = OsgiPropertyUtil.toMap(values, separator);
+        Map<String, String> result = ParameterUtil.toMap(values, separator);
         assertEquals(expResult, result);
     }
 
@@ -143,7 +143,7 @@ public class OsgiPropertyUtilTest {
         expResult.put("key2", "val:ue2");
         expResult.put("key3", "value3");
 
-        Map<String, String> result = OsgiPropertyUtil.toMap(values, separator, false, null, true);
+        Map<String, String> result = ParameterUtil.toMap(values, separator, false, null, true);
         assertEquals(expResult, result);
     }
 
@@ -155,7 +155,7 @@ public class OsgiPropertyUtilTest {
         expResult.put("key1", "value1");
         expResult.put("key3", "value3");
 
-        Map<String, String> result = OsgiPropertyUtil.toMap(values, separator);
+        Map<String, String> result = ParameterUtil.toMap(values, separator);
         assertEquals(expResult, result);
     }
 
@@ -167,7 +167,7 @@ public class OsgiPropertyUtilTest {
         expResult.put("key1", "value1");
         expResult.put("key3", "value3");
 
-        Map<String, String> result = OsgiPropertyUtil.toMap(values, separator);
+        Map<String, String> result = ParameterUtil.toMap(values, separator);
         assertEquals(expResult, result);
     }
 
@@ -179,7 +179,7 @@ public class OsgiPropertyUtilTest {
         expResult.put("key1", "value1");
         expResult.put("key3", "value3");
 
-        Map<String, String> result = OsgiPropertyUtil.toMap(values, separator);
+        Map<String, String> result = ParameterUtil.toMap(values, separator);
         assertEquals(expResult, result);
     }
 
@@ -191,7 +191,7 @@ public class OsgiPropertyUtilTest {
         expResult.put("key1", "value1");
         expResult.put("key3", "value3");
 
-        Map<String, String> result = OsgiPropertyUtil.toMap(values, separator);
+        Map<String, String> result = ParameterUtil.toMap(values, separator);
         assertEquals(expResult, result);
     }
 
@@ -207,7 +207,7 @@ public class OsgiPropertyUtilTest {
         expResult.put("key2", "value2");
         expResult.put("key3", "value3");
 
-        Map<String, String> result = OsgiPropertyUtil.toMap(values, separator, true, "testing-default");
+        Map<String, String> result = ParameterUtil.toMap(values, separator, true, "testing-default");
         assertEquals(expResult, result);
     }
 
@@ -221,7 +221,7 @@ public class OsgiPropertyUtilTest {
         expResult.put("key2", "testing-default");
         expResult.put("key3", "value3");
 
-        Map<String, String> result = OsgiPropertyUtil.toMap(values, separator, true, "testing-default");
+        Map<String, String> result = ParameterUtil.toMap(values, separator, true, "testing-default");
         assertEquals(expResult, result);
     }
 
@@ -234,7 +234,7 @@ public class OsgiPropertyUtilTest {
         expResult.put("key2", "testing-default");
         expResult.put("key3", "value3");
 
-        Map<String, String> result = OsgiPropertyUtil.toMap(values, separator, true, "testing-default");
+        Map<String, String> result = ParameterUtil.toMap(values, separator, true, "testing-default");
         assertEquals(expResult, result);
     }
 
@@ -246,7 +246,7 @@ public class OsgiPropertyUtilTest {
         expResult.put("key1", "value1");
         expResult.put("key3", "value3");
 
-        Map<String, String> result = OsgiPropertyUtil.toMap(values, separator, true, "testing-default");
+        Map<String, String> result = ParameterUtil.toMap(values, separator, true, "testing-default");
         assertEquals(expResult, result);
     }
 }


### PR DESCRIPTION
Addresses #501

@justinedelson wdyt?

OsgiPropertyUtil can remain as deprecated.

The naming of OsgiPropertyUtil really bothers me since we use it for other purposes now ... Any support in ACS Tools can be changed after ACS Commons 2.0.0 


