### PR TITLE
Ensure max limit is checked on form validation

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/add_multifield_limit.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/add_multifield_limit.js
@@ -44,6 +44,12 @@
                     return false;
                 }
             }
+            if (this.maxItems) {
+                if (this.getActualItemCount() > this.maxItems) {
+                    this.markInvalid(CQ.I18n.get('You are only allowed to add {0} items to this field', [this.maxItems]));
+                    return false;
+                }
+            }
             
             return originalValidateFunction.apply(this);
         },


### PR DESCRIPTION
Currently if an author surpasses the max limit on a multipanel (eg. the limit was added after the content was first created) then the max limit is not respected and the author is able to submit a an invalid form. This change runs the max limit check during validation, just like the min limit already operates.