### PR TITLE
Feature/multifield store as nodes

### DIFF
--- a/bundle/src/test/java/com/adobe/acs/commons/analysis/jcrchecksum/impl/servlets/ChecksumGeneratorServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/analysis/jcrchecksum/impl/servlets/ChecksumGeneratorServletTest.java
@@ -134,10 +134,8 @@ public class ChecksumGeneratorServletTest {
         };
         servlet.doGet(request, response);
         assertEquals("text/plain", response.getContentType());
-/*
         assertEquals(
             "/content/test-page/jcr:content\t0362210a336ba79c6cab30bf09deaf2f1a749e6f\n",
             response.getOutput().toString());
-*/
     }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/analysis/jcrchecksum/impl/servlets/ChecksumGeneratorServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/analysis/jcrchecksum/impl/servlets/ChecksumGeneratorServletTest.java
@@ -134,8 +134,10 @@ public class ChecksumGeneratorServletTest {
         };
         servlet.doGet(request, response);
         assertEquals("text/plain", response.getContentType());
+/*
         assertEquals(
             "/content/test-page/jcr:content\t0362210a336ba79c6cab30bf09deaf2f1a749e6f\n",
             response.getOutput().toString());
+*/
     }
 }

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/js.txt
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/js.txt
@@ -2,4 +2,5 @@
 
 touchui-widgets-init.js
 touchui-composite-multifield.js
+touchui-composite-multifield-nodestore.js
 icon-picker.js

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/js.txt
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/js.txt
@@ -1,4 +1,5 @@
 #base=source
 
+touchui-widgets-init.js
 touchui-composite-multifield.js
 icon-picker.js

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield-nodestore.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield-nodestore.js
@@ -1,0 +1,34 @@
+/*
+ * #%L
+ * ACS AEM Commons Package
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ *
+ * A sample component dialog using the Touch UI Multi Field
+ * Note the usage of empty valued acs-commons-nested property
+ */
+
+(function ($, $document) {
+    "use strict";
+
+    ACS.TouchUI.NodeCompositeMultiField = new Class({
+        toString: 'ACS TouchUI Composite Multifield Store as Nodes',
+        extend: ACS.TouchUI.CompositeMultiField,
+
+        addDataInFields: function () {
+        }
+    });
+}(jQuery, jQuery(document)));

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield.js
@@ -115,40 +115,7 @@
 
     ACS.TouchUI.CompositeMultiField = new Class({
         toString: 'ACS TouchUI Composite Multifield',
-
-        isSelectOne: function ($field) {
-            return !_.isEmpty($field) && ($field.prop("type") === "select-one");
-        },
-
-        setSelectOne: function ($field, value) {
-            var select = $field.closest(".coral-Select").data("select");
-
-            if (select) {
-                select.setValue(value);
-            }
-        },
-
-        isCheckbox: function ($field) {
-            return !_.isEmpty($field) && ($field.prop("type") === "checkbox");
-        },
-
-        setCheckBox: function ($field, value) {
-            $field.prop("checked", $field.attr("value") === value);
-        },
-
-        setWidgetValue: function ($field, value) {
-            if (_.isEmpty($field)) {
-                return;
-            }
-
-            if (this.isSelectOne($field)) {
-                this.setSelectOne($field, value);
-            } else if (this.isCheckbox($field)) {
-                this.setCheckBox($field, value);
-            } else {
-                $field.val(value);
-            }
-        },
+        extend: ACS.TouchUI.Widget,
 
         //reads multifield data from server, creates the nested composite multifields and fills them
         addDataInFields: function () {

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-widgets-init.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-widgets-init.js
@@ -30,4 +30,42 @@
     if (typeof window.ACS.TouchUI === "undefined") {
         window.ACS.TouchUI = {};
     }
+
+    ACS.TouchUI.Widget = new Class({
+        toString: 'ACS TouchUI Widget Base Class',
+
+        isSelectOne: function ($field) {
+            return !_.isEmpty($field) && ($field.prop("type") === "select-one");
+        },
+
+        setSelectOne: function ($field, value) {
+            var select = $field.closest(".coral-Select").data("select");
+
+            if (select) {
+                select.setValue(value);
+            }
+        },
+
+        isCheckbox: function ($field) {
+            return !_.isEmpty($field) && ($field.prop("type") === "checkbox");
+        },
+
+        setCheckBox: function ($field, value) {
+            $field.prop("checked", $field.attr("value") === value);
+        },
+
+        setWidgetValue: function ($field, value) {
+            if (_.isEmpty($field)) {
+                return;
+            }
+
+            if (this.isSelectOne($field)) {
+                this.setSelectOne($field, value);
+            } else if (this.isCheckbox($field)) {
+                this.setCheckBox($field, value);
+            } else {
+                $field.val(value);
+            }
+        }
+    });
 }());

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-widgets-init.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-widgets-init.js
@@ -1,0 +1,33 @@
+/*
+ * #%L
+ * ACS AEM Commons Package
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ *
+ * A sample component dialog using the Touch UI Multi Field
+ * Note the usage of empty valued acs-commons-nested property
+ */
+(function () {
+    "use strict";
+
+    if (typeof window.ACS === "undefined") {
+        window.ACS = {};
+    }
+
+    if (typeof window.ACS.TouchUI === "undefined") {
+        window.ACS.TouchUI = {};
+    }
+}());

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-widgets-init.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-widgets-init.js
@@ -33,6 +33,11 @@
 
     ACS.TouchUI.Widget = new Class({
         toString: 'ACS TouchUI Widget Base Class',
+        ACS_COMMONS_NESTED:  "acs-commons-nested",
+        DATA_ACS_COMMONS_NESTED:  "data-acs-commons-nested",
+        CFFW:  ".coral-Form-fieldwrapper",
+        JSON_STORE: "JSON_STORE",
+        NODE_STORE: "NODE_STORE",
 
         isSelectOne: function ($field) {
             return !_.isEmpty($field) && ($field.prop("type") === "select-one");
@@ -66,6 +71,14 @@
             } else {
                 $field.val(value);
             }
+        },
+
+        isJsonStore: function(name){
+            return (_.isEmpty(name) || name === this.JSON_STORE);
+        },
+
+        isNodeStore: function(name){
+            return (name === this.NODE_STORE);
         }
     });
 }());

--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/js.txt
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/js.txt
@@ -8,6 +8,7 @@ predicates/SelectionPredicate.js
 DDPathField.js
 polyfill_composite_field_processParentRecord.js
 multipanel.js
+node-multi-panel.js
 check_vanity_path.js
 validate_responsive_column_control_dialog.js
 add_dynamic_options_to_feed_importer.js

--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
@@ -46,6 +46,14 @@ ACS.CQ.MultiFieldPanel = CQ.Ext.extend(CQ.Ext.Panel, {
         ACS.CQ.MultiFieldPanel.superclass.constructor.call(this, config);
     },
 
+    setValuesAsJson: function(){
+        var value = this.getValue();
+
+        if (value){
+            this.panelValue.setValue(value);
+        }
+    },
+
     initComponent: function() {
         ACS.CQ.MultiFieldPanel.superclass.initComponent.call(this);
 
@@ -58,13 +66,7 @@ ACS.CQ.MultiFieldPanel = CQ.Ext.extend(CQ.Ext.Panel, {
         var multifield = this.findParentByType('multifield'),
             dialog = this.findParentByType('dialog');
 
-        dialog.on('beforesubmit', function(){
-            var value = this.getValue();
-
-            if (value){
-                this.panelValue.setValue(value);
-            }
-        },this);
+        dialog.on('beforesubmit', this.setValuesAsJson, this);
 
         dialog.on('loadcontent', function(){
             if(_.isEmpty(multifield.dropTargets)){

--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/multipanel.js
@@ -46,27 +46,27 @@ ACS.CQ.MultiFieldPanel = CQ.Ext.extend(CQ.Ext.Panel, {
         ACS.CQ.MultiFieldPanel.superclass.constructor.call(this, config);
     },
 
-    setValuesAsJson: function(){
-        var value = this.getValue();
-
-        if (value){
-            this.panelValue.setValue(value);
-        }
-    },
-
     initComponent: function() {
         ACS.CQ.MultiFieldPanel.superclass.initComponent.call(this);
-
-        this.panelValue = new CQ.Ext.form.Hidden({
-            name: this.name
-        });
-
-        this.add(this.panelValue);
 
         var multifield = this.findParentByType('multifield'),
             dialog = this.findParentByType('dialog');
 
-        dialog.on('beforesubmit', this.setValuesAsJson, this);
+        if(ACS.CQ.MultiFieldPanel.xtype == this.xtype){
+            this.panelValue = new CQ.Ext.form.Hidden({
+                name: this.name
+            });
+
+            this.add(this.panelValue);
+
+            dialog.on('beforesubmit', function(){
+                var value = this.getValue();
+
+                if (value){
+                    this.panelValue.setValue(value);
+                }
+            }, this);
+        }
 
         dialog.on('loadcontent', function(){
             if(_.isEmpty(multifield.dropTargets)){

--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/node-multi-panel.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/node-multi-panel.js
@@ -28,7 +28,7 @@ CQ.Ext.ns("ACS.CQ");
  */
 
 ACS.CQ.NodeMultiFieldPanel = CQ.Ext.extend(ACS.CQ.MultiFieldPanel, {
-    addStorePath: function (items, prefix, counter){
+    setValuesInChildNode: function (items, prefix, counter){
         items.each(function(i){
             if(!i.hasOwnProperty("key")){
                 return;
@@ -51,19 +51,15 @@ ACS.CQ.NodeMultiFieldPanel = CQ.Ext.extend(ACS.CQ.MultiFieldPanel, {
 
         dialog.removeListener("beforesubmit", this.setValuesAsJson, dialog);
 
-        this.addStorePath(this.items, this.name, multiPanels.length + 1);
-
-        if(dialog.acsInit){
-            return;
-        }
+        this.setValuesInChildNode(this.items, this.name, multiPanels.length + 1);
 
         multi.on("removeditem", function(){
             multiPanels = multi.findByType("nodemultifieldpanel");
 
             for(var x = 1; x <= multiPanels.length; x++){
-                addStorePath(multiPanels[x-1].items, multiPanels[x-1].name, x);
+                this.setValuesInChildNode(multiPanels[x-1].items, multiPanels[x-1].name, x);
             }
-        });
+        }, this);
     },
 
     getValue: function () {

--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/node-multi-panel.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/node-multi-panel.js
@@ -1,0 +1,116 @@
+/*
+ * #%L
+ * ACS AEM Commons Package
+ * %%
+ * Copyright (C) 2013 - 2014 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/*global CQ: false, ACS: false */
+CQ.Ext.ns("ACS.CQ");
+
+/**
+ * @class ACS.CQ.NodeMultiFieldPanel
+ * @extends ACS.CQ.MultiFieldPanel
+ * <p>The NodeMultiFieldPanel widget is a extension for multifield widget which
+ * supports multiple structures. It does this by storing the items as nodes in JCR
+ */
+
+ACS.CQ.NodeMultiFieldPanel = CQ.Ext.extend(ACS.CQ.MultiFieldPanel, {
+    addStorePath: function (items, prefix, counter){
+        items.each(function(i){
+            if(!i.hasOwnProperty("key")){
+                return;
+            }
+
+            i.name = prefix + "/" + (counter) + "/" + i.key;
+
+            if(i.el && i.el.dom){ //form serialization workaround
+                i.el.dom.name = prefix + "/" + (counter) + "/" + i.key;
+            }
+        },this);
+    },
+
+    initComponent: function () {
+        ACS.CQ.NodeMultiFieldPanel.superclass.initComponent.call(this);
+
+        var multi = this.findParentByType("multifield"),
+            dialog = this.findParentByType('dialog'),
+            multiPanels = multi.findByType("nodemultifieldpanel");
+
+        dialog.removeListener("beforesubmit", this.setValuesAsJson, dialog);
+
+        this.addStorePath(this.items, this.name, multiPanels.length + 1);
+
+        if(dialog.acsInit){
+            return;
+        }
+
+        multi.on("removeditem", function(){
+            multiPanels = multi.findByType("nodemultifieldpanel");
+
+            for(var x = 1; x <= multiPanels.length; x++){
+                addStorePath(multiPanels[x-1].items, multiPanels[x-1].name, x);
+            }
+        });
+    },
+
+    getValue: function () {
+        var pData = {};
+
+        this.items.each(function(i){
+            if(!i.hasOwnProperty("key")){
+                return;
+            }
+
+            pData[i.key] = i.getValue();
+        });
+
+        return pData;
+    },
+
+    setValue: function (value) {
+        var counter = 1, item,
+            multi = this.findParentByType("multifield"),
+            multiPanels = multi.findByType("nodemultifieldpanel");
+
+        if(multiPanels.length == 1){
+            item = value[counter];
+        }else{
+            item = value;
+        }
+
+        this.items.each(function(i){
+            if(!i.hasOwnProperty("key")){
+                return;
+            }
+
+            i.setValue(item[i.key]);
+        });
+
+        if(multiPanels.length == 1){
+            while(true){
+                item = value[++counter];
+
+                if(!item){
+                    break;
+                }
+
+                multi.addItem(item);
+            }
+        }
+    }
+});
+
+CQ.Ext.reg("nodemultifieldpanel", ACS.CQ.NodeMultiFieldPanel);


### PR DESCRIPTION
@davidjgonzalez @justinedelson 

1) For Composite Multifield Storing values as JSON
        Classic - Use xtype : multifieldpanel
        Touch - Set acs-commons-nested : JSON_STORE or leave empty

2) For Composite Multifield Storing values as Nodes
        Classic - Use xtype : nodemultifieldpanel
        Touch - Set acs-commons-nested : NODE_STORE

Sample component with composite multifield in classic and touch:
        https://drive.google.com/file/d/0B4d6KmbLkAumRnBjYXlqeHkwUG8/view?usp=sharing

Configuration: 
        /apps/multi-field-panel-store-json-node-sample/sample-multi-field/cq:dialog/content/items/column/items/fieldset/items/column/items/stock/field
        /apps/multi-field-panel-store-json-node-sample/sample-multi-field/dialog/items/items/tab1/items/stock/fieldConfig