### PR TITLE
Letter/Pillar box support

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/images/transformers/impl/LetterPillarBoxImageTransformerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/images/transformers/impl/LetterPillarBoxImageTransformerImpl.java
@@ -1,0 +1,232 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.images.transformers.impl;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.util.Map;
+
+import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.commons.osgi.PropertiesUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.acs.commons.images.ImageTransformer;
+import com.day.image.Layer;
+
+/**
+ * ACS AEM Commons - Image Transformer - Letter/Piller Box ImageTransformer that
+ * resizes the layer. Accepts two Integer params: height and width. If either is
+ * left blank the missing dimension will be computed based on the original
+ * layer's aspect ratio. If the newly resized image does not fit into the
+ * original dimensions, this will create a background layer
+ */
+//@formatter:off
+@Component
+@Properties({
+        @Property(
+                name = ImageTransformer.PROP_TYPE,
+                value = LetterPillarBoxImageTransformerImpl.TYPE
+        )
+})
+@Service
+//@formatter:on
+public class LetterPillarBoxImageTransformerImpl implements ImageTransformer {
+    private static final Logger log = LoggerFactory.getLogger(LetterPillarBoxImageTransformerImpl.class);
+
+    static final String TYPE = "letter-piller-box";
+
+    private static final String KEY_WIDTH = "width";
+    private static final String KEY_WIDTH_ALIAS = "w";
+
+    private static final String KEY_HEIGHT = "height";
+    private static final String KEY_HEIGHT_ALIAS = "h";
+
+    private static final String KEY_ALPHA = "alpha";
+    private static final String KEY_ALPHA_ALIAS = "a";
+
+    private static final String KEY_COLOR = "color";
+    private static final String KEY_COLOR_ALIAS = "c";
+
+    private static final Color TRANSPARENT = new Color(255, 255, 255, 0);
+
+    private static final int DEFAULT_MAX_DIMENSION = 50000;
+    private int maxDimension = DEFAULT_MAX_DIMENSION;
+    @Property(label = "Max dimension in px",
+            description = "Maximum size height and width can be re-sized to. [ Default: 50000 ]",
+            intValue = DEFAULT_MAX_DIMENSION)
+    public static final String PROP_MAX_DIMENSION = "max-dimension";
+
+    @Override
+    public final Layer transform(final Layer layer, final ValueMap properties) {
+
+        if ((properties == null) || properties.isEmpty()) {
+            log.warn("Transform [ {} ] requires parameters.", TYPE);
+            return layer;
+        }
+
+        log.debug("Transforming with [ {} ]", TYPE);
+
+        Dimension newSize = getResizeDimensions(properties, layer);
+        Color color = getColor(properties);
+        Layer resized = resize(layer, newSize);
+
+        Layer result = build(newSize, resized, color);
+
+        return result;
+    }
+
+    /*
+     * Creates the actual piller/letter boxing.
+     */
+    private Layer build(Dimension size, Layer img, Color color) {
+
+        Layer merged = new Layer(size.width, size.height, color);
+
+        int startXpos = 0;
+        int startYpos = 0;
+        if (img.getHeight() == size.height) {
+            // Pillar
+            startXpos = calculateStartPosition(size.width, img.getWidth());
+        } else if (img.getWidth() == size.width) {
+            // Letter
+            startYpos = calculateStartPosition(size.height, img.getHeight());
+        }
+
+        merged.blit(img, startXpos, startYpos, img.getWidth(), img.getHeight(), 0, 0);
+        return merged;
+    }
+
+    /*
+     * Resizes the layer but keeps original aspect ratio. Thus preparing it for
+     * the boxing.
+     */
+    private Layer resize(Layer original, Dimension newDimensions) {
+
+        final Dimension origDimensions = new Dimension(original.getWidth(), original.getHeight());
+        final int fixedDimension = getFixedDimension(origDimensions, newDimensions);
+        int newWidth = newDimensions.width;
+        int newHeight = newDimensions.height;
+
+        if (fixedDimension < 0) {
+
+            // Height is "fixed", calculate width
+            newWidth = (origDimensions.width * newDimensions.height) / origDimensions.height;
+        } else if (fixedDimension > 0) {
+
+            // Width is "fixed", calculate height
+            newHeight = (newDimensions.width * origDimensions.height) / origDimensions.width;
+        }
+
+        original.resize(newWidth, newHeight);
+        return original;
+    }
+
+    /*
+     * Calculates whether width or height is being used for resize basis.
+     *
+     * Returns an indicator value on which dimension is the "fixed" dimension
+     *
+     * Zero if the aspect ratios are the same Negative if the width should be
+     * fixed Positive if the height should be fixed
+     *
+     * @param start the dimensions of the original image
+     *
+     * @param end the dimensions of the final image
+     *
+     * @return a value indicating which dimension is fixed
+     */
+    private int getFixedDimension(Dimension start, Dimension end) {
+        double startRatio = start.getWidth() / start.getHeight();
+        double finalRatio = end.getWidth() / end.getHeight();
+        return Double.compare(startRatio, finalRatio);
+    }
+
+    private Dimension getResizeDimensions(final ValueMap properties, final Layer layer) {
+
+        int width = properties.get(KEY_WIDTH, properties.get(KEY_WIDTH_ALIAS, 0));
+        int height = properties.get(KEY_HEIGHT, properties.get(KEY_HEIGHT_ALIAS, 0));
+
+        if (width > maxDimension) {
+            width = maxDimension;
+        }
+
+        if (height > maxDimension) {
+            height = maxDimension;
+        }
+
+        if ((width < 1) && (height < 1)) {
+            width = layer.getWidth();
+            height = layer.getHeight();
+        } else if (width < 1) {
+            final float aspect = (float) height / layer.getHeight();
+            width = Math.round(layer.getWidth() * aspect);
+        } else if (height < 1) {
+            final float aspect = (float) width / layer.getWidth();
+            height = Math.round(layer.getHeight() * aspect);
+        }
+        return new Dimension(width, height);
+    }
+
+    private Color getColor(final ValueMap properties) {
+        String hexcolor = properties.get(KEY_COLOR, properties.get(KEY_COLOR_ALIAS, String.class));
+        float alpha = normalizeAlpha(properties.get(KEY_ALPHA, properties.get(KEY_ALPHA_ALIAS, 0.0)).floatValue());
+
+        Color color = null;
+        if (hexcolor != null) {
+            try {
+                Color parsed = Color.decode("0x" + hexcolor);
+                color = new Color(parsed.getRed(), parsed.getGreen(), parsed.getBlue(), alpha);
+            } catch (NumberFormatException ex) {
+                log.warn("Invalid hex color specified: {}", hexcolor);
+                color = TRANSPARENT;
+            }
+        }
+        return color;
+    }
+
+    private float normalizeAlpha(float alpha) {
+        if (alpha > 1) {
+            alpha = 1f;
+        } else if (alpha < 0) {
+            alpha = 0f;
+        }
+
+        return alpha;
+    }
+
+    private int calculateStartPosition(int originalSize, int newSize) {
+        int diff = originalSize - newSize;
+        int start = diff / 2;
+        return start;
+    }
+
+    @Activate
+    protected final void activate(final Map<String, String> config) {
+        maxDimension = PropertiesUtil.toInteger(config.get(PROP_MAX_DIMENSION), DEFAULT_MAX_DIMENSION);
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/images/transformers/impl/LetterPillarBoxImageTransformerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/images/transformers/impl/LetterPillarBoxImageTransformerImpl.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,7 +38,7 @@ import com.adobe.acs.commons.images.ImageTransformer;
 import com.day.image.Layer;
 
 /**
- * ACS AEM Commons - Image Transformer - Letter/Piller Box ImageTransformer that
+ * ACS AEM Commons - Image Transformer - Letter/Pillar Box ImageTransformer that
  * resizes the layer. Accepts two Integer params: height and width. If either is
  * left blank the missing dimension will be computed based on the original
  * layer's aspect ratio. If the newly resized image does not fit into the
@@ -102,7 +102,7 @@ public class LetterPillarBoxImageTransformerImpl implements ImageTransformer {
     }
 
     /*
-     * Creates the actual piller/letter boxing.
+     * Creates the actual pillar/letter boxing.
      */
     private Layer build(Dimension size, Layer img, Color color) {
 

--- a/bundle/src/test/java/com/adobe/acs/commons/images/transformers/impl/LetterPillarBoxImageTransformerImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/images/transformers/impl/LetterPillarBoxImageTransformerImplTest.java
@@ -1,0 +1,159 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.images.transformers.impl;
+
+import static org.mockito.Mockito.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.day.image.Layer;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LetterPillarBoxImageTransformerImplTest {
+    LetterPillarBoxImageTransformerImpl transformer;
+
+    @Mock
+    Layer layer;
+
+    Map<String, Object> map = null;
+
+    @Before
+    public void setUp() throws Exception {
+        map = new HashMap<String, Object>();
+        transformer = new LetterPillarBoxImageTransformerImpl();
+
+        when(layer.getWidth()).thenReturn(1600);
+        when(layer.getHeight()).thenReturn(900);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        map = null;
+        reset(layer);
+    }
+
+    @Test
+    public void testTransform() throws Exception {
+        final int width = 100;
+        final int height = 200;
+
+        map.put("width", width);
+        map.put("height", height);
+        ValueMap properties = new ValueMapDecorator(map);
+
+        transformer.transform(layer, properties);
+
+        verify(layer, times(1)).resize(width, height);
+        verifyNoMoreInteractions(layer);
+    }
+
+    @Test
+    public void testTransform_onlyWidth() throws Exception {
+        final int width = 160;
+
+        map.put("width", width);
+        ValueMap properties = new ValueMapDecorator(map);
+
+        transformer.transform(layer, properties);
+
+        verify(layer, times(1)).resize(width, 90);
+    }
+
+    @Test
+    public void testTransform_onlyHeight() throws Exception {
+        final int height = 90;
+
+        map.put("height", height);
+        ValueMap properties = new ValueMapDecorator(map);
+
+        transformer.transform(layer, properties);
+
+        verify(layer, times(1)).resize(160, height);
+    }
+
+    @Test
+    public void testTransform_invalidHeightAndWidth() throws Exception {
+        final int width = -100;
+        final int height = -200;
+
+        map.put("width", width);
+        map.put("height", height);
+        ValueMap properties = new ValueMapDecorator(map);
+
+        transformer.transform(layer, properties);
+
+        verify(layer, times(1)).resize(1600, 900);
+    }
+
+    @Test
+    public void testTransform_invalidWifth() throws Exception {
+        final int width = -100;
+        final int height = 90;
+
+        map.put("width", width);
+        map.put("height", height);
+        ValueMap properties = new ValueMapDecorator(map);
+
+        transformer.transform(layer, properties);
+
+        verify(layer, times(1)).resize(160, height);
+    }
+
+    @Test
+    public void testTransform_invalidHeight() throws Exception {
+        final int width = 160;
+        final int height = -100;
+
+        map.put("width", width);
+        map.put("height", height);
+        ValueMap properties = new ValueMapDecorator(map);
+
+        transformer.transform(layer, properties);
+
+        verify(layer, times(1)).resize(width, 90);
+    }
+
+    @Test
+    public void testTransform_emptyParams() throws Exception {
+        ValueMap properties = new ValueMapDecorator(map);
+
+        transformer.transform(layer, properties);
+
+        verifyZeroInteractions(layer);
+    }
+
+    @Test
+    public void testTransform_nullParams() throws Exception {
+        transformer.transform(layer, null);
+
+        verifyZeroInteractions(layer);
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/images/transformers/impl/LetterPillarBoxImageTransformerImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/images/transformers/impl/LetterPillarBoxImageTransformerImplTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,10 +20,15 @@
 
 package com.adobe.acs.commons.images.transformers.impl;
 
+import static junit.framework.Assert.*;
+import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
+import java.awt.Color;
+import java.awt.Paint;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
@@ -31,12 +36,18 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Matchers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
 import com.day.image.Layer;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(LetterPillarBoxImageTransformerImpl.class)
 public class LetterPillarBoxImageTransformerImplTest {
     LetterPillarBoxImageTransformerImpl transformer;
 
@@ -45,13 +56,14 @@ public class LetterPillarBoxImageTransformerImplTest {
 
     Map<String, Object> map = null;
 
+    private static final int START_WIDTH = 1600;
+    private static final int START_HEIGHT = 900;
+
     @Before
     public void setUp() throws Exception {
         map = new HashMap<String, Object>();
         transformer = new LetterPillarBoxImageTransformerImpl();
 
-        when(layer.getWidth()).thenReturn(1600);
-        when(layer.getHeight()).thenReturn(900);
     }
 
     @After
@@ -61,42 +73,198 @@ public class LetterPillarBoxImageTransformerImplTest {
     }
 
     @Test
-    public void testTransform() throws Exception {
-        final int width = 100;
-        final int height = 200;
+    public void testTransform_withColor() throws Exception {
+        final int width = 400;
+        final int height = 225;
+        final String color = "ABCDEF";
+        final float alpha = 0.5f;
+
+        final int alphaint = Math.round(255 * alpha);
+        Color expected = new Color(171, 205, 239, alphaint);
+
+        map.put("width", width);
+        map.put("height", height);
+        map.put("color", color);
+        map.put("alpha", alpha);
+        ValueMap properties = new ValueMapDecorator(map);
+
+        final Layer mockLayer = mock(Layer.class);
+
+        final AtomicReference<Layer> resultLayer = new AtomicReference<Layer>();
+        PowerMockito.whenNew(Layer.class).withParameterTypes(int.class, int.class, Paint.class)
+                .withArguments(anyInt(), anyInt(), Matchers.eq(expected)).thenAnswer(new Answer<Layer>() {
+                    @Override
+                    public Layer answer(InvocationOnMock invocation) throws Throwable {
+                        resultLayer.set(mockLayer);
+                        return mockLayer;
+                    }
+                });
+
+        when(layer.getWidth()).thenReturn(START_WIDTH, START_WIDTH, width);
+        when(layer.getHeight()).thenReturn(START_HEIGHT, START_HEIGHT, height);
+
+        doNothing().when(mockLayer).blit(any(Layer.class), anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt());
+
+        transformer.transform(layer, properties);
+
+        assertNotNull("Layer constructor was not intercepted.", resultLayer.get());
+        verify(layer, times(3)).getWidth();
+        verify(layer, times(3)).getHeight();
+        verify(layer, times(1)).resize(width, height);
+        verify(mockLayer, times(1)).blit(layer, 0, 0, width, height, 0, 0);
+        verifyNoMoreInteractions(layer);
+        verifyNoMoreInteractions(mockLayer);
+    }
+
+    @Test
+    public void testTransform_withLetterBoxing() throws Exception {
+        final int width = 600;
+        final int height = 600;
+
+        final int calcHeight = 338;
+        final int startPos = (width - calcHeight) / 2;
 
         map.put("width", width);
         map.put("height", height);
         ValueMap properties = new ValueMapDecorator(map);
 
+        final Layer mockLayer = mock(Layer.class);
+
+        final AtomicReference<Layer> resultLayer = setupMockLayer(mockLayer);
+
+        when(layer.getWidth()).thenReturn(START_WIDTH, START_WIDTH, width);
+        when(layer.getHeight()).thenReturn(START_HEIGHT, START_HEIGHT, calcHeight);
+
+        doNothing().when(mockLayer).blit(any(Layer.class), anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt());
+
         transformer.transform(layer, properties);
 
-        verify(layer, times(1)).resize(width, height);
+        assertNotNull("Layer constructor was not intercepted.", resultLayer.get());
+        verify(layer, times(3)).getWidth();
+        verify(layer, times(3)).getHeight();
+        verify(layer, times(1)).resize(width, calcHeight);
+        verify(mockLayer, times(1)).blit(layer, 0, startPos, width, calcHeight, 0, 0);
         verifyNoMoreInteractions(layer);
+        verifyNoMoreInteractions(mockLayer);
+    }
+
+    @Test
+    public void testTransform_withPillarBoxing() throws Exception {
+        final int width = 600;
+        final int height = 600;
+
+        final int calcWidth = 338;
+        final int startPos = (width - calcWidth) / 2;
+
+        map.put("width", width);
+        map.put("height", height);
+        ValueMap properties = new ValueMapDecorator(map);
+
+        final Layer mockLayer = mock(Layer.class);
+
+        final AtomicReference<Layer> resultLayer = setupMockLayer(mockLayer);
+
+        // Don't get confused, switching the dimensions forces Pillar boxing.
+        when(layer.getWidth()).thenReturn(START_HEIGHT, START_HEIGHT, calcWidth);
+        when(layer.getHeight()).thenReturn(START_WIDTH, START_WIDTH, height);
+
+        doNothing().when(mockLayer).blit(any(Layer.class), anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt());
+
+        transformer.transform(layer, properties);
+
+        assertNotNull("Layer constructor was not intercepted.", resultLayer.get());
+        verify(layer, times(3)).getWidth();
+        verify(layer, times(3)).getHeight();
+        verify(layer, times(1)).resize(calcWidth, height);
+        verify(mockLayer, times(1)).blit(layer, startPos, 0, calcWidth, height, 0, 0);
+        verifyNoMoreInteractions(layer);
+        verifyNoMoreInteractions(mockLayer);
+    }
+
+    @Test
+    public void testTransform() throws Exception {
+        final int width = 400;
+        final int height = 225;
+
+        map.put("width", width);
+        map.put("height", height);
+        ValueMap properties = new ValueMapDecorator(map);
+
+        final Layer mockLayer = mock(Layer.class);
+
+        final AtomicReference<Layer> resultLayer = setupMockLayer(mockLayer);
+
+        when(layer.getWidth()).thenReturn(START_WIDTH, START_WIDTH, width);
+        when(layer.getHeight()).thenReturn(START_HEIGHT, START_HEIGHT, height);
+
+        doNothing().when(mockLayer).blit(any(Layer.class), anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt());
+
+        transformer.transform(layer, properties);
+
+        assertNotNull("Layer constructor was not intercepted.", resultLayer.get());
+        verify(layer, times(3)).getWidth();
+        verify(layer, times(3)).getHeight();
+        verify(layer, times(1)).resize(width, height);
+        verify(mockLayer, times(1)).blit(layer, 0, 0, width, height, 0, 0);
+        verifyNoMoreInteractions(layer);
+        verifyNoMoreInteractions(mockLayer);
+
     }
 
     @Test
     public void testTransform_onlyWidth() throws Exception {
-        final int width = 160;
+        final int width = 400;
+        final int height = 225;
 
         map.put("width", width);
         ValueMap properties = new ValueMapDecorator(map);
 
+        final Layer mockLayer = mock(Layer.class);
+
+        final AtomicReference<Layer> resultLayer = setupMockLayer(mockLayer);
+
+        when(layer.getWidth()).thenReturn(START_WIDTH, START_WIDTH, width);
+        when(layer.getHeight()).thenReturn(START_HEIGHT, START_HEIGHT, height);
+
+        doNothing().when(mockLayer).blit(any(Layer.class), anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt());
+
         transformer.transform(layer, properties);
 
-        verify(layer, times(1)).resize(width, 90);
+        assertNotNull("Layer constructor was not intercepted.", resultLayer.get());
+        verify(layer, times(3)).getWidth();
+        verify(layer, times(3)).getHeight();
+        verify(layer, times(1)).resize(width, height);
+        verify(mockLayer, times(1)).blit(layer, 0, 0, width, height, 0, 0);
+        verifyNoMoreInteractions(layer);
+        verifyNoMoreInteractions(mockLayer);
     }
 
     @Test
     public void testTransform_onlyHeight() throws Exception {
-        final int height = 90;
+        final int width = 400;
+        final int height = 225;
 
         map.put("height", height);
         ValueMap properties = new ValueMapDecorator(map);
 
+        final Layer mockLayer = mock(Layer.class);
+
+        final AtomicReference<Layer> resultLayer = setupMockLayer(mockLayer);
+
+        when(layer.getWidth()).thenReturn(START_WIDTH, START_WIDTH, width);
+        when(layer.getHeight()).thenReturn(START_HEIGHT, START_HEIGHT, height);
+
+        doNothing().when(mockLayer).blit(any(Layer.class), anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt());
+
         transformer.transform(layer, properties);
 
-        verify(layer, times(1)).resize(160, height);
+        assertNotNull("Layer constructor was not intercepted.", resultLayer.get());
+        verify(layer, times(3)).getWidth();
+        verify(layer, times(3)).getHeight();
+        verify(layer, times(1)).resize(width, height);
+        verify(mockLayer, times(1)).blit(layer, 0, 0, width, height, 0, 0);
+        verifyNoMoreInteractions(layer);
+        verifyNoMoreInteractions(mockLayer);
     }
 
     @Test
@@ -108,37 +276,87 @@ public class LetterPillarBoxImageTransformerImplTest {
         map.put("height", height);
         ValueMap properties = new ValueMapDecorator(map);
 
+        final Layer mockLayer = mock(Layer.class);
+
+        final AtomicReference<Layer> resultLayer = setupMockLayer(mockLayer);
+
+        when(layer.getWidth()).thenReturn(START_WIDTH);
+        when(layer.getHeight()).thenReturn(START_HEIGHT);
+
+        doNothing().when(mockLayer).blit(any(Layer.class), anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt());
+
         transformer.transform(layer, properties);
 
-        verify(layer, times(1)).resize(1600, 900);
+        assertNotNull("Layer constructor was not intercepted.", resultLayer.get());
+        verify(layer, times(3)).getWidth();
+        verify(layer, times(3)).getHeight();
+        verify(layer, times(1)).resize(START_WIDTH, START_HEIGHT);
+        verify(mockLayer, times(1)).blit(layer, 0, 0, START_WIDTH, START_HEIGHT, 0, 0);
+        verifyNoMoreInteractions(layer);
+        verifyNoMoreInteractions(mockLayer);
+
     }
 
     @Test
     public void testTransform_invalidWifth() throws Exception {
         final int width = -100;
-        final int height = 90;
+        final int height = 225;
+
+        final int targetWidth = 400;
 
         map.put("width", width);
         map.put("height", height);
         ValueMap properties = new ValueMapDecorator(map);
 
+        final Layer mockLayer = mock(Layer.class);
+
+        final AtomicReference<Layer> resultLayer = setupMockLayer(mockLayer);
+
+        when(layer.getWidth()).thenReturn(START_WIDTH, START_WIDTH, targetWidth);
+        when(layer.getHeight()).thenReturn(START_HEIGHT, START_HEIGHT, height);
+
+        doNothing().when(mockLayer).blit(any(Layer.class), anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt());
+
         transformer.transform(layer, properties);
 
-        verify(layer, times(1)).resize(160, height);
+        assertNotNull("Layer constructor was not intercepted.", resultLayer.get());
+        verify(layer, times(3)).getWidth();
+        verify(layer, times(3)).getHeight();
+        verify(layer, times(1)).resize(targetWidth, height);
+        verify(mockLayer, times(1)).blit(layer, 0, 0, targetWidth, height, 0, 0);
+        verifyNoMoreInteractions(layer);
+        verifyNoMoreInteractions(mockLayer);
     }
 
     @Test
     public void testTransform_invalidHeight() throws Exception {
-        final int width = 160;
+        final int width = 400;
         final int height = -100;
+
+        final int targetheight = 225;
 
         map.put("width", width);
         map.put("height", height);
         ValueMap properties = new ValueMapDecorator(map);
 
+        final Layer mockLayer = mock(Layer.class);
+
+        final AtomicReference<Layer> resultLayer = setupMockLayer(mockLayer);
+
+        when(layer.getWidth()).thenReturn(START_WIDTH, START_WIDTH, width);
+        when(layer.getHeight()).thenReturn(START_HEIGHT, START_HEIGHT, targetheight);
+
+        doNothing().when(mockLayer).blit(any(Layer.class), anyInt(), anyInt(), anyInt(), anyInt(), anyInt(), anyInt());
+
         transformer.transform(layer, properties);
 
-        verify(layer, times(1)).resize(width, 90);
+        assertNotNull("Layer constructor was not intercepted.", resultLayer.get());
+        verify(layer, times(3)).getWidth();
+        verify(layer, times(3)).getHeight();
+        verify(layer, times(1)).resize(width, targetheight);
+        verify(mockLayer, times(1)).blit(layer, 0, 0, width, targetheight, 0, 0);
+        verifyNoMoreInteractions(layer);
+        verifyNoMoreInteractions(mockLayer);
     }
 
     @Test
@@ -156,4 +374,18 @@ public class LetterPillarBoxImageTransformerImplTest {
 
         verifyZeroInteractions(layer);
     }
+
+    private AtomicReference<Layer> setupMockLayer(final Layer mockLayer) throws Exception {
+        final AtomicReference<Layer> resultLayer = new AtomicReference<Layer>();
+        PowerMockito.whenNew(Layer.class).withParameterTypes(int.class, int.class, Paint.class)
+                .withArguments(anyInt(), anyInt(), Matchers.isA(Paint.class)).thenAnswer(new Answer<Layer>() {
+                    @Override
+                    public Layer answer(InvocationOnMock invocation) throws Throwable {
+                        resultLayer.set(mockLayer);
+                        return mockLayer;
+                    }
+                });
+        return resultLayer;
+    }
+
 }


### PR DESCRIPTION
This is a replacement for #364. Supports l/p-boxing when resize aspect ratio isn't right. Also allows configuration to specify background color and opacity if desired (default transparent).