### PR TITLE
Checksum Generator refactor to be OSGi service rather than static Util

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/analysis/jcrchecksum/ChecksumGenerator.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/analysis/jcrchecksum/ChecksumGenerator.java
@@ -21,32 +21,11 @@
 package com.adobe.acs.commons.analysis.jcrchecksum;
 
 import aQute.bnd.annotation.ProviderType;
-import com.adobe.acs.commons.analysis.jcrchecksum.impl.options.DefaultChecksumGeneratorOptions;
-import com.day.jcr.vault.util.Text;
-import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.jcr.Node;
-import javax.jcr.NodeIterator;
-import javax.jcr.Property;
-import javax.jcr.PropertyIterator;
-import javax.jcr.PropertyType;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
-import javax.jcr.Value;
 import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  * Utility that generates checksums for JCR paths.  The checksum is calculated using a depth first traversal
@@ -54,26 +33,18 @@ import java.util.TreeMap;
  * (via {@link ChecksumGeneratorOptions}).
  */
 @ProviderType
-public final class ChecksumGenerator {
-    private static final Logger log = LoggerFactory.getLogger(ChecksumGenerator.class);
-
-    private ChecksumGenerator() {
-        // Private cstor for static util
-    }
-
+public interface ChecksumGenerator {
     /**
-     * Convenience method for  generateChecksum(session, path, new DefaultChecksumGeneratorOptions()).
+     * Convenience method for generateChecksums(session, path, new DefaultChecksumGeneratorOptions()).
      *
      * @param session the session
-     * @param path tthe root path to generate checksums for
+     * @param path    the root path to generate checksums for
      * @return the map of abs path ~> checksums
      * @throws RepositoryException
      * @throws IOException
      */
-    public static Map<String, String> generateChecksum(Session session, String path) throws RepositoryException,
-            IOException {
-        return generateChecksum(session, path, new DefaultChecksumGeneratorOptions());
-    }
+    Map<String, String> generateChecksums(Session session, String path) throws RepositoryException,
+            IOException;
 
     /**
      * Traverses the content tree whose root is defined by the path param, respecting the {@link
@@ -81,319 +52,12 @@ public final class ChecksumGenerator {
      * Generates map of checksum hashes in the format [ ABSOLUTE PATH ] : [ CHECKSUM OF NODE SYSTEM ]
      *
      * @param session the session
-     * @param path the root path to generate checksums for
+     * @param path    the root path to generate checksums for
      * @param options the {@link ChecksumGeneratorOptions} that define the checksum generation
      * @return the map of abs path ~> checksums
      * @throws RepositoryException
      * @throws IOException
      */
-    public static Map<String, String> generateChecksum(Session session, String path, ChecksumGeneratorOptions options)
-            throws RepositoryException, IOException {
-
-        Node node = session.getNode(path);
-
-        if (node == null) {
-            log.warn("Path [ {} ] not found while generating checksums", path);
-            return new LinkedHashMap<String, String>();
-        }
-
-        return traverseTree(node, options);
-    }
-
-    /**
-     * Traverse the tree for candidate aggregate nodes.
-     * @param node the current node being traversed
-     * @param options the checksum generator options
-     * @return a map of paths and checksums
-     * @throws RepositoryException
-     * @throws IOException
-     */
-    private static Map<String, String> traverseTree(Node node, ChecksumGeneratorOptions options) throws
-            RepositoryException,
-            IOException {
-
-        final Map<String, String> checksums = new LinkedHashMap<String, String>();
-
-        if (isChecksumable(node, options)) {
-            // Tree-traversal has found a node to checksum (checksum will include all valid sub-tree nodes)
-            checksums.put(node.getPath(),
-                    generatedNodeChecksum(node.getPath(), node, options));
-
-            log.debug("Top Level Node: {} ~> {}",
-                    node.getPath(),
-                    checksums.get(node.getPath()));
-        } else {
-            // Traverse the tree for checksum-able node systems
-            NodeIterator children = node.getNodes();
-
-            while (children.hasNext()) {
-                // Check each child with recursive logic; if child is checksum-able the call into traverseTree will
-                // handle this case
-                checksums.putAll(traverseTree(children.nextNode(), options));
-            }
-        }
-
-        return checksums;
-    }
-
-
-    /**
-     * Ensures the node's primary type is included in the Included Node Types and NOT in the Excluded Node Types.
-     *
-     * @param node    the candidate node
-     * @param options the checksum options containing the included and excluded none types
-     * @return true if the node represents a checksum-able node system
-     * @throws RepositoryException
-     */
-    private static boolean isChecksumable(Node node, ChecksumGeneratorOptions options) throws RepositoryException {
-        final Set<String> nodeTypeIncludes = options.getIncludedNodeTypes();
-        final Set<String> nodeTypeExcludes = options.getExcludedNodeTypes();
-
-        final String primaryNodeType = node.getPrimaryNodeType().getName();
-
-        return nodeTypeIncludes.contains(primaryNodeType) && !nodeTypeExcludes.contains(primaryNodeType);
-    }
-
-    /**
-     * Generates a checksum for a single node and its node sub-system, respecting the options.
-     * @param aggregateNodePath the absolute path of the node being aggregated into a checksum
-     * @param node the node whose subsystem to create a checksum for
-     * @param options the {@link ChecksumGeneratorOptions} options
-     * @return a map containing 1 entry in the form [ node.getPath() ] : [ CHECKSUM OF NODE SYSTEM ]
-     * @throws RepositoryException
-     * @throws IOException
-     */
-    protected static String generatedNodeChecksum(final String aggregateNodePath,
-                                                  final Node node,
-                                                  final ChecksumGeneratorOptions options)
-            throws RepositoryException, IOException {
-
-        final Set<String> nodeTypeExcludes = options.getExcludedNodeTypes();
-
-        final Map<String, String> checksums = new LinkedHashMap<String, String>();
-
-        /* Create checksums for Node's properties */
-        checksums.put(getChecksumKey(aggregateNodePath, node.getPath()),
-                generatePropertyChecksums(aggregateNodePath, node, options));
-
-        /* Then process node's children */
-
-        final Map<String, String> lexicographicallySortedChecksums = new TreeMap<String, String>();
-        final boolean hasOrderedChildren = hasOrderedChildren(node);
-        final NodeIterator children = node.getNodes();
-
-        while (children.hasNext()) {
-            final Node child = children.nextNode();
-
-            if (!nodeTypeExcludes.contains(child.getPrimaryNodeType().getName())) {
-                if (hasOrderedChildren) {
-                    // Use the order dictated by the JCR
-                    checksums.put(
-                            getChecksumKey(aggregateNodePath, child.getPath()),
-                            generatedNodeChecksum(aggregateNodePath, child, options));
-
-                    log.debug("Aggregated Ordered Node: {} ~> {}",
-                            getChecksumKey(aggregateNodePath, child.getPath()),
-                            checksums.get(getChecksumKey(aggregateNodePath, child.getPath())));
-                } else {
-                    // If order is not dictated by JCR, collect so we can sort later
-                    lexicographicallySortedChecksums.put(
-                            getChecksumKey(aggregateNodePath, child.getPath()),
-                            generatedNodeChecksum(aggregateNodePath, child, options));
-
-                    log.debug("Aggregated Unordered Node: {} ~> {}",
-                            getChecksumKey(aggregateNodePath, child.getPath()),
-                            lexicographicallySortedChecksums.get(getChecksumKey(aggregateNodePath, child.getPath())));
-
-                }
-            }
-        }
-
-        if (!hasOrderedChildren && lexicographicallySortedChecksums.size() > 0) {
-            // Order is not dictated by JCR, so add the lexicographically sorted entries to the checksums string
-            checksums.putAll(lexicographicallySortedChecksums);
-        }
-
-        final String nodeChecksum = aggregateChecksums(checksums);
-        log.debug("Node [ {} ] has a aggregated checksum of [ {} ]",
-                getChecksumKey(aggregateNodePath, node.getPath()),
-                nodeChecksum);
-
-        return nodeChecksum;
-    }
-
-    /**
-     * Returns a lexicographically sorted map of the [PROPERTY PATH] : [CHECKSUM OF PROPERTIES].
-     * @param aggregateNodePath the absolute path of the node being aggregated into a checksum
-     * @param node  the node to collect and checksum the properties for
-     * @param options the checksum generator options
-     * @return the map of the properties and their checksums
-     * @throws RepositoryException
-     */
-    protected static String generatePropertyChecksums(final String aggregateNodePath,
-                                                      final Node node,
-                                                      final ChecksumGeneratorOptions options)
-            throws RepositoryException, IOException {
-
-        SortedMap<String, String> propertyChecksums = new TreeMap<String, String>();
-        PropertyIterator properties = node.getProperties();
-
-        while (properties.hasNext()) {
-            final Property property = properties.nextProperty();
-
-            if (options.getExcludedProperties().contains(property.getName())) {
-                // Skip this property as it is excluded
-                log.debug("Excluding property: {}", node.getPath() + "/@" + property.getName());
-                continue;
-            }
-
-            /* Accept the property for checksuming */
-
-            final List<String> checksums = new ArrayList<String>();
-
-            final List<Value> values = getPropertyValues(property);
-
-            for (final Value value : values) {
-                if (value.getType() == PropertyType.BINARY) {
-                    checksums.add(getBinaryChecksum(value));
-                } else {
-                    checksums.add(getStringChecksum(value));
-                }
-            }
-
-            if (!options.getSortedProperties().contains(property.getName())) {
-                Collections.sort(checksums);
-            }
-
-            if (log.isDebugEnabled()) {
-                log.debug("Property: {} ~> {}",
-                        getChecksumKey(aggregateNodePath, property.getPath()),
-                        StringUtils.join(checksums, ","));
-            }
-
-            propertyChecksums.put(getChecksumKey(aggregateNodePath, property.getPath()),
-                    StringUtils.join(checksums, ","));
-        }
-
-        return aggregateChecksums(propertyChecksums);
-    }
-
-
-    /**
-     * Generates the relative key used for tracking nodes and properties.
-     * @param aggregatePath the absolute path of the node being aggregated.
-     * @param path the path of the item being checksumed
-     * @return the key
-     */
-    protected static String getChecksumKey(String aggregatePath, String path) {
-        if ("/".equals(aggregatePath) && "/".equals(path)) {
-            return "/";
-        } else if ("/".equals(aggregatePath)) {
-            return path;
-        }
-
-        String baseNodeName = Text.getName(aggregatePath);
-        String relPath = StringUtils.removeStart(path, aggregatePath);
-
-        return baseNodeName + relPath;
-    }
-
-    /**
-     * Normalizes a property values to a list; allows single and multi-values to be treated the same in code.
-     * @param property the propert to get the value(s) from
-     * @return a list of the property's value(s)
-     * @throws RepositoryException
-     */
-    private static List<Value> getPropertyValues(final Property property) throws RepositoryException {
-        final List<Value> values = new ArrayList<Value>();
-
-        if (property.isMultiple()) {
-            values.addAll(Arrays.asList(property.getValues()));
-        } else {
-            values.add(property.getValue());
-        }
-
-        return values;
-    }
-
-    /**
-     * Gets the checksum for a Binary value.
-     * @param value the Value
-     * @return the checksum
-     * @throws RepositoryException
-     * @throws IOException
-     */
-    protected static String getBinaryChecksum(final Value value) throws RepositoryException, IOException {
-        InputStream stream = null;
-
-        try {
-            stream = value.getBinary().getStream();
-            return DigestUtils.shaHex(stream);
-        } finally {
-            if (stream != null) {
-                stream.close();
-            }
-        }
-    }
-
-    /**
-     * Gets the checksum for a String value.
-     * @param value the Value
-     * @return the checksum
-     * @throws RepositoryException
-     */
-    protected static String getStringChecksum(final Value value) throws RepositoryException {
-        return DigestUtils.shaHex(value.getString());
-    }
-
-    /**
-     * Checks if node has ordered children.
-     * @param node the node
-     * @return true if the node has ordered children
-     * @throws RepositoryException
-     */
-    protected static boolean hasOrderedChildren(final Node node) throws RepositoryException {
-        boolean hasOrderedChildren = false;
-
-        try {
-            hasOrderedChildren = node.getPrimaryNodeType().hasOrderableChildNodes();
-        } catch (UnsupportedOperationException e) {
-            // This is an exception thrown in the test scenarios using the Mock JCR API
-            // This would not happen using the actual JCR APIs
-            // Allow other exceptions to be thrown and break processing normally
-        }
-
-        return hasOrderedChildren;
-    }
-
-    /**
-     * Aggregates a set of checksum entries into a single checksum value.
-     * @param checksums the checksums
-     * @return the checksum value
-     */
-    protected static String aggregateChecksums(final Map<String, String> checksums) {
-        StringBuilder data = new StringBuilder();
-
-        for (Map.Entry<String, String> entry : checksums.entrySet()) {
-            data.append(entry.getKey() + "=" + entry.getValue());
-        }
-
-        return DigestUtils.shaHex(data.toString());
-    }
-
-    /**
-     * Helper method for debugging output.
-     * @param map a map
-     * @return a String representation of the map.
-     */
-    private static String toString(Map<String, String> map) {
-        StringBuilder sb = new StringBuilder();
-
-        sb.append("\n");
-        for (Map.Entry<String, String> entry : map.entrySet()) {
-            sb.append(entry.getKey() + " = " + entry.getValue() + "\n");
-        }
-
-        return sb.toString();
-    }
+    Map<String, String> generateChecksums(Session session, String path, ChecksumGeneratorOptions options)
+            throws RepositoryException, IOException;
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/analysis/jcrchecksum/impl/ChecksumGeneratorImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/analysis/jcrchecksum/impl/ChecksumGeneratorImpl.java
@@ -1,0 +1,384 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.analysis.jcrchecksum.impl;
+
+import aQute.bnd.annotation.ProviderType;
+import com.adobe.acs.commons.analysis.jcrchecksum.ChecksumGenerator;
+import com.adobe.acs.commons.analysis.jcrchecksum.ChecksumGeneratorOptions;
+import com.adobe.acs.commons.analysis.jcrchecksum.impl.options.DefaultChecksumGeneratorOptions;
+import com.day.jcr.vault.util.Text;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Service;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.Property;
+import javax.jcr.PropertyIterator;
+import javax.jcr.PropertyType;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Value;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Utility that generates checksums for JCR paths.  The checksum is calculated using a depth first traversal
+ * and calculates an aggregate checksum on the nodes with the specified node types
+ * (via {@link ChecksumGeneratorOptions}).
+ */
+@Component
+@Service
+public class ChecksumGeneratorImpl implements ChecksumGenerator {
+    private static final Logger log = LoggerFactory.getLogger(ChecksumGeneratorImpl.class);
+
+    /**
+     * Convenience method for  generateChecksums(session, path, new DefaultChecksumGeneratorOptions()).
+     *
+     * @param session the session
+     * @param path tthe root path to generate checksums for
+     * @return the map of abs path ~> checksums
+     * @throws RepositoryException
+     * @throws IOException
+     */
+    public Map<String, String> generateChecksums(Session session, String path) throws RepositoryException,
+            IOException {
+        return generateChecksums(session, path, new DefaultChecksumGeneratorOptions());
+    }
+
+    /**
+     * Traverses the content tree whose root is defined by the path param, respecting the {@link
+     * ChecksumGeneratorOptions}.
+     * Generates map of checksum hashes in the format [ ABSOLUTE PATH ] : [ CHECKSUM OF NODE SYSTEM ]
+     *
+     * @param session the session
+     * @param path the root path to generate checksums for
+     * @param options the {@link ChecksumGeneratorOptions} that define the checksum generation
+     * @return the map of abs path ~> checksums
+     * @throws RepositoryException
+     * @throws IOException
+     */
+    public Map<String, String> generateChecksums(Session session, String path, ChecksumGeneratorOptions options)
+            throws RepositoryException, IOException {
+
+        Node node = session.getNode(path);
+
+        if (node == null) {
+            log.warn("Path [ {} ] not found while generating checksums", path);
+            return new LinkedHashMap<String, String>();
+        }
+
+        return traverseTree(node, options);
+    }
+
+    /**
+     * Traverse the tree for candidate aggregate nodes.
+     * @param node the current node being traversed
+     * @param options the checksum generator options
+     * @return a map of paths and checksums
+     * @throws RepositoryException
+     * @throws IOException
+     */
+    private Map<String, String> traverseTree(Node node, ChecksumGeneratorOptions options) throws
+            RepositoryException,
+            IOException {
+
+        final Map<String, String> checksums = new LinkedHashMap<String, String>();
+
+        if (isChecksumable(node, options)) {
+            // Tree-traversal has found a node to checksum (checksum will include all valid sub-tree nodes)
+            checksums.put(node.getPath(),
+                    generatedNodeChecksum(node.getPath(), node, options));
+
+            log.debug("Top Level Node: {} ~> {}",
+                    node.getPath(),
+                    checksums.get(node.getPath()));
+        } else {
+            // Traverse the tree for checksum-able node systems
+            NodeIterator children = node.getNodes();
+
+            while (children.hasNext()) {
+                // Check each child with recursive logic; if child is checksum-able the call into traverseTree will
+                // handle this case
+                checksums.putAll(traverseTree(children.nextNode(), options));
+            }
+        }
+
+        return checksums;
+    }
+
+
+    /**
+     * Ensures the node's primary type is included in the Included Node Types and NOT in the Excluded Node Types.
+     *
+     * @param node    the candidate node
+     * @param options the checksum options containing the included and excluded none types
+     * @return true if the node represents a checksum-able node system
+     * @throws RepositoryException
+     */
+    private boolean isChecksumable(Node node, ChecksumGeneratorOptions options) throws RepositoryException {
+        final Set<String> nodeTypeIncludes = options.getIncludedNodeTypes();
+        final Set<String> nodeTypeExcludes = options.getExcludedNodeTypes();
+
+        final String primaryNodeType = node.getPrimaryNodeType().getName();
+
+        return nodeTypeIncludes.contains(primaryNodeType) && !nodeTypeExcludes.contains(primaryNodeType);
+    }
+
+    /**
+     * Generates a checksum for a single node and its node sub-system, respecting the options.
+     * @param aggregateNodePath the absolute path of the node being aggregated into a checksum
+     * @param node the node whose subsystem to create a checksum for
+     * @param options the {@link ChecksumGeneratorOptions} options
+     * @return a map containing 1 entry in the form [ node.getPath() ] : [ CHECKSUM OF NODE SYSTEM ]
+     * @throws RepositoryException
+     * @throws IOException
+     */
+    protected String generatedNodeChecksum(final String aggregateNodePath,
+                                                  final Node node,
+                                                  final ChecksumGeneratorOptions options)
+            throws RepositoryException, IOException {
+
+        final Set<String> nodeTypeExcludes = options.getExcludedNodeTypes();
+
+        final Map<String, String> checksums = new LinkedHashMap<String, String>();
+
+        /* Create checksums for Node's properties */
+        checksums.put(getChecksumKey(aggregateNodePath, node.getPath()),
+                generatePropertyChecksums(aggregateNodePath, node, options));
+
+        /* Then process node's children */
+
+        final Map<String, String> lexicographicallySortedChecksums = new TreeMap<String, String>();
+        final boolean hasOrderedChildren = hasOrderedChildren(node);
+        final NodeIterator children = node.getNodes();
+
+        while (children.hasNext()) {
+            final Node child = children.nextNode();
+
+            if (!nodeTypeExcludes.contains(child.getPrimaryNodeType().getName())) {
+                if (hasOrderedChildren) {
+                    // Use the order dictated by the JCR
+                    checksums.put(
+                            getChecksumKey(aggregateNodePath, child.getPath()),
+                            generatedNodeChecksum(aggregateNodePath, child, options));
+
+                    log.debug("Aggregated Ordered Node: {} ~> {}",
+                            getChecksumKey(aggregateNodePath, child.getPath()),
+                            checksums.get(getChecksumKey(aggregateNodePath, child.getPath())));
+                } else {
+                    // If order is not dictated by JCR, collect so we can sort later
+                    lexicographicallySortedChecksums.put(
+                            getChecksumKey(aggregateNodePath, child.getPath()),
+                            generatedNodeChecksum(aggregateNodePath, child, options));
+
+                    log.debug("Aggregated Unordered Node: {} ~> {}",
+                            getChecksumKey(aggregateNodePath, child.getPath()),
+                            lexicographicallySortedChecksums.get(getChecksumKey(aggregateNodePath, child.getPath())));
+
+                }
+            }
+        }
+
+        if (!hasOrderedChildren && lexicographicallySortedChecksums.size() > 0) {
+            // Order is not dictated by JCR, so add the lexicographically sorted entries to the checksums string
+            checksums.putAll(lexicographicallySortedChecksums);
+        }
+
+        final String nodeChecksum = aggregateChecksums(checksums);
+        log.debug("Node [ {} ] has a aggregated checksum of [ {} ]",
+                getChecksumKey(aggregateNodePath, node.getPath()),
+                nodeChecksum);
+
+        return nodeChecksum;
+    }
+
+    /**
+     * Returns a lexicographically sorted map of the [PROPERTY PATH] : [CHECKSUM OF PROPERTIES].
+     * @param aggregateNodePath the absolute path of the node being aggregated into a checksum
+     * @param node  the node to collect and checksum the properties for
+     * @param options the checksum generator options
+     * @return the map of the properties and their checksums
+     * @throws RepositoryException
+     */
+    protected String generatePropertyChecksums(final String aggregateNodePath,
+                                                      final Node node,
+                                                      final ChecksumGeneratorOptions options)
+            throws RepositoryException, IOException {
+
+        SortedMap<String, String> propertyChecksums = new TreeMap<String, String>();
+        PropertyIterator properties = node.getProperties();
+
+        while (properties.hasNext()) {
+            final Property property = properties.nextProperty();
+
+            if (options.getExcludedProperties().contains(property.getName())) {
+                // Skip this property as it is excluded
+                log.debug("Excluding property: {}", node.getPath() + "/@" + property.getName());
+                continue;
+            }
+
+            /* Accept the property for checksuming */
+
+            final List<String> checksums = new ArrayList<String>();
+
+            final List<Value> values = getPropertyValues(property);
+
+            for (final Value value : values) {
+                if (value.getType() == PropertyType.BINARY) {
+                    checksums.add(getBinaryChecksum(value));
+                } else {
+                    checksums.add(getStringChecksum(value));
+                }
+            }
+
+            if (!options.getSortedProperties().contains(property.getName())) {
+                Collections.sort(checksums);
+            }
+
+            if (log.isDebugEnabled()) {
+                log.debug("Property: {} ~> {}",
+                        getChecksumKey(aggregateNodePath, property.getPath()),
+                        StringUtils.join(checksums, ","));
+            }
+
+            propertyChecksums.put(getChecksumKey(aggregateNodePath, property.getPath()),
+                    StringUtils.join(checksums, ","));
+        }
+
+        return aggregateChecksums(propertyChecksums);
+    }
+
+
+    /**
+     * Generates the relative key used for tracking nodes and properties.
+     * @param aggregatePath the absolute path of the node being aggregated.
+     * @param path the path of the item being checksumed
+     * @return the key
+     */
+    protected String getChecksumKey(String aggregatePath, String path) {
+        if ("/".equals(aggregatePath) && "/".equals(path)) {
+            return "/";
+        } else if ("/".equals(aggregatePath)) {
+            return path;
+        }
+
+        String baseNodeName = Text.getName(aggregatePath);
+        String relPath = StringUtils.removeStart(path, aggregatePath);
+
+        return baseNodeName + relPath;
+    }
+
+    /**
+     * Normalizes a property values to a list; allows single and multi-values to be treated the same in code.
+     * @param property the propert to get the value(s) from
+     * @return a list of the property's value(s)
+     * @throws RepositoryException
+     */
+    private List<Value> getPropertyValues(final Property property) throws RepositoryException {
+        final List<Value> values = new ArrayList<Value>();
+
+        if (property.isMultiple()) {
+            values.addAll(Arrays.asList(property.getValues()));
+        } else {
+            values.add(property.getValue());
+        }
+
+        return values;
+    }
+
+    /**
+     * Gets the checksum for a Binary value.
+     * @param value the Value
+     * @return the checksum
+     * @throws RepositoryException
+     * @throws IOException
+     */
+    protected String getBinaryChecksum(final Value value) throws RepositoryException, IOException {
+        InputStream stream = null;
+
+        try {
+            stream = value.getBinary().getStream();
+            return DigestUtils.shaHex(stream);
+        } finally {
+            if (stream != null) {
+                stream.close();
+            }
+        }
+    }
+
+    /**
+     * Gets the checksum for a String value.
+     * @param value the Value
+     * @return the checksum
+     * @throws RepositoryException
+     */
+    protected static String getStringChecksum(final Value value) throws RepositoryException {
+        return DigestUtils.shaHex(value.getString());
+    }
+
+    /**
+     * Checks if node has ordered children.
+     * @param node the node
+     * @return true if the node has ordered children
+     * @throws RepositoryException
+     */
+    protected boolean hasOrderedChildren(final Node node) throws RepositoryException {
+        boolean hasOrderedChildren = false;
+
+        try {
+            hasOrderedChildren = node.getPrimaryNodeType().hasOrderableChildNodes();
+        } catch (UnsupportedOperationException e) {
+            // This is an exception thrown in the test scenarios using the Mock JCR API
+            // This would not happen using the actual JCR APIs
+            // Allow other exceptions to be thrown and break processing normally
+        }
+
+        return hasOrderedChildren;
+    }
+
+    /**
+     * Aggregates a set of checksum entries into a single checksum value.
+     * @param checksums the checksums
+     * @return the checksum value
+     */
+    protected String aggregateChecksums(final Map<String, String> checksums) {
+        StringBuilder data = new StringBuilder();
+
+        for (Map.Entry<String, String> entry : checksums.entrySet()) {
+            data.append(entry.getKey() + "=" + entry.getValue());
+        }
+
+        return DigestUtils.shaHex(data.toString());
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/analysis/jcrchecksum/impl/servlets/BaseChecksumServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/analysis/jcrchecksum/impl/servlets/BaseChecksumServlet.java
@@ -18,13 +18,11 @@
  * #L%
  */
 
-package com.adobe.acs.commons.analysis.jcrchecksum.impl;
+package com.adobe.acs.commons.analysis.jcrchecksum.impl.servlets;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletException;
 import java.io.IOException;

--- a/bundle/src/main/java/com/adobe/acs/commons/analysis/jcrchecksum/impl/servlets/JSONDumpServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/analysis/jcrchecksum/impl/servlets/JSONDumpServlet.java
@@ -18,10 +18,10 @@
  * #L%
  */
 
-package com.adobe.acs.commons.analysis.jcrchecksum.impl;
+package com.adobe.acs.commons.analysis.jcrchecksum.impl.servlets;
 
-import com.adobe.acs.commons.analysis.jcrchecksum.ChecksumGenerator;
 import com.adobe.acs.commons.analysis.jcrchecksum.ChecksumGeneratorOptions;
+import com.adobe.acs.commons.analysis.jcrchecksum.impl.JSONGenerator;
 import com.adobe.acs.commons.analysis.jcrchecksum.impl.options.ChecksumGeneratorOptionsFactory;
 import com.adobe.acs.commons.analysis.jcrchecksum.impl.options.RequestChecksumGeneratorOptions;
 import org.apache.commons.collections.CollectionUtils;
@@ -31,6 +31,8 @@ import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.commons.json.JSONException;
+import org.apache.sling.commons.json.io.JSONWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,62 +41,71 @@ import javax.jcr.Session;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Map;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.Set;
 
 @SuppressWarnings("serial")
 @Component
 @Properties({
-        @Property(
-                name="sling.servlet.paths",
-                value= ChecksumGeneratorServlet.SERVLET_PATH
-        ),
-        @Property(
-                name="sling.auth.requirements",
-                value= "-" + ChecksumGeneratorServlet.SERVLET_PATH
-        )
+    @Property(
+            name="sling.servlet.paths",
+            value= JSONDumpServlet.SERVLET_PATH
+    ),
+    @Property(
+        name="sling.auth.requirements",
+        value= "-" + JSONDumpServlet.SERVLET_PATH
+    )
 })
 @Service
-public class ChecksumGeneratorServlet extends BaseChecksumServlet {
-    public static final Logger log = LoggerFactory.getLogger(ChecksumGeneratorServlet.class);
+public class JSONDumpServlet extends BaseChecksumServlet {
+    private static final Logger log = LoggerFactory.getLogger(JSONDumpServlet.class);
 
     public static final String SERVLET_PATH =  ServletConstants.SERVLET_PATH  + "."
-            + ServletConstants.CHECKSUM_SERVLET_SELECTOR + "."
-            + ServletConstants.CHECKSUM_SERVLET_EXTENSION;
+            + ServletConstants.JSON_SERVLET_SELECTOR + "."
+            + ServletConstants.JSON_SERVLET_EXTENSION;
 
     @Override
     public final void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response) throws
-            ServletException {
+            ServletException, IOException {
         try {
             this.handleCORS(request, response);
             this.handleRequest(request, response);
-        } catch (IOException e) {
-            throw new ServletException(e);
         } catch (RepositoryException e) {
             throw new ServletException(e);
         }
     }
 
     public final void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response) throws
-            ServletException {
+            ServletException, IOException {
         try {
             this.handleCORS(request, response);
             this.handleRequest(request, response);
-        } catch (IOException e) {
-            throw new ServletException(e);
         } catch (RepositoryException e) {
             throw new ServletException(e);
         }
     }
 
-    private void handleRequest(SlingHttpServletRequest request,
-                               SlingHttpServletResponse response) throws IOException, RepositoryException {
+    private void handleRequest(SlingHttpServletRequest request, SlingHttpServletResponse response)
+            throws IOException,
+        RepositoryException, ServletException {
 
-        response.setContentType("text/plain");
+        response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
 
+        // Generate current date and time for filename
+        DateFormat df = new SimpleDateFormat("yyyyddMM_HHmmss");
+        Date today = Calendar.getInstance().getTime();
+        String filename = df.format(today);
+
+        response.setHeader("Content-Disposition", "filename=jcr-checksum-"
+            + filename + ".json");
+
         String optionsName = request.getParameter(ServletConstants.OPTIONS_NAME);
-        ChecksumGeneratorOptions options = ChecksumGeneratorOptionsFactory.getOptions(request, optionsName);
+        ChecksumGeneratorOptions options =
+            ChecksumGeneratorOptionsFactory.getOptions(request, optionsName);
 
         if (log.isDebugEnabled()) {
             log.debug(options.toString());
@@ -103,23 +114,25 @@ public class ChecksumGeneratorServlet extends BaseChecksumServlet {
         Set<String> paths = RequestChecksumGeneratorOptions.getPaths(request);
 
         if (CollectionUtils.isEmpty(paths)) {
-            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-            response.getWriter().print("ERROR: At least one path must be specified");
+            try {
+                response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                response.getWriter().print(
+                    "ERROR: At least one path must be specified");
+            } catch (IOException ioe) {
+                throw ioe;
+            }
         }
 
-        final Session session = request.getResourceResolver().adaptTo(Session.class);
+        Session session = request.getResourceResolver().adaptTo(Session.class);
 
-        for (final String path : paths) {
-            log.debug("Generating checksum for path [ {} ]", path);
+        JSONWriter jsonWriter = new JSONWriter(response.getWriter());
 
-            Map<String, String> checksums = ChecksumGenerator.generateChecksum(session, path, options);
-
-            log.debug("Collected [ {} ] checksum entries under [ {} ]", checksums.size(), path);
-
-            for(final Map.Entry<String, String> entry : checksums.entrySet()) {
-                log.trace("Checksum [ {} ~> {} ]", entry.getKey(), entry.getValue());
-                response.getWriter().println(entry.getKey() + "\t" + entry.getValue());
-            }
+        try {
+            JSONGenerator.generateJSON(session, paths, options, jsonWriter);
+        } catch (RepositoryException e) {
+            throw new ServletException("Error accessing repository", e);
+        } catch (JSONException e) {
+            throw new ServletException("Unable to generate json", e);
         }
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/analysis/jcrchecksum/impl/servlets/ServletConstants.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/analysis/jcrchecksum/impl/servlets/ServletConstants.java
@@ -18,7 +18,7 @@
  * #L%
  */
 
-package com.adobe.acs.commons.analysis.jcrchecksum.impl;
+package com.adobe.acs.commons.analysis.jcrchecksum.impl.servlets;
 
 public final class ServletConstants {
 

--- a/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndex.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndex.java
@@ -94,6 +94,9 @@ public class EnsureOakIndex {
     private AemCapabilityHelper capabilityHelper;
 
     @Reference
+    private ChecksumGenerator checksumGenerator;
+
+    @Reference
     private ResourceResolverFactory resourceResolverFactory;
 
     private static final String DEFAULT_ENSURE_DEFINITIONS_PATH = StringUtils.EMPTY;
@@ -382,7 +385,7 @@ public class EnsureOakIndex {
         ensureDefinitionOptions.addExcludedProperties(IGNORE_PROPERTIES);
 
         final Map<String, String> srcChecksum =
-                ChecksumGenerator.generateChecksum(session, ensureDefinition.getPath(), ensureDefinitionOptions);
+                checksumGenerator.generateChecksums(session, ensureDefinition.getPath(), ensureDefinitionOptions);
 
         // Compile checksum for the oakIndex node system
         final CustomChecksumGeneratorOptions oakIndexOptions = new CustomChecksumGeneratorOptions();
@@ -390,7 +393,7 @@ public class EnsureOakIndex {
         oakIndexOptions.addExcludedProperties(IGNORE_PROPERTIES);
 
         final Map<String, String> destChecksum =
-                ChecksumGenerator.generateChecksum(session, oakIndex.getPath(), oakIndexOptions);
+                checksumGenerator.generateChecksums(session, oakIndex.getPath(), oakIndexOptions);
 
         // Compare checksums
         return !StringUtils.equals(srcChecksum.get(ensureDefinition.getPath()), destChecksum.get(oakIndex.getPath()));

--- a/bundle/src/test/java/com/adobe/acs/commons/analysis/jcrchecksum/impl/ChecksumGeneratorImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/analysis/jcrchecksum/impl/ChecksumGeneratorImplTest.java
@@ -18,8 +18,9 @@
  * #L%
  */
 
-package com.adobe.acs.commons.analysis.jcrchecksum;
+package com.adobe.acs.commons.analysis.jcrchecksum.impl;
 
+import com.adobe.acs.commons.analysis.jcrchecksum.ChecksumGeneratorOptions;
 import com.adobe.acs.commons.analysis.jcrchecksum.impl.options.CustomChecksumGeneratorOptions;
 import com.adobe.acs.commons.analysis.jcrchecksum.impl.options.DefaultChecksumGeneratorOptions;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -46,7 +47,9 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ChecksumGeneratorTest {
+public class ChecksumGeneratorImplTest {
+
+    ChecksumGeneratorImpl checksumGenerator = new ChecksumGeneratorImpl();
 
     StringWriter sw;
 
@@ -117,23 +120,23 @@ public class ChecksumGeneratorTest {
     @Test
     public void testGetChecksumKey() {
         String expected = "jcr:content";
-        String actual = ChecksumGenerator.getChecksumKey("/content/page/jcr:content", "/content/page/jcr:content");
+        String actual = checksumGenerator.getChecksumKey("/content/page/jcr:content", "/content/page/jcr:content");
         assertEquals(expected, actual);
 
         expected = "jcr:content/foo";
-        actual = ChecksumGenerator.getChecksumKey("/content/page/jcr:content", "/content/page/jcr:content/foo");
+        actual = checksumGenerator.getChecksumKey("/content/page/jcr:content", "/content/page/jcr:content/foo");
         assertEquals(expected, actual);
 
         expected = "jcr:content/foo/bar";
-        actual = ChecksumGenerator.getChecksumKey("/content/page/jcr:content", "/content/page/jcr:content/foo/bar");
+        actual = checksumGenerator.getChecksumKey("/content/page/jcr:content", "/content/page/jcr:content/foo/bar");
         assertEquals(expected, actual);
 
         expected = "/";
-        actual = ChecksumGenerator.getChecksumKey("/", "/");
+        actual = checksumGenerator.getChecksumKey("/", "/");
         assertEquals(expected, actual);
 
         expected = "/etc/workflow";
-        actual = ChecksumGenerator.getChecksumKey("/", "/etc/workflow");
+        actual = checksumGenerator.getChecksumKey("/", "/etc/workflow");
         assertEquals(expected, actual);
     }
 
@@ -141,7 +144,7 @@ public class ChecksumGeneratorTest {
     public void testHashForCqPageContentNode1() throws IOException, RepositoryException {
         Node page = setupPage1();
 
-        Map<String, String> actual = ChecksumGenerator.generateChecksum(session, "/content");
+        Map<String, String> actual = checksumGenerator.generateChecksums(session, "/content");
 
         assertEquals("0362210a336ba79c6cab30bf09deaf2f1a749e6f",
                 actual.get("/content/test-page/jcr:content"));
@@ -157,7 +160,7 @@ public class ChecksumGeneratorTest {
         opts.addIncludedNodeTypes(new String[]{ "cq:PageContent" });
         opts.addExcludedNodeTypes(new String[]{ "nt:unstructured" });
 
-        Map<String, String> actual = ChecksumGenerator.generateChecksum(session, "/content", opts);
+        Map<String, String> actual = checksumGenerator.generateChecksums(session, "/content", opts);
 
         assertEquals("0362210a336ba79c6cab30bf09deaf2f1a749e6f",
                 actual.get("/content/test-page/jcr:content"));
@@ -182,7 +185,7 @@ public class ChecksumGeneratorTest {
 
         final String originalJcrContentChecksum = nodeChecksum;
 
-        assertEquals(originalJcrContentChecksum, ChecksumGenerator.generatedNodeChecksum(asset.getPath(), asset.getNode
+        assertEquals(originalJcrContentChecksum, checksumGenerator.generatedNodeChecksum(asset.getPath(), asset.getNode
                 ("renditions/original/jcr:content"), opts));
 
         // jcr:content/renditions/original
@@ -196,7 +199,7 @@ public class ChecksumGeneratorTest {
 
         final String originalChecksum = nodeChecksum;
 
-        assertEquals(originalChecksum, ChecksumGenerator.generatedNodeChecksum(asset.getPath(),
+        assertEquals(originalChecksum, checksumGenerator.generatedNodeChecksum(asset.getPath(),
                 asset.getNode("renditions/original"), opts));
 
 
@@ -208,7 +211,7 @@ public class ChecksumGeneratorTest {
 
         final String renditionsChecksum = nodeChecksum;
 
-        assertEquals(renditionsChecksum, ChecksumGenerator.generatedNodeChecksum(asset.getPath(),
+        assertEquals(renditionsChecksum, checksumGenerator.generatedNodeChecksum(asset.getPath(),
                 asset.getNode("renditions"), opts));
 
         // jcr:content/metadata
@@ -219,7 +222,7 @@ public class ChecksumGeneratorTest {
 
         final String metadataChecksum = nodeChecksum;
 
-        assertEquals(metadataChecksum, ChecksumGenerator.generatedNodeChecksum(asset.getPath(),
+        assertEquals(metadataChecksum, checksumGenerator.generatedNodeChecksum(asset.getPath(),
                 asset.getNode("metadata"), opts));
 
 
@@ -233,11 +236,11 @@ public class ChecksumGeneratorTest {
 
         String jcrContentChecksum = nodeChecksum;
 
-        assertEquals(jcrContentChecksum, ChecksumGenerator.generatedNodeChecksum(asset.getPath(),
+        assertEquals(jcrContentChecksum, checksumGenerator.generatedNodeChecksum(asset.getPath(),
                 asset, opts));
 
 
-        Map<String, String> actual = ChecksumGenerator.generateChecksum(session, "/content", opts);
+        Map<String, String> actual = checksumGenerator.generateChecksums(session, "/content", opts);
 
         // df5fa249ada79b02d435fe75d28afb6811d54edb
         assertEquals(jcrContentChecksum, actual.get("/content/dam/foo.jpg/jcr:content"));
@@ -260,7 +263,7 @@ public class ChecksumGeneratorTest {
 
         options.addSortedProperties(defaultOptions.getSortedProperties());
 
-        Map<String, String> actual = ChecksumGenerator.generateChecksum(session, "/content", options);
+        Map<String, String> actual = checksumGenerator.generateChecksums(session, "/content", options);
 
         // Checksums proven by above tests
         assertEquals("0362210a336ba79c6cab30bf09deaf2f1a749e6f", actual.get(page.getPath()));
@@ -292,7 +295,7 @@ public class ChecksumGeneratorTest {
         opts.addSortedProperties(new String[]{ "sorted" });
         opts.addIncludedNodeTypes(new String[]{ "nt:unstructured" });
 
-        Map<String, String> actual = ChecksumGenerator.generateChecksum(session, node.getPath(), opts);
+        Map<String, String> actual = checksumGenerator.generateChecksums(session, node.getPath(), opts);
 
         assertEquals(expected, actual.get("/page/jcr:content"));
     }
@@ -341,11 +344,11 @@ public class ChecksumGeneratorTest {
         opts.addIncludedNodeTypes(new String[]{ "nt:unstructured" });
 
         // A checksum
-        assertEquals(bChecksum, ChecksumGenerator.generatedNodeChecksum(node.getPath(), a.getNode("b"), opts));
-        assertEquals(cChecksum, ChecksumGenerator.generatedNodeChecksum(node.getPath(), a.getNode("c"), opts));
-        assertEquals(aChecksum, ChecksumGenerator.generatedNodeChecksum(node.getPath(), a, opts));
+        assertEquals(bChecksum, checksumGenerator.generatedNodeChecksum(node.getPath(), a.getNode("b"), opts));
+        assertEquals(cChecksum, checksumGenerator.generatedNodeChecksum(node.getPath(), a.getNode("c"), opts));
+        assertEquals(aChecksum, checksumGenerator.generatedNodeChecksum(node.getPath(), a, opts));
 
-        Map<String, String> actual = ChecksumGenerator.generateChecksum(node.getSession(), node.getPath(), opts);
+        Map<String, String> actual = checksumGenerator.generateChecksums(node.getSession(), node.getPath(), opts);
         assertEquals(expected, actual.get(node.getPath()));
     }
 
@@ -381,7 +384,7 @@ public class ChecksumGeneratorTest {
         CustomChecksumGeneratorOptions opts = new CustomChecksumGeneratorOptions();
         opts.addSortedProperties(new String[]{ "sorted" });
 
-        String actual = ChecksumGenerator.generatePropertyChecksums(node.getPath(), node, opts);
+        String actual = checksumGenerator.generatePropertyChecksums(node.getPath(), node, opts);
 
         assertEquals(expected, actual);
     }
@@ -417,7 +420,7 @@ public class ChecksumGeneratorTest {
         opts.addSortedProperties(new String[]{ "sorted" });
         opts.addExcludedProperties(new String[]{ "jcr:description", "long" });
 
-        String actual = ChecksumGenerator.generatePropertyChecksums(node.getPath(), node, opts);
+        String actual = checksumGenerator.generatePropertyChecksums(node.getPath(), node, opts);
 
         assertEquals(expected, actual);
     }
@@ -429,7 +432,7 @@ public class ChecksumGeneratorTest {
         checksums.put("jcr:content/bar", "5678,9012");
 
         String expected = DigestUtils.shaHex("jcr:content/foo=1234jcr:content/bar=5678,9012");
-        String actual = ChecksumGenerator.aggregateChecksums(checksums);
+        String actual = checksumGenerator.aggregateChecksums(checksums);
 
         assertEquals(expected, actual);
     }


### PR DESCRIPTION
No functional change, Minor refactor; changed ChecksumGenerator to be OSGi service rather than static Util prior to release. Positions functionality build on ChecksumGenerator to be more extensible while not violating the released API.

Ex. Building in "interrupt" functionality to stop checksum generation if the process becomes too taxing.

/cc @andrewmkhoury