### PR TITLE
Add a null check on the adapted ValueMap

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/widgets/MultiFieldPanelFunctions.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/widgets/MultiFieldPanelFunctions.java
@@ -57,7 +57,7 @@ public final class MultiFieldPanelFunctions {
     public static List<Map<String, String>> getMultiFieldPanelValues(Resource resource, String name) {
         ValueMap map = resource.adaptTo(ValueMap.class);
         List<Map<String, String>> results = new ArrayList<Map<String, String>>();
-        if (map.containsKey(name)) {
+        if (map != null && map.containsKey(name)) {
             String[] values = map.get(name, new String[0]);
             for (String value : values) {
 

--- a/bundle/src/test/java/com/adobe/acs/commons/widgets/MultiFieldPanelFunctionsTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/widgets/MultiFieldPanelFunctionsTest.java
@@ -77,4 +77,11 @@ public class MultiFieldPanelFunctionsTest {
                 "non-existing");
         assertEquals(0, actual.size());
     }
+
+    @Test
+    public void testResourceAdaptToValueMapNull() {
+        when(resource.adaptTo(ValueMap.class)).thenReturn(null);
+        List<Map<String, String>> actual = MultiFieldPanelFunctions.getMultiFieldPanelValues(resource, "single");
+        assertEquals(0, actual.size());
+    }
 }


### PR DESCRIPTION
If resource is a SyntheticResource (which happens when the invoking component is included via a <cq:include path="<a non-existent path>" />), an attempt to adaptTo(ValueMap.class) will result in a null value.  In this case, it makes more sense to fail gracefully, returning an empty results object instead of causing the NPE to bubble up as an ELException.