### PR TITLE
Allow callers to specify node types for WfPkgMgr.getPaths()

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/WorkflowPackageManager.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/WorkflowPackageManager.java
@@ -82,6 +82,23 @@ public interface WorkflowPackageManager {
     List<String> getPaths(ResourceResolver resourceResolver, String workflowPackagePath) throws RepositoryException;
 
     /**
+     * Gets the payload paths in the Workflow Package.
+     *
+     * This method will always return a List.
+     * - If the path does not resolve to a resource > an empty list
+     * - If the path does not resolve to a Workflow Package > a List of one item; the param path
+     * - If the path does resolve to a Workflow Package > a List of all resources in the Workflow Package but not the
+     * WF Package itself.
+     *
+     * @param resourceResolver The resource resolver to access the Workflow Package
+     * @param workflowPackagePath the absolute path to the Workflow Package
+     * @param nodeTypes the allowed node types to include in the Workflow Package
+     * @return a list of paths contained in the Workflow Package
+     * @throws RepositoryException
+     */
+    List<String> getPaths(ResourceResolver resourceResolver, String workflowPackagePath, String[] nodeTypes) throws RepositoryException;
+
+    /**
      * Deletes the specified Workflow Package.
      *
      * @param resourceResolver The resource resolver to access the Workflow Package

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/impl/WorkflowPackageManagerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/impl/WorkflowPackageManagerImpl.java
@@ -147,7 +147,14 @@ public class WorkflowPackageManagerImpl implements WorkflowPackageManager {
      */
     public final List<String> getPaths(final ResourceResolver resourceResolver,
                                        final String path) throws RepositoryException {
+        return getPaths(resourceResolver,path, workflowPackageTypes);
+    }
 
+    /**
+     * {@inheritDoc}
+     */
+    public final List<String> getPaths(final ResourceResolver resourceResolver,
+            final String path, final String[] nodeTypes) throws RepositoryException {
         final List<String> collectionPaths = new ArrayList<String>();
 
         final Resource resource = resourceResolver.getResource(path);
@@ -171,7 +178,7 @@ public class WorkflowPackageManagerImpl implements WorkflowPackageManager {
                         ResourceCollectionUtil.getResourceCollection(node, resourceCollectionManager);
 
                 if (resourceCollection != null) {
-                    final List<Node> members = resourceCollection.list(workflowPackageTypes);
+                    final List<Node> members = resourceCollection.list(nodeTypes);
                     for (final Node member : members) {
                         collectionPaths.add(member.getPath());
                     }


### PR DESCRIPTION
I had a need to create a WF package with oak:Unstructured nodes.  From my testing, the creation part worked, but when using the getPaths API, it failed to return those nodes back to me.  While modifying the config could work, I probably don't want the oak:Unstructured returned in the general case, just this specific case, so modifying the API to allow this scenario seemed like the best option, especially since it's already supported by the underlying ResourceCollection API.

A note on testing: I looked at creating a test for this, but since the ResourceCollection is being mocked in the current tests, it didn't seem worth while.  Probably possible by mocking node type, extending the existing mock, etc.  If you want me to do that I will, just figured I'd start with this PR, and make those changes based on feedback.  