### PR TITLE
Component Error Handler / Error Page Handler Collision

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/ComponentErrorHandlerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/ComponentErrorHandlerImpl.java
@@ -164,7 +164,7 @@ public class ComponentErrorHandlerImpl implements ComponentErrorHandler, Filter 
     @Property(label = "Suppressed Resource Types",
             description = "Resource types this Filter will ignore during Sling Includes.",
             cardinality = Integer.MAX_VALUE,
-            value = { })
+            value = {})
     public static final String PROP_SUPPRESSED_RESOURCE_TYPES = "suppress-resource-types";
 
 
@@ -173,8 +173,12 @@ public class ComponentErrorHandlerImpl implements ComponentErrorHandler, Filter 
     }
 
     @Override
-    public final void doFilter(ServletRequest request, ServletResponse response,
+    public final void doFilter(ServletRequest servletRequest, ServletResponse servletResponse,
                                FilterChain chain) throws IOException, ServletException {
+
+        // We are in a Sling Filter, so these request/response objects are guarenteed to be of type Sling...
+        final SlingHttpServletRequest request = (SlingHttpServletRequest) servletRequest;
+        final SlingHttpServletResponse response = (SlingHttpServletResponse) servletResponse;
 
         if (!this.accepts(request, response)) {
             chain.doFilter(request, response);
@@ -294,10 +298,23 @@ public class ComponentErrorHandlerImpl implements ComponentErrorHandler, Filter 
         return "";
     }
 
-    protected final boolean accepts(final ServletRequest request, final ServletResponse response) {
-        // Ensure we are dealing with Sling Requests/Responses
-        if (!(request instanceof SlingHttpServletRequest)
-                || !(response instanceof SlingHttpServletResponse)) {
+    protected final boolean accepts(final SlingHttpServletRequest request, final SlingHttpServletResponse response) {
+
+        if (!StringUtils.endsWith(request.getRequestURI(), ".html") ||
+                !StringUtils.contains(response.getContentType(), "html")) {
+            // Do not inject around non-HTML requests
+            return false;
+        }
+
+        final ComponentContext componentContext = WCMUtils.getComponentContext(request);
+        if (componentContext == null) {
+            // ComponentContext is null
+            return false;
+        } else if (componentContext.getComponent() == null) {
+            // Component is null
+            return false;
+        } else if (componentContext.isRoot()) {
+            // Suppress on root context
             return false;
         }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/ComponentErrorHandlerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/ComponentErrorHandlerImpl.java
@@ -188,12 +188,7 @@ public class ComponentErrorHandlerImpl implements ComponentErrorHandler, Filter 
         final SlingHttpServletRequest slingRequest = (SlingHttpServletRequest) request;
         final SlingHttpServletResponse slingResponse = (SlingHttpServletResponse) response;
 
-        final ComponentContext componentContext = WCMUtils.getComponentContext(request);
-
-        if (componentContext == null
-                || componentContext.isRoot()) {
-            chain.doFilter(request, response);
-        } else if (editModeEnabled
+        if (editModeEnabled
                 && (componentHelper.isEditMode(slingRequest)
                 || componentHelper.isDesignMode(slingRequest)
                 || WCMMode.ANALYTICS.equals(WCMMode.fromRequest(slingRequest)))) {

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/ComponentErrorHandlerImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/ComponentErrorHandlerImplTest.java
@@ -22,6 +22,7 @@ package com.adobe.acs.commons.wcm.impl;
 
 import com.adobe.acs.commons.wcm.ComponentErrorHandler;
 import com.adobe.acs.commons.wcm.ComponentHelper;
+import com.day.cq.wcm.api.components.Component;
 import com.day.cq.wcm.api.components.ComponentContext;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
@@ -46,6 +47,7 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -83,6 +85,7 @@ public class ComponentErrorHandlerImplTest {
     @Before
     public void setUp() throws Exception {
         when(request.getAttribute("com.day.cq.wcm.componentcontext")).thenReturn(componentContext);
+        when(componentContext.getComponent()).thenReturn(mock(Component.class));
         when(request.getResource()).thenReturn(resource);
 
         when(resource.getPath()).thenReturn("/content/test");
@@ -90,6 +93,9 @@ public class ComponentErrorHandlerImplTest {
         when(resource.isResourceType("acs-commons/test/demo")).thenReturn(true);
 
         when(response.getWriter()).thenReturn(responseWriter);
+        
+        when(request.getRequestURI()).thenReturn("/content/page.html");
+        when(response.getContentType()).thenReturn("text/html");
     }
 
     @After


### PR DESCRIPTION
Resolves #535 

CEH should not listen on errors that occur in root component context.
Also added a check to only respond to HTML requests.
