### PR TITLE
Feature/synthetic wf model support

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/SyntheticWorkflowModel.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/SyntheticWorkflowModel.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.workflow.synthetic;
 
 import java.util.Map;

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/SyntheticWorkflowModel.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/SyntheticWorkflowModel.java
@@ -8,7 +8,7 @@ public interface SyntheticWorkflowModel {
      *
      * @return
      */
-    String[] getWorkflowModelNames();
+    String[] getWorkflowProcessNames();
 
     /**
      *

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/SyntheticWorkflowModel.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/SyntheticWorkflowModel.java
@@ -1,0 +1,18 @@
+package com.adobe.acs.commons.workflow.synthetic;
+
+import java.util.Map;
+
+public interface SyntheticWorkflowModel {
+
+    /**
+     *
+     * @return
+     */
+    String[] getWorkflowModelNames();
+
+    /**
+     *
+     * @return
+     */
+    Map<String, Map<String, Object>> getSyntheticWorkflowModelData();
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/SyntheticWorkflowRunner.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/SyntheticWorkflowRunner.java
@@ -20,7 +20,6 @@
 
 package com.adobe.acs.commons.workflow.synthetic;
 
-import com.adobe.acs.commons.workflow.synthetic.impl.SyntheticWorkflowModelImpl;
 import com.day.cq.workflow.WorkflowException;
 import com.day.cq.workflow.WorkflowService;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -28,52 +27,99 @@ import org.apache.sling.api.resource.ResourceResolver;
 import java.util.Map;
 
 public interface SyntheticWorkflowRunner extends WorkflowService {
+    enum WorkflowProcessIdType {
+        PROCESS_LABEL,
+        PROCESS_NAME
+    }
+
     String PROCESS_ARGS = "PROCESS_ARGS";
 
     /**
      * Process a payload path using using the provided Workflow Processes.
      *
-     * @param resourceResolver the resourceResolver object that provides access to the JCR for WF operations
-     * @param payloadPath the path to execute the workflow against
-     * @param workflowProcessLabels the process.labels of the workflow to execute in order against the payloadPath
-     *                              resource
-     * @param processArgs the WF args metadata maps; each workflowProcessLabel can have one map
+     * @param resourceResolver                 the resourceResolver object that provides access to the JCR for WF operations
+     * @param payloadPath                      the path to execute the workflow against
+     * @param workflowProcessIdType            defines is the worlflow ProcessIds are process.labels or process class names
+     * @param workflowProcessIds               the process.labels or process names of the workflow to execute in order against the payloadPath
+     *                                         resource
+     * @param processArgs                      the WF args metadata maps; each workflowProcessLabel can have one map
      * @param autoSaveAfterEachWorkflowProcess persist changes to JCR after each Workflow Process completes
-     * @param autoSaveAtEnd persist changes to JCR after all Workflow Process complete
-     *
+     * @param autoSaveAtEnd                    persist changes to JCR after all Workflow Process complete
      * @throws com.day.cq.workflow.WorkflowException
      */
     void execute(ResourceResolver resourceResolver,
-               String payloadPath,
-               String[] workflowProcessLabels,
-               Map<String, Map<String, Object>> processArgs,
-               boolean autoSaveAfterEachWorkflowProcess,
-               boolean autoSaveAtEnd) throws WorkflowException;
-
+                 String payloadPath,
+                 WorkflowProcessIdType workflowProcessIdType,
+                 String[] workflowProcessIds,
+                 Map<String, Map<String, Object>> processArgs,
+                 boolean autoSaveAfterEachWorkflowProcess,
+                 boolean autoSaveAtEnd) throws WorkflowException;
 
     /**
      * Process a payload path using using the provided Workflow Processes.
      *
+     * @param resourceResolver                 the resourceResolver object that provides access to the JCR for WF operations
+     * @param payloadPath                      the path to execute the workflow against
+     * @param workflowProcessLabels            the process.labels of the workflow to execute in order against the payloadPath
+     *                                         resource
+     * @param processArgs                      the WF args metadata maps; each workflowProcessLabel can have one map
+     * @param autoSaveAfterEachWorkflowProcess persist changes to JCR after each Workflow Process completes
+     * @param autoSaveAtEnd                    persist changes to JCR after all Workflow Process complete
+     * @throws com.day.cq.workflow.WorkflowException
+     */
+    @Deprecated
+    void execute(ResourceResolver resourceResolver,
+                 String payloadPath,
+                 String[] workflowProcessLabels,
+                 Map<String, Map<String, Object>> processArgs,
+                 boolean autoSaveAfterEachWorkflowProcess,
+                 boolean autoSaveAtEnd) throws WorkflowException;
+
+    /**
+     * Process a payload path using using the provided Workflow Processes.
      * Convenience method for calling:
+     * > execute(resourceResolver, payloadPath, workflowProcessLabels, null, false, false);
      *
-     *  > execute(resourceResolver, payloadPath, workflowProcessLabels, null, false, false);
-     *
-     * @param resourceResolver the resourceResolver object that provides access to the JCR for WF operations
-     * @param payloadPath the path to execute the workflow against
+     * @param resourceResolver      the resourceResolver object that provides access to the JCR for WF operations
+     * @param payloadPath           the path to execute the workflow against
      * @param workflowProcessLabels the process.labels of the workflow to execute in order against the payloadPath
      *                              resource
-     *
      * @throws com.day.cq.workflow.WorkflowException
      */
     void execute(ResourceResolver resourceResolver,
-               String payloadPath,
-               String[] workflowProcessLabels) throws WorkflowException;
+                 String payloadPath,
+                 String[] workflowProcessLabels) throws WorkflowException;
 
+    /**
+     * Execute the provided Synthetic Workflow Model in the context of Synthetic Workflow.
+     *
+     * @param resourceResolver                  the resourceResolver object that provides access to the JCR for WF operations
+     * @param payloadPath                       the path to execute the workflow against
+     * @param syntheticWorkflowModel            the Synthetic Workflow Model to execute
+     * @param autoSaveAfterEachWorkflowProcess  persist changes to JCR after each Workflow Process completes
+     * @param autoSaveAtEnd                     persist changes to JCR after all Workflow Process complete
+     * @throws WorkflowException
+     */
     void execute(ResourceResolver resourceResolver,
                  String payloadPath,
-                 SyntheticWorkflowModelImpl syntheticWorkflowModel) throws WorkflowException;
+                 SyntheticWorkflowModel syntheticWorkflowModel,
+                 boolean autoSaveAfterEachWorkflowProcess,
+                 boolean autoSaveAtEnd) throws WorkflowException;
 
-    public String[] getWorkflowModelNames();
-
-    SyntheticWorkflowModel getSyntheticWorkflowModel(ResourceResolver resourceResolver, String workflowModelId);
+    /**
+     * Generates the SyntheticWorkflowModel that represents the AEM Workflow Model to execute in the context of Synthetic Workflow.
+     *
+     * @param resourceResolver          the resourceResolver object that provides access to the JCR for WF operations
+     * @param workflowModelId           the AEM Workflow Model ID
+     * @param ignoreIncompatibleTypes   ignore incompatible workflow node types to the best of Synthetic Workflow ability
+     * @return                          the Synthetic Workflow Model  
+     * @throws WorkflowException
+     */
+    SyntheticWorkflowModel getSyntheticWorkflowModel(ResourceResolver resourceResolver,
+                                                     String workflowModelId,
+                                                     boolean ignoreIncompatibleTypes) throws WorkflowException;
 }
+
+
+
+

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/SyntheticWorkflowRunner.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/SyntheticWorkflowRunner.java
@@ -20,6 +20,7 @@
 
 package com.adobe.acs.commons.workflow.synthetic;
 
+import com.adobe.acs.commons.workflow.synthetic.impl.SyntheticWorkflowModelImpl;
 import com.day.cq.workflow.WorkflowException;
 import com.day.cq.workflow.WorkflowService;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -67,4 +68,12 @@ public interface SyntheticWorkflowRunner extends WorkflowService {
     void execute(ResourceResolver resourceResolver,
                String payloadPath,
                String[] workflowProcessLabels) throws WorkflowException;
+
+    void execute(ResourceResolver resourceResolver,
+                 String payloadPath,
+                 SyntheticWorkflowModelImpl syntheticWorkflowModel) throws WorkflowException;
+
+    public String[] getWorkflowModelNames();
+
+    SyntheticWorkflowModel getSyntheticWorkflowModel(ResourceResolver resourceResolver, String workflowModelId);
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/SyntheticWorkflowRunner.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/SyntheticWorkflowRunner.java
@@ -2,7 +2,7 @@
  * #%L
  * ACS AEM Commons Bundle
  * %%
- * Copyright (C) 2013 Adobe
+ * Copyright (C) 2015 Adobe
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,10 +37,10 @@ public interface SyntheticWorkflowRunner extends WorkflowService {
     /**
      * Process a payload path using using the provided Workflow Processes.
      *
-     * @param resourceResolver                 the resourceResolver object that provides access to the JCR for WF operations
+     * @param resourceResolver                 the resourceResolver object that provides access to the JCR for WF ops
      * @param payloadPath                      the path to execute the workflow against
-     * @param workflowProcessIdType            defines is the worlflow ProcessIds are process.labels or process class names
-     * @param workflowProcessIds               the process.labels or process names of the workflow to execute in order against the payloadPath
+     * @param workflowProcessIdType            defines is the WF ProcessIds are process.labels or process class names
+     * @param workflowProcessIds               the process.labels or process names of the WF to execute in order against the payloadPath
      *                                         resource
      * @param processArgs                      the WF args metadata maps; each workflowProcessLabel can have one map
      * @param autoSaveAfterEachWorkflowProcess persist changes to JCR after each Workflow Process completes
@@ -112,7 +112,7 @@ public interface SyntheticWorkflowRunner extends WorkflowService {
      * @param resourceResolver          the resourceResolver object that provides access to the JCR for WF operations
      * @param workflowModelId           the AEM Workflow Model ID
      * @param ignoreIncompatibleTypes   ignore incompatible workflow node types to the best of Synthetic Workflow ability
-     * @return                          the Synthetic Workflow Model  
+     * @return                          the Synthetic Workflow Model
      * @throws WorkflowException
      */
     SyntheticWorkflowModel getSyntheticWorkflowModel(ResourceResolver resourceResolver,

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticMetaDataMap.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticMetaDataMap.java
@@ -2,7 +2,7 @@
  * #%L
  * ACS AEM Commons Bundle
  * %%
- * Copyright (C) 2013 Adobe
+ * Copyright (C) 2015 Adobe
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticRoute.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticRoute.java
@@ -33,29 +33,29 @@ public class SyntheticRoute implements Route {
     public SyntheticRoute(boolean backRoute) {
         this.backRoute = backRoute;
     }
-    
+
     @Override
-    public String getId() {
+    public final String getId() {
         return "synthetic-route";
     }
 
     @Override
-    public String getName() {
+    public final String getName() {
         return "Synthetic Route";
     }
 
     @Override
-    public boolean hasDefault() {
+    public final boolean hasDefault() {
         return false;
     }
 
     @Override
-    public List<WorkflowTransition> getDestinations() {
+    public final List<WorkflowTransition> getDestinations() {
         return new ArrayList<WorkflowTransition>();
     }
 
     @Override
-    public boolean isBackRoute() {
+    public final boolean isBackRoute() {
         return this.backRoute;
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticRoute.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticRoute.java
@@ -1,0 +1,61 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.workflow.synthetic.impl;
+
+import com.day.cq.workflow.exec.Route;
+import com.day.cq.workflow.model.WorkflowTransition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SyntheticRoute implements Route {
+
+    private final boolean backRoute;
+
+    public SyntheticRoute(boolean backRoute) {
+        this.backRoute = backRoute;
+    }
+    
+    @Override
+    public String getId() {
+        return "synthetic-route";
+    }
+
+    @Override
+    public String getName() {
+        return "Synthetic Route";
+    }
+
+    @Override
+    public boolean hasDefault() {
+        return false;
+    }
+
+    @Override
+    public List<WorkflowTransition> getDestinations() {
+        return new ArrayList<WorkflowTransition>();
+    }
+
+    @Override
+    public boolean isBackRoute() {
+        return this.backRoute;
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkItem.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkItem.java
@@ -2,7 +2,7 @@
  * #%L
  * ACS AEM Commons Bundle
  * %%
- * Copyright (C) 2013 Adobe
+ * Copyright (C) 2015 Adobe
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflow.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflow.java
@@ -2,7 +2,7 @@
  * #%L
  * ACS AEM Commons Bundle
  * %%
- * Copyright (C) 2013 Adobe
+ * Copyright (C) 2015 Adobe
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowData.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowData.java
@@ -2,7 +2,7 @@
  * #%L
  * ACS AEM Commons Bundle
  * %%
- * Copyright (C) 2013 Adobe
+ * Copyright (C) 2015 Adobe
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowModelImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowModelImpl.java
@@ -71,13 +71,13 @@ public class SyntheticWorkflowModelImpl implements SyntheticWorkflowModel {
             }
 
             // No issues with Workflow Model; Collect the Process type
-            log.info("Workflow node title [ {} ]", node.getTitle());
+            log.debug("Workflow node title [ {} ]", node.getTitle());
 
             if (this.isProcessType(node)) {
                 final String processName = node.getMetaDataMap().get("PROCESS", "");
 
                 if (StringUtils.isNotBlank(processName)) {
-                    log.info("Adding Workflow Process [ {} ] to Synthetic Workflow", processName);
+                    log.debug("Adding Workflow Process [ {} ] to Synthetic Workflow", processName);
                     syntheticWorkflowModel.put(processName, node.getMetaDataMap());
                 }
             }

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowModelImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowModelImpl.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.workflow.synthetic.impl;
 
 import com.adobe.acs.commons.workflow.synthetic.SyntheticWorkflowModel;
@@ -16,7 +36,7 @@ import java.util.Map;
 
 public class SyntheticWorkflowModelImpl implements SyntheticWorkflowModel {
     private static final Logger log = LoggerFactory.getLogger(SyntheticWorkflowModelImpl.class);
-    
+
     private static final String WORKFLOW_MODEL_PATH_PREFIX = "/etc/workflow/models/";
     private static final String WORKFLOW_MODEL_PATH_SUFFIX = "/jcr:content/model";
 
@@ -33,11 +53,11 @@ public class SyntheticWorkflowModelImpl implements SyntheticWorkflowModel {
         if (!StringUtils.endsWith(modelId, WORKFLOW_MODEL_PATH_SUFFIX)) {
             modelId = modelId + WORKFLOW_MODEL_PATH_SUFFIX;
         }
-        
+
         final WorkflowModel model = workflowSession.getModel(modelId);
-        
+
         log.debug("Located Workflow Model [ {} ] with modelId [ {} ]", model.getTitle(), modelId);
-        
+
         final List<WorkflowNode> nodes = model.getNodes();
 
         for (final WorkflowNode node : nodes) {
@@ -47,13 +67,12 @@ public class SyntheticWorkflowModelImpl implements SyntheticWorkflowModel {
                         + " is of incompatible type " + node.getType());
             } else if (node.getTransitions().size() > 1) {
                 throw new SyntheticWorkflowModelException(node.getId()
-                        + " has unsupported decision based execution (multiple transitions are not allowed)");
+                        + " has unsupported decision based execution (more than 1 transitions is not allowed)");
             }
 
             // No issues with Workflow Model; Collect the Process type
+            log.info("Workflow node title [ {} ]", node.getTitle());
 
-            log.info("Workflow Node Title [ {} ]", node.getTitle());
-            
             if (this.isProcessType(node)) {
                 final String processName = node.getMetaDataMap().get("PROCESS", "");
 
@@ -65,11 +84,11 @@ public class SyntheticWorkflowModelImpl implements SyntheticWorkflowModel {
         }
     }
 
-    public String[] getWorkflowProcessNames() {
+    public final String[] getWorkflowProcessNames() {
         return this.syntheticWorkflowModel.keySet().toArray(new String[this.syntheticWorkflowModel.keySet().size()]);
     }
-    
-    public Map<String, Map<String, Object>> getSyntheticWorkflowModelData() {
+
+    public final Map<String, Map<String, Object>> getSyntheticWorkflowModelData() {
         return this.syntheticWorkflowModel;
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowModelImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowModelImpl.java
@@ -1,0 +1,66 @@
+package com.adobe.acs.commons.workflow.synthetic.impl;
+
+import com.adobe.acs.commons.workflow.synthetic.SyntheticWorkflowModel;
+import com.adobe.acs.commons.workflow.synthetic.impl.exceptions.SyntheticWorkflowModelException;
+import com.day.cq.workflow.WorkflowException;
+import com.day.cq.workflow.WorkflowSession;
+import com.day.cq.workflow.model.WorkflowModel;
+import com.day.cq.workflow.model.WorkflowNode;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SyntheticWorkflowModelImpl implements SyntheticWorkflowModel {
+
+    private Map<String, Map<String, Object>> syntheticWorkflowModel = new LinkedHashMap<String, Map<String, Object>>()
+
+    public SyntheticWorkflowModelImpl(WorkflowSession workflowSession, String modelId, boolean
+            ignoredIncompatibleTypes) throws WorkflowException {
+
+        final WorkflowModel model = workflowSession.getModel(modelId);
+        final List<WorkflowNode> nodes = model.getNodes();
+
+        for (final WorkflowNode node : nodes) {
+            if(!ignoredIncompatibleTypes && !this.isValidType(node)) {
+                // Only Process Steps are allowed
+                throw new SyntheticWorkflowModelException(node.getId()
+                        + " is of incompatible type " + node.getType());
+            } else if(node.getTransitions().size() != 1) {
+                throw new SyntheticWorkflowModelException(node.getId()
+                        + " has unsupported decision based execution (multiple transitions are not allowed)");
+            }
+
+            // No issues with Workflow Model; Collect the Process type
+
+            if (this.isProcessType(node)) {
+                final String processName = node.getMetaDataMap().get("PROCESS", "");
+
+                if (StringUtils.isNotBlank(processName)) {
+                    syntheticWorkflowModel.put(processName, node.getMetaDataMap());
+                }
+            }
+        }
+    }
+
+
+    public String[] getWorkflowModelNames() {
+        return this.syntheticWorkflowModel.keySet().toArray(new String[this.syntheticWorkflowModel.keySet().size()]);
+    }
+
+
+    public Map<String, Map<String, Object>> getSyntheticWorkflowModelData() {
+        return this.syntheticWorkflowModel;
+    }
+
+    private boolean isValidType(WorkflowNode node) {
+        return WorkflowNode.TYPE_START.equals(node.getType())
+                || WorkflowNode.TYPE_START.equals(node.getType())
+                ||  WorkflowNode.TYPE_PROCESS.equals(node.getType());
+    }
+
+    private boolean isProcessType(WorkflowNode node) {
+        return WorkflowNode.TYPE_PROCESS.equals(node.getType();
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowModelImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowModelImpl.java
@@ -7,49 +7,68 @@ import com.day.cq.workflow.WorkflowSession;
 import com.day.cq.workflow.model.WorkflowModel;
 import com.day.cq.workflow.model.WorkflowNode;
 import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 public class SyntheticWorkflowModelImpl implements SyntheticWorkflowModel {
+    private static final Logger log = LoggerFactory.getLogger(SyntheticWorkflowModelImpl.class);
+    
+    private static final String WORKFLOW_MODEL_PATH_PREFIX = "/etc/workflow/models/";
+    private static final String WORKFLOW_MODEL_PATH_SUFFIX = "/jcr:content/model";
 
-    private Map<String, Map<String, Object>> syntheticWorkflowModel = new LinkedHashMap<String, Map<String, Object>>()
+    private Map<String, Map<String, Object>> syntheticWorkflowModel = new LinkedHashMap<String, Map<String, Object>>();
 
-    public SyntheticWorkflowModelImpl(WorkflowSession workflowSession, String modelId, boolean
-            ignoredIncompatibleTypes) throws WorkflowException {
+    public SyntheticWorkflowModelImpl(WorkflowSession workflowSession,
+                                      String modelId,
+                                      boolean ignoredIncompatibleTypes) throws WorkflowException {
 
+        if (!StringUtils.startsWith(modelId, WORKFLOW_MODEL_PATH_PREFIX)) {
+            modelId = WORKFLOW_MODEL_PATH_PREFIX + modelId;
+        }
+
+        if (!StringUtils.endsWith(modelId, WORKFLOW_MODEL_PATH_SUFFIX)) {
+            modelId = modelId + WORKFLOW_MODEL_PATH_SUFFIX;
+        }
+        
         final WorkflowModel model = workflowSession.getModel(modelId);
+        
+        log.debug("Located Workflow Model [ {} ] with modelId [ {} ]", model.getTitle(), modelId);
+        
         final List<WorkflowNode> nodes = model.getNodes();
 
         for (final WorkflowNode node : nodes) {
-            if(!ignoredIncompatibleTypes && !this.isValidType(node)) {
+            if (!ignoredIncompatibleTypes && !this.isValidType(node)) {
                 // Only Process Steps are allowed
                 throw new SyntheticWorkflowModelException(node.getId()
                         + " is of incompatible type " + node.getType());
-            } else if(node.getTransitions().size() != 1) {
+            } else if (node.getTransitions().size() > 1) {
                 throw new SyntheticWorkflowModelException(node.getId()
                         + " has unsupported decision based execution (multiple transitions are not allowed)");
             }
 
             // No issues with Workflow Model; Collect the Process type
 
+            log.info("Workflow Node Title [ {} ]", node.getTitle());
+            
             if (this.isProcessType(node)) {
                 final String processName = node.getMetaDataMap().get("PROCESS", "");
 
                 if (StringUtils.isNotBlank(processName)) {
+                    log.info("Adding Workflow Process [ {} ] to Synthetic Workflow", processName);
                     syntheticWorkflowModel.put(processName, node.getMetaDataMap());
                 }
             }
         }
     }
 
-
-    public String[] getWorkflowModelNames() {
+    public String[] getWorkflowProcessNames() {
         return this.syntheticWorkflowModel.keySet().toArray(new String[this.syntheticWorkflowModel.keySet().size()]);
     }
-
-
+    
     public Map<String, Map<String, Object>> getSyntheticWorkflowModelData() {
         return this.syntheticWorkflowModel;
     }
@@ -57,10 +76,10 @@ public class SyntheticWorkflowModelImpl implements SyntheticWorkflowModel {
     private boolean isValidType(WorkflowNode node) {
         return WorkflowNode.TYPE_START.equals(node.getType())
                 || WorkflowNode.TYPE_START.equals(node.getType())
-                ||  WorkflowNode.TYPE_PROCESS.equals(node.getType());
+                || WorkflowNode.TYPE_PROCESS.equals(node.getType());
     }
 
     private boolean isProcessType(WorkflowNode node) {
-        return WorkflowNode.TYPE_PROCESS.equals(node.getType();
+        return WorkflowNode.TYPE_PROCESS.equals(node.getType());
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowRunnerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowRunnerImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * ACS AEM Commons Bundle
  * %%
- * Copyright (C) 2013 Adobe
+ * Copyright (C) 2015 Adobe
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,17 +73,18 @@ public class SyntheticWorkflowRunnerImpl implements SyntheticWorkflowRunner {
 
     private Map<String, WorkflowProcess> workflowProcessesByLabel = new ConcurrentHashMap<String, WorkflowProcess>();
 
-    private Map<String, WorkflowProcess> workflowProcessesByProcessName = new ConcurrentHashMap<String, WorkflowProcess>();
+    private Map<String, WorkflowProcess> workflowProcessesByProcessName =
+            new ConcurrentHashMap<String, WorkflowProcess>();
 
     @Reference
     private WorkflowService aemWorkflowService;
-    
+
     /**
      * {@inheritDoc}
      */
     @Override
     public final void execute(final ResourceResolver resourceResolver, final String payloadPath,
-                         final String[] workflowProcessLabels) throws WorkflowException {
+                              final String[] workflowProcessLabels) throws WorkflowException {
         this.execute(resourceResolver, payloadPath, workflowProcessLabels, null, false, false);
     }
 
@@ -97,28 +98,27 @@ public class SyntheticWorkflowRunnerImpl implements SyntheticWorkflowRunner {
                               Map<String, Map<String, Object>> processArgs,
                               final boolean autoSaveAfterEachWorkflowProcess,
                               final boolean autoSaveAtEnd) throws WorkflowException {
-    
-        this.execute(resourceResolver, 
-                payloadPath, 
+
+        this.execute(resourceResolver,
+                payloadPath,
                 WorkflowProcessIdType.PROCESS_LABEL,
-                workflowProcessLabels, 
+                workflowProcessLabels,
                 processArgs,
-                autoSaveAfterEachWorkflowProcess, 
+                autoSaveAfterEachWorkflowProcess,
                 autoSaveAtEnd);
     }
-    
-    
+
     /**
      * {@inheritDoc}
      */
     @Override
     public final void execute(final ResourceResolver resourceResolver,
-                        final String payloadPath,
-                        final WorkflowProcessIdType workflowProcessIdType,
-                        final String[] workflowProcessIds,
-                        Map<String, Map<String, Object>> processArgs,
-                        final boolean autoSaveAfterEachWorkflowProcess,
-                        final boolean autoSaveAtEnd) throws WorkflowException {
+                              final String payloadPath,
+                              final WorkflowProcessIdType workflowProcessIdType,
+                              final String[] workflowProcessIds,
+                              Map<String, Map<String, Object>> processArgs,
+                              final boolean autoSaveAfterEachWorkflowProcess,
+                              final boolean autoSaveAtEnd) throws WorkflowException {
 
         final long start = System.currentTimeMillis();
 
@@ -137,7 +137,7 @@ public class SyntheticWorkflowRunnerImpl implements SyntheticWorkflowRunner {
                 if (log.isInfoEnabled()) {
                     long duration = System.currentTimeMillis() - start;
                     log.info("Synthetic workflow execution of payload [ {} ] completed in [ {} ] ms",
-                        payloadPath, duration);
+                            payloadPath, duration);
                 }
 
                 return;
@@ -153,7 +153,6 @@ public class SyntheticWorkflowRunnerImpl implements SyntheticWorkflowRunner {
         } while (count < MAX_RESTART_COUNT);
     }
 
-    
     private void run(final ResourceResolver resourceResolver,
                      final String payloadPath,
                      final WorkflowProcessIdType workflowProcessIdType,
@@ -174,8 +173,8 @@ public class SyntheticWorkflowRunnerImpl implements SyntheticWorkflowRunner {
 
         for (final String workflowProcessId : workflowProcessIds) {
             WorkflowProcess workflowProcess;
-            
-            if(WorkflowProcessIdType.PROCESS_LABEL.equals(workflowProcessIdType)) {
+
+            if (WorkflowProcessIdType.PROCESS_LABEL.equals(workflowProcessIdType)) {
                 workflowProcess = this.workflowProcessesByLabel.get(workflowProcessId);
             } else {
                 workflowProcess = this.workflowProcessesByProcessName.get(workflowProcessId);
@@ -235,12 +234,12 @@ public class SyntheticWorkflowRunnerImpl implements SyntheticWorkflowRunner {
     }
 
     @Override
-    public void execute(final ResourceResolver resourceResolver,
-                        final String payloadPath,
-                        final SyntheticWorkflowModel syntheticWorkflowModel,
-                        final boolean autoSaveAfterEachWorkflowProcess,
-                        final boolean autoSaveAtEnd) throws WorkflowException {
-        
+    public final void execute(final ResourceResolver resourceResolver,
+                              final String payloadPath,
+                              final SyntheticWorkflowModel syntheticWorkflowModel,
+                              final boolean autoSaveAfterEachWorkflowProcess,
+                              final boolean autoSaveAtEnd) throws WorkflowException {
+
         final String[] processNames = syntheticWorkflowModel.getWorkflowProcessNames();
         final Map<String, Map<String, Object>> processConfigs = syntheticWorkflowModel.getSyntheticWorkflowModelData();
 
@@ -254,16 +253,14 @@ public class SyntheticWorkflowRunnerImpl implements SyntheticWorkflowRunner {
     }
 
     @Override
-    public SyntheticWorkflowModel getSyntheticWorkflowModel(final ResourceResolver resourceResolver,
-                                                            final String workflowModelId,
-                                                            final boolean ignoreIncompatibleTypes) throws WorkflowException {
+    public final SyntheticWorkflowModel getSyntheticWorkflowModel(final ResourceResolver resourceResolver,
+                                                                  final String workflowModelId,
+                                                                  final boolean ignoreIncompatibleTypes)
+            throws WorkflowException {
 
-        
-        
         final WorkflowSession workflowSession = this.getWorkflowSession(resourceResolver.adaptTo(Session.class));
         return new SyntheticWorkflowModelImpl(workflowSession, workflowModelId, ignoreIncompatibleTypes);
     }
-
 
 
     /**
@@ -295,15 +292,17 @@ public class SyntheticWorkflowRunnerImpl implements SyntheticWorkflowRunner {
     }
 
     /**
-     * Getter for the AEM Workflow Service; This is only available at the Impl level and not part of the public SyntheticWorkflowRunner interface.
-     * The use of this service should be well understand as to prevent potential overhead of the the non-synthetic aspects of WF.
+     * Getter for the AEM Workflow Service; This is only available at the Impl level and not part of the public
+     * SyntheticWorkflowRunner interface.
+     * The use of this service should be well understand as to prevent potential overhead of the the non-synthetic
+     * aspects of WF.
      *
      * @return the AEM Workflow Service
      */
     public final WorkflowService getAEMWorkflowService() {
         return this.aemWorkflowService;
     }
-    
+
     @Deprecated
     @Override
     public final Dictionary<String, Object> getConfig() {
@@ -325,7 +324,7 @@ public class SyntheticWorkflowRunnerImpl implements SyntheticWorkflowRunner {
         }
 
         // Workflow Process Name
-        if(service != null) {
+        if (service != null) {
             final String processName = service.getClass().getCanonicalName();
             if (processName != null) {
                 this.workflowProcessesByProcessName.put(processName, service);
@@ -343,7 +342,7 @@ public class SyntheticWorkflowRunnerImpl implements SyntheticWorkflowRunner {
         }
 
         // Workflow Process Name
-        if(service != null) {
+        if (service != null) {
             final String processName = service.getClass().getCanonicalName();
             if (processName != null) {
                 this.workflowProcessesByProcessName.remove(processName);

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowSession.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowSession.java
@@ -20,6 +20,7 @@
 
 package com.adobe.acs.commons.workflow.synthetic.impl;
 
+import com.adobe.acs.commons.workflow.synthetic.impl.exceptions.SyntheticCompleteWorkflowException;
 import com.adobe.acs.commons.workflow.synthetic.impl.exceptions.SyntheticRestartWorkflowException;
 import com.adobe.acs.commons.workflow.synthetic.impl.exceptions.SyntheticTerminateWorkflowException;
 import com.day.cq.security.Authorizable;
@@ -81,7 +82,7 @@ public class SyntheticWorkflowSession implements WorkflowSession {
     @Override
     public final void terminateWorkflow(final Workflow workflow) throws WorkflowException {
         if (workflow instanceof SyntheticWorkflow) {
-            throw new SyntheticTerminateWorkflowException("Synthetic workflow terminated");
+            throw new SyntheticTerminateWorkflowException("Synthetic workflow [ " + workflow.getId() + " ] terminated");
         } else {
             throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MESSAGE);
         }
@@ -90,7 +91,8 @@ public class SyntheticWorkflowSession implements WorkflowSession {
     @Override
     public final void complete(final WorkItem workItem, final Route route) throws WorkflowException {
         if (workItem instanceof SyntheticWorkItem) {
-            throw new SyntheticTerminateWorkflowException("Synthetic workflow complete");
+            throw new SyntheticCompleteWorkflowException("Synthetic workflow [ "
+                    + workItem.getWorkflow().getId() + " : " + workItem.getId() + " ] completed");
         } else {
             throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MESSAGE);
         }
@@ -99,7 +101,7 @@ public class SyntheticWorkflowSession implements WorkflowSession {
     @Override
     public final void restartWorkflow(final Workflow workflow) throws WorkflowException {
         if (workflow instanceof SyntheticWorkflow) {
-            throw new SyntheticRestartWorkflowException("Synthetic workflow restarted");
+            throw new SyntheticRestartWorkflowException("Synthetic workflow [ " + workflow.getId() + " ] restarted");
         } else {
             throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MESSAGE);
         }
@@ -260,25 +262,25 @@ public class SyntheticWorkflowSession implements WorkflowSession {
 
     @Override
     public final List<Route> getRoutes(final WorkItem workItem) throws WorkflowException {
-        log.info("Synthetic Workflow does not support routes; Defaults to a single Synthetic Route");
+        log.debug("Synthetic Workflow does not support routes; Defaults to a single Synthetic Route");
         return this.routes;
     }
 
     @Override
     public final List<Route> getRoutes(final WorkItem workItem, final boolean b) throws WorkflowException {
-        log.info("Synthetic Workflow does not support routes; Defaults to a single Synthetic Route");
+        log.debug("Synthetic Workflow does not support routes; Defaults to a single Synthetic Route");
         return this.routes;
     }
 
     @Override
     public final List<Route> getBackRoutes(final WorkItem workItem) throws WorkflowException {
-        log.info("Synthetic Workflow does not support back routes; Defaults to a single Synthetic Route");
+        log.debug("Synthetic Workflow does not support back routes; Defaults to a single Synthetic Route");
         return this.backRoutes;
     }
 
     @Override
     public final List<Route> getBackRoutes(final WorkItem workItem, final boolean b) throws WorkflowException {
-        log.info("Synthetic Workflow does not back support routes; Defaults to a single Synthetic Route");
+        log.debug("Synthetic Workflow does not back support routes; Defaults to a single Synthetic Route");
         return this.backRoutes;
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowSession.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowSession.java
@@ -147,7 +147,9 @@ public class SyntheticWorkflowSession implements WorkflowSession {
 
     @Override
     public final WorkflowModel getModel(final String s) throws WorkflowException {
-        throw new UnsupportedOperationException(UNSUPPORTED_OPERATION_MESSAGE);
+        final WorkflowSession workflowSession = workflowService.getWorkflowSession(this.getSession());
+
+        return workflowSession.getModel(s);
     }
 
     @Override

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowSession.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowSession.java
@@ -2,7 +2,7 @@
  * #%L
  * ACS AEM Commons Bundle
  * %%
- * Copyright (C) 2013 Adobe
+ * Copyright (C) 2015 Adobe
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,26 +47,25 @@ import java.util.Map;
 
 public class SyntheticWorkflowSession implements WorkflowSession {
     private static final Logger log = LoggerFactory.getLogger(SyntheticWorkflowSession.class);
-    
+
     private static final String UNSUPPORTED_OPERATION_MESSAGE = "Operation not supported by Synthetic Workflow";
 
     private final Session session;
 
     private final SyntheticWorkflowRunnerImpl workflowService;
-    
+
     private final List<Route> routes;
     private final List<Route> backRoutes;
 
     public SyntheticWorkflowSession(SyntheticWorkflowRunnerImpl workflowService, Session session) {
         this.workflowService = workflowService;
         this.session = session;
-        
+
         this.routes = new ArrayList<Route>();
         this.routes.add(new SyntheticRoute(false));
 
         this.backRoutes = new ArrayList<Route>();
         this.backRoutes.add(new SyntheticRoute(true));
-
     }
 
     @Override
@@ -166,7 +165,8 @@ public class SyntheticWorkflowSession implements WorkflowSession {
 
     @Override
     public final WorkflowModel getModel(final String modelId) throws WorkflowException {
-        final WorkflowSession workflowSession = this.workflowService.getAEMWorkflowService().getWorkflowSession(this.session);
+        final WorkflowSession workflowSession =
+                this.workflowService.getAEMWorkflowService().getWorkflowSession(this.session);
         return workflowSession.getModel(modelId);
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/exceptions/SyntheticCompleteWorkflowException.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/exceptions/SyntheticCompleteWorkflowException.java
@@ -1,0 +1,31 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.workflow.synthetic.impl.exceptions;
+
+import com.day.cq.workflow.WorkflowException;
+
+@SuppressWarnings("serial")
+public class SyntheticCompleteWorkflowException extends WorkflowException {
+
+    public SyntheticCompleteWorkflowException(String message) {
+        super(message);
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/exceptions/SyntheticRestartWorkflowException.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/exceptions/SyntheticRestartWorkflowException.java
@@ -2,7 +2,7 @@
  * #%L
  * ACS AEM Commons Bundle
  * %%
- * Copyright (C) 2013 Adobe
+ * Copyright (C) 2015 Adobe
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/exceptions/SyntheticTerminateWorkflowException.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/exceptions/SyntheticTerminateWorkflowException.java
@@ -2,7 +2,7 @@
  * #%L
  * ACS AEM Commons Bundle
  * %%
- * Copyright (C) 2013 Adobe
+ * Copyright (C) 2015 Adobe
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/exceptions/SyntheticWorkflowModelException.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/exceptions/SyntheticWorkflowModelException.java
@@ -1,0 +1,9 @@
+package com.adobe.acs.commons.workflow.synthetic.impl.exceptions;
+
+import com.day.cq.workflow.WorkflowException;
+
+public class SyntheticWorkflowModelException extends WorkflowException {
+    public SyntheticWorkflowModelException(String message) {
+        super(message);
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/exceptions/SyntheticWorkflowModelException.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/exceptions/SyntheticWorkflowModelException.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.workflow.synthetic.impl.exceptions;
 
 import com.day.cq.workflow.WorkflowException;

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/package-info.java
@@ -2,7 +2,7 @@
  * #%L
  * ACS AEM Commons Bundle
  * %%
- * Copyright (C) 2013 Adobe
+ * Copyright (C) 2015 Adobe
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/package-info.java
@@ -21,5 +21,5 @@
 /**
  * Synthetic AEM Workflow APIs.
  */
-@aQute.bnd.annotation.Version("1.0.0")
+@aQute.bnd.annotation.Version("2.0.0")
 package com.adobe.acs.commons.workflow.synthetic;


### PR DESCRIPTION
Allows Synthetic WF to be executed against AEM Workflow Models. The Model support is restricted to Workflow Process steps ONLY (excluding Start and End), and there can be no decision trees; all Workflow Node's must have 0 or 1 Transitions (0 because End has 0).


Example Fiddle for execution OOTB DAM Asset Update WF model via Synthetic WF

```
<%@include file="/libs/foundation/global.jsp"%><%
%><%@page session="false" contentType="text/html; charset=utf-8" 
	pageEncoding="UTF-8"
    import="org.apache.sling.api.resource.*,
    java.util.*,
    javax.jcr.*,
    com.adobe.acs.commons.workflow.synthetic.*,
    com.day.cq.dam.commons.util.DamUtil,
    com.day.cq.wcm.api.*,
    com.day.cq.dam.api.*"%><%

    // Get Synthetic Workflow Runner service 
    SyntheticWorkflowRunner swr = sling.getService(SyntheticWorkflowRunner.class);   
    SyntheticWorkflowModel model = swr.getSyntheticWorkflowModel(resourceResolver,
                                        "/etc/workflow/models/dam/update_asset",
                                        true);
    
    // Collect the Resource to execute the Workflow against 
    String rootPath = "/content/dam/synthetic-workflow";
    Resource root = resourceResolver.getResource(rootPath);
    int count = 0;
    for(Resource r : root.getChildren()) {
        if(DamUtil.resolveToAsset(r) == null) { continue; }

        boolean saveAfterEachWFProcess = false;
        boolean saveAtEndOfAllWFProcesses = false;
        
        swr.execute(resourceResolver, 
            r.getPath() + "/jcr:content/renditions/original", 
            model,
            saveAfterEachWFProcess, 
            saveAtEndOfAllWFProcesses);

        if(++count % 1000 == 0) {
        	// Save in batches of 1000; How data is saved should be driven by the use case.
        	resourceResolver.commit();
        }	
    }
    
    // Final save to catch stragglers
    resourceResolver.commit();

%>
```

Debug Log output

```
Located Workflow Model [ DAM Update Asset ] with modelId [ /etc/workflow/models/dam/update_asset/jcr:content/model ]
Workflow node title [ Start ]
Workflow node title [ Continue updating? ]
Adding Workflow Process [ com.day.cq.dam.core.process.GateKeeperProcess ] to Synthetic Workflow
Workflow node title [ Metadata extraction ]
Adding Workflow Process [ com.day.cq.dam.core.process.ExtractMetadataProcess ] to Synthetic Workflow
Workflow node title [ Dynamic Media On-Premise copy asset ]
Adding Workflow Process [ com.day.cq.dam.s7dam.onprem.process.S7damImageCopyProcess ] to Synthetic Workflow
Workflow node title [ Dynamic Media On-Premise extract image info ]
Adding Workflow Process [ com.day.cq.dam.s7dam.onprem.process.S7damExtractImageInfoProcess ] to Synthetic Workflow
Workflow node title [ Dynamic Media On-Premise Process CSS ]
Adding Workflow Process [ com.day.cq.dam.s7dam.onprem.process.S7damCssProcess ] to Synthetic Workflow
Workflow node title [ Create PTIFF Rendition (Dynamic Media) ]
Adding Workflow Process [ com.adobe.cq.dam.s7imaging.impl.is.CreatePTIFFProcess ] to Synthetic Workflow
Workflow node title [ Thumbnail creation ]
Adding Workflow Process [ com.day.cq.dam.core.process.CreateThumbnailProcess ] to Synthetic Workflow
Workflow node title [ FFmpeg thumbnails ]
Adding Workflow Process [ com.day.cq.dam.video.FFMpegThumbnailProcess ] to Synthetic Workflow
Workflow node title [ EPS thumbnails (powered by ImageMagick) ]
Adding Workflow Process [ com.day.cq.dam.core.process.CommandLineProcess ] to Synthetic Workflow
Workflow node title [ FFmpeg transcoding ]
Adding Workflow Process [ com.day.cq.dam.video.FFMpegTranscodeProcess ] to Synthetic Workflow
Workflow node title [ Web enabled rendition ]
Adding Workflow Process [ com.day.cq.dam.core.process.CreateWebEnabledImageProcess ] to Synthetic Workflow
Workflow node title [ Media Extraction ]
Workflow node title [ INDD Verify Thumbnail ]
Adding Workflow Process [ com.day.cq.dam.indd.process.INDDCreateThumbnailProcess ] to Synthetic Workflow
Workflow node title [ Page Extraction ]
Adding Workflow Process [ com.day.cq.dam.indd.process.INDDPageExtractProcess ] to Synthetic Workflow
Workflow node title [ Dynamic Media Video Service Process ]
Adding Workflow Process [ com.day.cq.dam.s7dam.common.process.VideoProxyServiceProcess ] to Synthetic Workflow
Workflow node title [ Create Reference ]
Adding Workflow Process [ com.day.cq.dam.core.process.CreateReferenceProcess ] to Synthetic Workflow
Workflow node title [ Update Folder Thumbnail ]
Adding Workflow Process [ com.day.cq.dam.core.process.UpdateFolderThumbnailProcess ] to Synthetic Workflow
Workflow node title [ Apply Metadata Processing Profile ]
Adding Workflow Process [ com.day.cq.dam.core.process.ApplyProcessingProfileProcess ] to Synthetic Workflow
Workflow node title [ Dynamic Media On-Premise Apply Image Profile ]
Adding Workflow Process [ com.day.cq.dam.s7dam.onprem.process.ApplyImageProfileProcess ] to Synthetic Workflow
Workflow node title [ Product Asset Upload ]
Adding Workflow Process [ com.day.cq.dam.pim.impl.sourcing.upload.process.ProductAssetsUploadProcess ] to Synthetic Workflow
Workflow node title [ End ]
Synthetic Workflow does not support routes; Defaults to a single Synthetic Route
Executed synthetic workflow process [ com.day.cq.dam.core.process.GateKeeperProcess ] on [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] in [ 2 ] ms
Executed synthetic workflow process [ com.day.cq.dam.core.process.ExtractMetadataProcess ] on [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] in [ 64 ] ms
Executed synthetic workflow process [ com.day.cq.dam.s7dam.onprem.process.S7damImageCopyProcess ] on [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] in [ 1 ] ms
Executed synthetic workflow process [ com.day.cq.dam.s7dam.onprem.process.S7damExtractImageInfoProcess ] on [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] in [ 0 ] ms
Executed synthetic workflow process [ com.day.cq.dam.s7dam.onprem.process.S7damCssProcess ] on [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] in [ 1 ] ms
Synthetic workflow runner retrieved a null Workflow Process for process.label [ com.adobe.cq.dam.s7imaging.impl.is.CreatePTIFFProcess ]
Executed synthetic workflow process [ com.day.cq.dam.core.process.CreateThumbnailProcess ] on [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] in [ 83 ] ms
Executed synthetic workflow process [ com.day.cq.dam.video.FFMpegThumbnailProcess ] on [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] in [ 1 ] ms
Executed synthetic workflow process [ com.day.cq.dam.core.process.CommandLineProcess ] on [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] in [ 1 ] ms
Executed synthetic workflow process [ com.day.cq.dam.video.FFMpegTranscodeProcess ] on [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] in [ 1 ] ms
Executed synthetic workflow process [ com.day.cq.dam.core.process.CreateWebEnabledImageProcess ] on [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] in [ 120 ] ms
Executed synthetic workflow process [ com.day.cq.dam.indd.process.INDDCreateThumbnailProcess ] on [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] in [ 1 ] ms
Executed synthetic workflow process [ com.day.cq.dam.indd.process.INDDPageExtractProcess ] on [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] in [ 1 ] ms
Executed synthetic workflow process [ com.day.cq.dam.s7dam.common.process.VideoProxyServiceProcess ] on [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] in [ 6 ] ms
Executed synthetic workflow process [ com.day.cq.dam.core.process.CreateReferenceProcess ] on [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] in [ 1 ] ms
Executed synthetic workflow process [ com.day.cq.dam.core.process.UpdateFolderThumbnailProcess ] on [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] in [ 2 ] ms
Executed synthetic workflow process [ com.day.cq.dam.core.process.ApplyProcessingProfileProcess ] on [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] in [ 3 ] ms
Executed synthetic workflow process [ com.day.cq.dam.s7dam.onprem.process.ApplyImageProfileProcess ] on [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] in [ 2 ] ms
Executed synthetic workflow process [ com.day.cq.dam.pim.impl.sourcing.upload.process.ProductAssetsUploadProcess ] on [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] in [ 18 ] ms
Synthetic workflow execution of payload [ /content/dam/synthetic-workflow/2015-08-22 at 9.33 AM.png/jcr:content/renditions/original ] completed in [ 312 ] ms
```