### PR TITLE
Feature/519 sreek

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
@@ -170,7 +170,12 @@ ACS.CQ.MultiFieldPanel = CQ.Ext.extend(CQ.Ext.Panel, {
         var valid = true;
 
         this.items.each(function(i){
-            if(i.xtype === "label" || i.xtype === "hidden" || !i.hasOwnProperty("key")){
+            if(!i.hasOwnProperty("key")){
+                return;
+            }
+
+            if(!i.isVisible()){
+                i.allowBlank = true;
                 return;
             }
 

--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
@@ -167,7 +167,19 @@ ACS.CQ.MultiFieldPanel = CQ.Ext.extend(CQ.Ext.Panel, {
     },
 
     validate: function(){
-        return true;
+        var valid = true;
+
+        this.items.each(function(i){
+            if(i.xtype === "label" || i.xtype === "hidden" || !i.hasOwnProperty("key")){
+                return;
+            }
+
+            if(!i.validate()){
+                valid = false;
+            }
+        });
+
+        return valid;
     },
 
     getName: function(){

--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
@@ -53,7 +53,8 @@ ACS.CQ.MultiFieldPanel = CQ.Ext.extend(CQ.Ext.Panel, {
 
         this.add(this.panelValue);
 
-        var dialog = this.findParentByType('dialog');
+        var multifield = this.findParentByType('multifield'),
+            dialog = this.findParentByType('dialog');
 
         dialog.on('beforesubmit', function(){
             var value = this.getValue();
@@ -62,6 +63,40 @@ ACS.CQ.MultiFieldPanel = CQ.Ext.extend(CQ.Ext.Panel, {
                 this.panelValue.setValue(value);
             }
         },this);
+
+        dialog.on('loadcontent', function(){
+            if(_.isEmpty(multifield.dropTargets)){
+                multifield.dropTargets = [];
+            }
+
+            multifield.dropTargets = multifield.dropTargets.concat(this.getDropTargets());
+
+            _.each(multifield.dropTargets, function(target){
+                if (!target.highlight) {
+                    return;
+                }
+
+                var dialogZIndex = parseInt(dialog.el.getStyle("z-index"), 10);
+
+                if (!isNaN(dialogZIndex)) {
+                    target.highlight.zIndex = dialogZIndex + 1;
+                }
+            });
+        }, this);
+
+        if(dialog.acsInit){
+            return;
+        }
+
+        dialog.on('hide', function(){
+            var editable = CQ.utils.WCM.getEditables()[this.path];
+
+            //dialog caching is a real pain when there are multifield items; donot cache
+            delete editable.dialogs[CQ.wcm.EditBase.EDIT];
+            delete CQ.WCM.getDialogs()["editdialog-" + this.path];
+        }, dialog);
+
+        dialog.acsInit = true;
     },
 
     afterRender : function(){
@@ -101,7 +136,29 @@ ACS.CQ.MultiFieldPanel = CQ.Ext.extend(CQ.Ext.Panel, {
             }
 
             i.setValue(pData[i.key]);
+
+            i.fireEvent('loadcontent', this);
         });
+    },
+
+    getDropTargets : function() {
+        var targets = [], t;
+
+        this.items.each(function(){
+            if(!this.getDropTargets){
+                return;
+            }
+
+            t = this.getDropTargets();
+
+            if(_.isEmpty(t)){
+                return;
+            }
+
+            targets = targets.concat(t);
+        });
+
+        return targets;
     },
 
     validate: function(){
@@ -113,4 +170,28 @@ ACS.CQ.MultiFieldPanel = CQ.Ext.extend(CQ.Ext.Panel, {
     }
 });
 
-CQ.Ext.reg("multifieldpanel", ACS.CQ.MultiFieldPanel);	
+CQ.Ext.reg("multifieldpanel", ACS.CQ.MultiFieldPanel);
+
+//test function for intelsecurity loadcontent bugfix, not part of acs aem commons
+ACS.CQ.TestLoadStatesFn = function(){
+    var cValue = this.getValue(),
+        panel = this.findParentByType('multifieldpanel'),
+        state = panel.getComponent('state');
+
+    state.setValue(null);
+
+    if(_.isEmpty(cValue)){
+        return;
+    }
+
+    var india = [   { value : "TELANGANA", text : "Telangana"},
+            { value : "ANDHRA", text : "Andhra" }],
+        usa = [   { value : "TEXAS", text : "Texas"},
+            { value : "FLORIDA", text : "Florida" } ];
+
+    if(cValue == "INDIA"){
+        state.setOptions(india);
+    }else if(cValue == "USA"){
+        state.setOptions(usa);
+    }
+};

--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
@@ -32,6 +32,11 @@ CQ.Ext.ns("ACS.CQ");
 ACS.CQ.MultiFieldPanel = CQ.Ext.extend(CQ.Ext.Panel, {
     panelValue: '',
 
+    /**
+     * @constructor
+     * Creates a new MultiFieldPanel.
+     * @param {Object} config The config object
+     */
     constructor: function(config){
         config = config || {};
         if (!config.layout) {

--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
@@ -19,6 +19,7 @@
  */
 /*global CQ: false, ACS: false */
 CQ.Ext.ns("ACS.CQ"); 
+
 /**
  * @class ACS.CQ.MultiFieldPanel
  * @extends CQ.form.Panel
@@ -27,14 +28,10 @@ CQ.Ext.ns("ACS.CQ");
  * key/value pairs serialized as a JSON object. The keys for each pair is defined by setting the
  * 'key' property on the field.</p>
  */
+
 ACS.CQ.MultiFieldPanel = CQ.Ext.extend(CQ.Ext.Panel, {
     panelValue: '',
 
-    /**
-     * @constructor
-     * Creates a new MultiFieldPanel.
-     * @param {Object} config The config object
-     */
     constructor: function(config){
         config = config || {};
         if (!config.layout) {
@@ -88,10 +85,18 @@ ACS.CQ.MultiFieldPanel = CQ.Ext.extend(CQ.Ext.Panel, {
             return;
         }
 
+        var tabPanel = multifield.findParentByType("tabpanel");
+
+        if(tabPanel){
+            tabPanel.on("tabchange", function(panel){
+                panel.doLayout();
+            });
+        }
+
         dialog.on('hide', function(){
             var editable = CQ.utils.WCM.getEditables()[this.path];
 
-            //dialog caching is a real pain when there are multifield items; donot cache
+            //dialog caching is a real pain when there are multifield items; remove from cache
             delete editable.dialogs[CQ.wcm.EditBase.EDIT];
             delete CQ.WCM.getDialogs()["editdialog-" + this.path];
         }, dialog);
@@ -171,27 +176,3 @@ ACS.CQ.MultiFieldPanel = CQ.Ext.extend(CQ.Ext.Panel, {
 });
 
 CQ.Ext.reg("multifieldpanel", ACS.CQ.MultiFieldPanel);
-
-//test function for intelsecurity loadcontent bugfix, not part of acs aem commons
-ACS.CQ.TestLoadStatesFn = function(){
-    var cValue = this.getValue(),
-        panel = this.findParentByType('multifieldpanel'),
-        state = panel.getComponent('state');
-
-    state.setValue(null);
-
-    if(_.isEmpty(cValue)){
-        return;
-    }
-
-    var india = [   { value : "TELANGANA", text : "Telangana"},
-            { value : "ANDHRA", text : "Andhra" }],
-        usa = [   { value : "TEXAS", text : "Texas"},
-            { value : "FLORIDA", text : "Florida" } ];
-
-    if(cValue == "INDIA"){
-        state.setOptions(india);
-    }else if(cValue == "USA"){
-        state.setOptions(usa);
-    }
-};


### PR DESCRIPTION
Bug Fixes for McAfee

1) Drag and Drop Issue: drag and drop to pathfield (in multifield) doesn't work when a component dialog is reopened without refreshing the page

2) Shrink Issue:  widgets added in multifield in a tab other than the visible one, shrink...

3) LoadContent Issue: Loadcontent event doesn;t fire on widgets added in multifield

4) Allow Blank Issue:  validation issues for widgets added in multifield

check the following two code statements; when a multifield is added, the component dialog isn't cached anymore, so every double click creates new dialog window...

            //dialog caching is a real pain when there are multifield items; remove from cache
            delete editable.dialogs[CQ.wcm.EditBase.EDIT];
            delete CQ.WCM.getDialogs()["editdialog-" + this.path];
