### PR TITLE
When URL are mapped through sling resource mapping 404 fall back to G…

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/errorpagehandler/404.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/errorpagehandler/404.jsp
@@ -18,7 +18,10 @@
   #L%
   --%>
 <%@page session="false"
-        import="com.adobe.acs.commons.errorpagehandler.ErrorPageHandlerService"%><%
+        import="com.adobe.acs.commons.errorpagehandler.ErrorPageHandlerService,
+        org.apache.sling.api.resource.Resource,
+      	org.apache.sling.api.SlingHttpServletRequest,
+      	org.apache.commons.lang3.StringUtils"%><%
 %><%@include file="/libs/foundation/global.jsp" %><%
     ErrorPageHandlerService errorPageHandlerService = sling.getService(ErrorPageHandlerService.class);
 
@@ -26,12 +29,23 @@
         // Check for and handle 404 Requests properly according on Author/Publish
         if (errorPageHandlerService.doHandle404(slingRequest, slingResponse)) {
 
-            final String path = errorPageHandlerService.findErrorPage(slingRequest, resource);
+            SlingHttpServletRequest req = sling.getRequest();
 
+            String resourcePath = StringUtils.removeEnd(resource.getPath(),resource.getName());
+
+            Resource res = resource.getResourceResolver().resolve(req , resourcePath);
+
+
+            final String path = errorPageHandlerService.findErrorPage(slingRequest, res);
+
+           
             if (path != null) {
                 slingResponse.setStatus(404);
                 errorPageHandlerService.includeUsingGET(slingRequest, slingResponse, path);
                 return;
+
+
+                
             }
         }
     }


### PR DESCRIPTION
…eneric error. Fix this behavior by providing the absolute of the parent page so that resource can be mapped correctly.