### PR TITLE
Deprecated API Use

### DIFF
--- a/bundle/src/test/java/com/adobe/acs/commons/images/transformers/impl/LetterPillarBoxImageTransformerImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/images/transformers/impl/LetterPillarBoxImageTransformerImplTest.java
@@ -20,7 +20,7 @@
 
 package com.adobe.acs.commons.images.transformers.impl;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 


### PR DESCRIPTION
Didn't realize I was using the wrong Assert API in unit tests.