### PR TITLE
add a Page Info Provider which filters the available workflow models …

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/WorkflowModelFilterPageInfoProvider.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/WorkflowModelFilterPageInfoProvider.java
@@ -52,7 +52,7 @@ public class WorkflowModelFilterPageInfoProvider implements PageInfoProvider {
 
     private static final String KEY_WORKFLOWS = "workflows";
 
-    private static final String PN_APPLIES_TO = "appliesTo";
+    private static final String PN_APPLIES_TO_PATH = "appliesToPath";
 
     private static final Logger log = LoggerFactory.getLogger(WorkflowModelFilterPageInfoProvider.class);
 
@@ -84,7 +84,7 @@ public class WorkflowModelFilterPageInfoProvider implements PageInfoProvider {
                 // we're looking for the appliesTo property on the jcr:content node, the wid value
                 // is the path to the jcr:content/model node.
                 final ValueMap properties = modelResource.getParent().getValueMap();
-                final String[] appliesTo = properties.get(PN_APPLIES_TO, String[].class);
+                final String[] appliesTo = properties.get(PN_APPLIES_TO_PATH, String[].class);
                 if (appliesTo == null) {
                     newModels.put(modelObject);
                 } else {

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/WorkflowModelFilterPageInfoProvider.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/WorkflowModelFilterPageInfoProvider.java
@@ -1,0 +1,98 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.wcm.impl;
+
+import java.util.Iterator;
+
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.commons.json.JSONArray;
+import org.apache.sling.commons.json.JSONException;
+import org.apache.sling.commons.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.day.cq.wcm.api.PageInfoProvider;
+
+/**
+ * PageInfoProvider which filters the Workflow models available for a
+ * page based on a regular expression in the "applyTo" property on a workflow
+ * model's jcr:content node.
+ * 
+ * Must run <b>after</b> <code>com.day.cq.wcm.core.impl.DefaultPageStatusProvider</code>
+ */
+@Component
+@Service
+public class WorkflowModelFilterPageInfoProvider implements PageInfoProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(WorkflowModelFilterPageInfoProvider.class);
+
+    private static final String KEY_WORKFLOWS = "workflows";
+
+    @Override
+    public void updatePageInfo(SlingHttpServletRequest request, JSONObject info, Resource resource)
+            throws JSONException {
+        if (info.has(KEY_WORKFLOWS)) {
+            final JSONObject workflows = info.getJSONObject(KEY_WORKFLOWS);
+            final String resourcePath = resource.getPath();
+            final ResourceResolver resourceResolver = resource.getResourceResolver();
+            for (final Iterator<String> types = workflows.keys(); types.hasNext();) {
+                final String type = types.next();
+                final JSONObject typeObject = workflows.getJSONObject(type);
+                filter(typeObject, resourcePath, resourceResolver);
+            }
+        } else {
+            log.warn("No workflows found in existing page info. Check order of cq:infoProviders.");
+        }
+    }
+
+    private void filter(JSONObject typeObject, String resourcePath, ResourceResolver resourceResolver) throws JSONException {
+        final JSONArray models = typeObject.getJSONArray("models");
+        final JSONArray newModels = new JSONArray();
+        for (int i = 0; i < models.length(); i++) {
+            final JSONObject modelObject = models.getJSONObject(i);
+            final String path = modelObject.getString("wid");
+            final Resource modelResource = resourceResolver.getResource(path);
+            if (modelResource != null) {
+                // we're looking for the appliesTo property on the jcr:content node, the wid value
+                // is the path to the jcr:content/model node.
+                final ValueMap properties = modelResource.getParent().getValueMap();
+                final String[] appliesTo = properties.get("appliesTo", String[].class);
+                if (appliesTo == null) {
+                    newModels.put(modelObject);
+                } else {
+                    for (final String appliesToValue : appliesTo) {
+                        if (resourcePath.matches(appliesToValue)) {
+                            newModels.put(modelObject);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        
+        typeObject.put("models", newModels);
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/WorkflowModelFilterPageInfoProvider.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/WorkflowModelFilterPageInfoProvider.java
@@ -52,7 +52,7 @@ public class WorkflowModelFilterPageInfoProvider implements PageInfoProvider {
 
     private static final String KEY_WORKFLOWS = "workflows";
 
-    private static final String PN_APPLIES_TO_PATH = "appliesToPath";
+    private static final String PN_ALLOWED_PATHS = "allowedPaths";
 
     private static final Logger log = LoggerFactory.getLogger(WorkflowModelFilterPageInfoProvider.class);
 
@@ -84,12 +84,12 @@ public class WorkflowModelFilterPageInfoProvider implements PageInfoProvider {
                 // we're looking for the appliesTo property on the jcr:content node, the wid value
                 // is the path to the jcr:content/model node.
                 final ValueMap properties = modelResource.getParent().getValueMap();
-                final String[] appliesTo = properties.get(PN_APPLIES_TO_PATH, String[].class);
-                if (appliesTo == null) {
+                final String[] allowedPaths = properties.get(PN_ALLOWED_PATHS, String[].class);
+                if (allowedPaths == null) {
                     newModels.put(modelObject);
                 } else {
-                    for (final String appliesToValue : appliesTo) {
-                        if (resourcePath.matches(appliesToValue)) {
+                    for (final String allowedPath : allowedPaths) {
+                        if (resourcePath.matches(allowedPath)) {
                             newModels.put(modelObject);
                             break;
                         }

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/WorkflowModelFilterPageInfoProvider.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/WorkflowModelFilterPageInfoProvider.java
@@ -46,9 +46,15 @@ import com.day.cq.wcm.api.PageInfoProvider;
 @Service
 public class WorkflowModelFilterPageInfoProvider implements PageInfoProvider {
 
-    private static final Logger log = LoggerFactory.getLogger(WorkflowModelFilterPageInfoProvider.class);
+    private static final String KEY_MODELS = "models";
+
+    private static final String KEY_MODEL_PATH = "wid";
 
     private static final String KEY_WORKFLOWS = "workflows";
+
+    private static final String PN_APPLIES_TO = "appliesTo";
+
+    private static final Logger log = LoggerFactory.getLogger(WorkflowModelFilterPageInfoProvider.class);
 
     @Override
     public void updatePageInfo(SlingHttpServletRequest request, JSONObject info, Resource resource)
@@ -68,17 +74,17 @@ public class WorkflowModelFilterPageInfoProvider implements PageInfoProvider {
     }
 
     private void filter(JSONObject typeObject, String resourcePath, ResourceResolver resourceResolver) throws JSONException {
-        final JSONArray models = typeObject.getJSONArray("models");
+        final JSONArray models = typeObject.getJSONArray(KEY_MODELS);
         final JSONArray newModels = new JSONArray();
         for (int i = 0; i < models.length(); i++) {
             final JSONObject modelObject = models.getJSONObject(i);
-            final String path = modelObject.getString("wid");
+            final String path = modelObject.getString(KEY_MODEL_PATH);
             final Resource modelResource = resourceResolver.getResource(path);
             if (modelResource != null) {
                 // we're looking for the appliesTo property on the jcr:content node, the wid value
                 // is the path to the jcr:content/model node.
                 final ValueMap properties = modelResource.getParent().getValueMap();
-                final String[] appliesTo = properties.get("appliesTo", String[].class);
+                final String[] appliesTo = properties.get(PN_APPLIES_TO, String[].class);
                 if (appliesTo == null) {
                     newModels.put(modelObject);
                 } else {
@@ -92,7 +98,7 @@ public class WorkflowModelFilterPageInfoProvider implements PageInfoProvider {
             }
         }
         
-        typeObject.put("models", newModels);
+        typeObject.put(KEY_MODELS, newModels);
     }
 
 }


### PR DESCRIPTION
…for a page

To use this:

* Create a node (if it doesn't already exists) called `cq:infoProviders` under your base page component.
* Under this node, create a new node with a property named `className` set to `com.adobe.acs.commons.wcm.impl.WorkflowModelFilterPageInfoProvider`. (there's no need to copy the default providers from `/libs/foundation/components/page/cq:infoProviders`)
* In your workflow models, on their jcr:content node, specify a property named `allowedPaths` containing a regex matching the paths for which you want this model to appear. If there is no `allowedPaths` property, the model will always appear.

More information on the underlying functionality can be found here: https://docs.adobe.com/docs/en/aem/6-1/develop/components/pageinfo.html