### PR TITLE
remove java8 specific javadoc-parameters from analysis profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,8 +161,7 @@
                     <configuration>
                         <excludePackageNames>
                             *.impl
-                        </excludePackageNames>
-                        <additionalparam>-Xdoclint:none</additionalparam>
+                        </excludePackageNames>          
                     </configuration>
                 </plugin>
                 <plugin>
@@ -484,6 +483,26 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+        	<id>jdk18-pedantic-javadoc</id>
+        	<activation>
+        		<jdk>[1.8,)</jdk>
+        	</activation>
+        	<build>
+        		<plugins>
+        			<plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                        	<excludePackageNames>
+                            	*.impl
+                        	</excludePackageNames>
+                        <additionalparam>-Xdoclint:none</additionalparam>
+                    </configuration>
+                    </plugin>
+        		</plugins>
+        	</build>
+        
         </profile>
     </profiles>
 


### PR DESCRIPTION
Fixing #605 
Now the analysis profile should work with java7 again.