### PR TITLE
Add a Sling Models 1.2 compliant injector-specific annotation.

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -51,8 +51,11 @@
                         <Bundle-Activator>com.adobe.acs.commons.Activator</Bundle-Activator>
                         <Bundle-SymbolicName>com.adobe.acs.acs-aem-commons-bundle</Bundle-SymbolicName>
                         <Import-Package>
+                        	
                             com.adobe.cq.dialogconversion;resolution:=optional,
                             sun.misc.*;resolution:=optional,
+                            org.apache.sling.models.annotations.*;resolution:=optional, <!-- the used class InjectionStrategy is only since Sling Models API 1.2 -->
+                            org.apache.sling.models.spi.injectorspecific.*;resolution:=optional, <!-- that package was added with Sling Models API 1.1 -->
                             *
                         </Import-Package>
                         <Embed-Dependency>guava</Embed-Dependency>
@@ -239,16 +242,11 @@
             <version>2.7.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.models.api</artifactId>
-            <version>1.1.0</version>
-            <scope>test</scope>
-        </dependency>
+        
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.models.impl</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -256,6 +254,12 @@
             <artifactId>org.apache.sling.commons.html</artifactId>
             <version>1.0.0</version>
             <scope>test</scope>
+        </dependency>
+        <!-- the custom annotation for AemObject -->
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.models.api</artifactId>
+            <version>1.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.adobe.aem</groupId>

--- a/bundle/src/main/java/com/adobe/acs/commons/models/injectors/annotation/AemObject.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/models/injectors/annotation/AemObject.java
@@ -1,0 +1,75 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 - 2014 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.models.injectors.annotation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.apache.sling.models.annotations.Source;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
+import org.apache.sling.models.spi.injectorspecific.InjectAnnotation;
+
+/**
+ *
+ * Sling Models Injector which injects the Adobe AEM objects defined in
+ * <a href="http://bit.ly/1gmlmfE">&lt;cq:defineObjects/&gt;</a>.
+ * <p>
+ * the following objects can be injected:
+ * <ul>
+ * <li> resource the current resource
+ * <li> resourceResolver the current resource resolver
+ *
+ * <li> componentContext component context of this request
+ *
+ * <li> pageManager page manager
+ * <li> currentPage containing page addressed by the request
+ * <li> resourcePage containing page of the addressed resource
+ *
+ * <li> designer the designer
+ * <li> currentDesign design of the addressed resource
+ * <li> resourceDesign design of the addressed resource
+ *
+ * <li> currentStyle style addressed by the request
+ * <li> session the current session
+ * <li> xssApi cross site scripting provider for the current request
+ * </ul>
+ *
+ * Note: This can only be used together with Sling Models API bundle in version 1.2.0
+ */
+@Target({ METHOD, FIELD, PARAMETER })
+@Retention(RUNTIME)
+@InjectAnnotation
+@Source("define-objects")
+public @interface AemObject {
+
+    /**
+     * if set to REQUIRED injection is mandatory, if set to OPTIONAL injection is optional, in case of DEFAULT 
+     * the standard annotations ({@link org.apache.sling.models.annotations.Optional}, {@link org.apache.sling.models.annotations.Required}) are used.
+     * If even those are not available the default injection strategy defined on the {@link org.apache.sling.models.annotations.Model} applies.
+     * Default value = DEFAULT.
+     */
+    public InjectionStrategy injectionStrategy() default InjectionStrategy.DEFAULT;
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/models/injectors/annotation/impl/AemObjectAnnotationProcessorFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/models/injectors/annotation/impl/AemObjectAnnotationProcessorFactory.java
@@ -1,0 +1,65 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 - 2014 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.models.injectors.annotation.impl;
+
+import java.lang.reflect.AnnotatedElement;
+
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
+import org.apache.sling.models.spi.injectorspecific.AbstractInjectAnnotationProcessor2;
+import org.apache.sling.models.spi.injectorspecific.InjectAnnotationProcessor2;
+import org.apache.sling.models.spi.injectorspecific.StaticInjectAnnotationProcessorFactory;
+
+import com.adobe.acs.commons.models.injectors.annotation.AemObject;
+/**
+ * The annotation processor for the {@link AemObject} annotation
+ *
+ * Note: This can only be used together with Sling Models API bundle in version 1.2.0 (due to the dependency on InjectionStrategy)
+ */
+@Component
+@Service
+public class AemObjectAnnotationProcessorFactory implements StaticInjectAnnotationProcessorFactory{
+
+	@Override
+    public InjectAnnotationProcessor2 createAnnotationProcessor(final AnnotatedElement element) {
+        // check if the element has the expected annotation
+        AemObject annotation = element.getAnnotation(AemObject.class);
+        if (annotation != null) {
+            return new AemObjectAnnotationProcessor(annotation);
+        }
+        return null;
+    }
+
+    private static class AemObjectAnnotationProcessor extends AbstractInjectAnnotationProcessor2 {
+
+        private final AemObject annotation;
+
+        public AemObjectAnnotationProcessor(final AemObject annotation) {
+            this.annotation = annotation;
+        }
+
+        @Override
+        public InjectionStrategy getInjectionStrategy() {
+            return annotation.injectionStrategy();
+        }
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/models/injectors/impl/AemObjectInjector.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/models/injectors/impl/AemObjectInjector.java
@@ -76,7 +76,7 @@ import java.lang.reflect.Type;
  * pre-configured from the current request.
  */
 @Property(name = Constants.SERVICE_RANKING, intValue = 4500)
-public final class AemObjectsInjector implements Injector {
+public final class AemObjectInjector implements Injector {
 
     private static final String COM_DAY_CQ_WCM_TAGS_DEFINE_OBJECTS_TAG = "com.day.cq.wcm.tags.DefineObjectsTag";
 

--- a/bundle/src/test/java/com/adobe/acs/commons/models/injectors/impl/AemObjectInjectorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/models/injectors/impl/AemObjectInjectorTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class AemObjectsInjectorTest {
+public class AemObjectInjectorTest {
 
     @Mock
     private Resource resource;
@@ -71,7 +71,7 @@ public class AemObjectsInjectorTest {
 
     @Before
     public final void setUp() throws Exception {
-        AemObjectsInjector aemObjectsInjector = new AemObjectsInjector();
+        AemObjectInjector aemObjectsInjector = new AemObjectInjector();
         factory = new TestModelAdapterFactory();
 
         factory.bindInjector(aemObjectsInjector, Collections.<String, Object> singletonMap(Constants.SERVICE_ID, 1L));


### PR DESCRIPTION
All dependencies are marked optional to make sure the bundle still runs with AEM 6.0.

This fixes #470