### PR TITLE
Feature/ResourceResolver.map(..) Transformer

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/ResourceResolverMapTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/ResourceResolverMapTransformerFactory.java
@@ -1,0 +1,122 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.rewriter.impl;
+
+import com.adobe.acs.commons.rewriter.AbstractTransformer;
+import com.adobe.acs.commons.util.ParameterUtil;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.ConfigurationPolicy;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.commons.osgi.PropertiesUtil;
+import org.apache.sling.rewriter.ProcessingComponentConfiguration;
+import org.apache.sling.rewriter.ProcessingContext;
+import org.apache.sling.rewriter.Transformer;
+import org.apache.sling.rewriter.TransformerFactory;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Rewriter pipeline component which maps attribute values.
+ */
+@Component(
+        label = "ACS AEM Commons - Resource Resolver Map Rewriter",
+        description = "Rewriter pipeline component which resourceResolver.map's any element/attribute.",
+        metatype = true,
+        configurationFactory = true,
+        policy = ConfigurationPolicy.REQUIRE)
+
+@Property(
+        label = "Rewriter Pipeline Type",
+        description = "Type identifier to be referenced in rewriter pipeline configuration.",
+        name = "pipeline.type",
+        value = "resourceresolver-map",
+        propertyPrivate = true)
+@Service
+public final class ResourceResolverMapTransformerFactory implements TransformerFactory {
+
+    private static final String[] DEFAULT_ATTRIBUTES = new String[]{"img:src"};
+    private Map<String, String[]> attributes;
+    @Property(label = "Rewrite Attributes",
+            description = "List of element/attribute pairs to rewrite",
+            value = {"img:src"})
+    private static final String PROP_ATTRIBUTES = "attributes";
+
+    public Transformer createTransformer() {
+        return new ResourceResolverMapTransformer();
+    }
+
+    protected Attributes rebuildAttributes(final SlingHttpServletRequest slingRequest,
+                                         final String elementName, final Attributes attrs) {
+        if (slingRequest == null || !attributes.containsKey(elementName)) {
+            // element is not defined as a candidate to rewrite
+            return attrs;
+        }
+        final String[] modifiableAttributes = attributes.get(elementName);
+
+        // clone the attributes
+        final AttributesImpl newAttrs = new AttributesImpl(attrs);
+        final int len = newAttrs.getLength();
+
+        for (int i = 0; i < len; i++) {
+            final String attrName = newAttrs.getLocalName(i);
+            if (ArrayUtils.contains(modifiableAttributes, attrName)) {
+                final String attrValue = newAttrs.getValue(i);
+                if (StringUtils.startsWith(attrValue, "/") && !StringUtils.startsWith(attrValue, "//")) {
+                    // Only map absolute paths (starting w /), avoid relative-scheme URLs starting w //
+                    newAttrs.setValue(i, slingRequest.getResourceResolver().map(slingRequest, attrValue));
+                }
+            }
+        }
+        return newAttrs;
+    }
+
+    @Activate
+    protected void activate(final Map<String, Object> config) {
+        final String[] attrProp = PropertiesUtil.toStringArray(config.get(PROP_ATTRIBUTES), DEFAULT_ATTRIBUTES);
+        this.attributes = ParameterUtil.toMap(attrProp, ":", ",");
+    }
+
+    public final class ResourceResolverMapTransformer extends AbstractTransformer {
+
+        private SlingHttpServletRequest slingRequest;
+
+        @Override
+        public void init(ProcessingContext context, ProcessingComponentConfiguration config) throws IOException {
+            super.init(context, config);
+            this.slingRequest = context.getRequest();
+        }
+
+        @Override
+        public void startElement(String namespaceURI, String localName, String qName, Attributes atts)
+                throws SAXException {
+            getContentHandler().startElement(namespaceURI, localName, qName,
+                    rebuildAttributes(this.slingRequest, localName, atts));
+        }
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/ResourceResolverMapTransformerFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/ResourceResolverMapTransformerFactoryTest.java
@@ -1,0 +1,100 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.rewriter.impl;
+
+import junit.framework.TestCase;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.rewriter.ProcessingContext;
+import org.apache.sling.rewriter.Transformer;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.helpers.AttributesImpl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ResourceResolverMapTransformerFactoryTest extends TestCase {
+
+    @Mock
+    SlingHttpServletRequest request;
+    
+    @Mock
+    ResourceResolver resourceResolver;
+    
+    @Mock
+    private ContentHandler handler;
+    
+    @Mock
+    ProcessingContext processingContext;
+
+    @Captor
+    private ArgumentCaptor<Attributes> attributesCaptor;
+    
+    @Before
+    public void setUp() throws Exception {
+        when(processingContext.getRequest()).thenReturn(request);
+        when(request.getResourceResolver()).thenReturn(resourceResolver);
+    }
+
+    @Test
+    public void testRebuildAttributes() throws Exception {
+        when(resourceResolver.map(request, "/content/site/en/jcr:content/img.png")).thenReturn("/en/jcr:content/img.png");
+
+        final Map<String, Object> config = new HashMap<String, Object>();
+        config.put("attributes", new String[]{"img:src"});
+
+        ResourceResolverMapTransformerFactory factory = new ResourceResolverMapTransformerFactory();
+
+        factory.activate(config);
+        Transformer transformer = factory.createTransformer();
+        transformer.init(processingContext, null);
+        transformer.setContentHandler(handler);
+
+        AttributesImpl in = new AttributesImpl();
+        in.addAttribute(null, "src", null, "CDATA", "/content/site/en/jcr:content/img.png");
+
+        /* Execute */
+        
+        transformer.startElement(null, "img", null, in);
+        
+        /* Verify */
+        
+        verify(handler, only()).startElement(isNull(String.class), eq("img"), isNull(String.class),
+                attributesCaptor.capture());
+        Attributes out = attributesCaptor.getValue();
+        assertEquals("/en/jcr:content/img.png", out.getValue(0));
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/ResourceResolverMapTransformerFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/ResourceResolverMapTransformerFactoryTest.java
@@ -43,6 +43,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -96,5 +97,31 @@ public class ResourceResolverMapTransformerFactoryTest extends TestCase {
                 attributesCaptor.capture());
         Attributes out = attributesCaptor.getValue();
         assertEquals("/en/jcr:content/img.png", out.getValue(0));
+    }
+
+    @Test
+    public void testRebuildAttributes_NegativeScenario() throws Exception {
+        final Map<String, Object> config = new HashMap<String, Object>();
+        config.put("attributes", new String[]{"img:src"});
+
+        ResourceResolverMapTransformerFactory factory = new ResourceResolverMapTransformerFactory();
+
+        factory.activate(config);
+        Transformer transformer = factory.createTransformer();
+        transformer.init(processingContext, null);
+        transformer.setContentHandler(handler);
+
+        AttributesImpl in = new AttributesImpl();
+        in.addAttribute(null, "data-uri", null, "CDATA", "/img.png");
+
+        /* Execute */
+
+        transformer.startElement(null, "img", null, in);
+        
+        /* Verify */
+
+        verify(handler, only()).startElement(isNull(String.class), eq("img"), isNull(String.class),
+                attributesCaptor.capture());
+        verifyZeroInteractions(resourceResolver);
     }
 }


### PR DESCRIPTION
Transformer that called `slingRequest.getResourceResolver().map(slingRequest, <path>)` on a configurable set of `<element>:<attributes>`

This is to allow mapping of attributes that may not end in .html or .htm and/or not "links" (OOTB Linkchecker has some limitations with its mapping)
