### PR TITLE
Configure parsys placeholder text and drop zone background colors 

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/js.txt
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/js.txt
@@ -5,3 +5,4 @@ touchui-composite-multifield.js
 touchui-composite-multifield-nodestore.js
 icon-picker.js
 touchui-limit-parsys.js
+touchui-configure-parsys-placeholder.js

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-configure-parsys-placeholder.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-configure-parsys-placeholder.js
@@ -1,0 +1,147 @@
+/*
+ * #%L
+ * ACS AEM Commons Package
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ *
+ * Extends /libs/foundation/components/parsys to configure drop zone placeholder text and colors
+ * To enable this feature set the following properties on desing node - eg. /etc/designs/geometrixx/jcr:content/contentpage/par
+ * acsParsysPlaceholderText - to replace default placeholder "Drop Components Here" with custom text eg. "Please drop images only!!!"
+ * acsParsysTextColor - placeholder text color eg. #0000FF
+ * acsParsysBackgroundColor - drop zone background color - eg.#9DB68C
+ * acsParsysBorderColor - drop zone border color - eg. #E5E500
+ */
+(function($, $document, gAuthor){
+    var ACS_PARSYS_PLACEHOLDER_TEXT = "acsParsysPlaceholderText",
+        ACS_PARSYS_TEXT_COLOR = "acsParsysTextColor",
+        ACS_PARSYS_BG_COLOR = "acsParsysBackgroundColor",
+        ACS_PARSYS_BORDER_COLOR = "acsParsysBorderColor",
+        PARSYS = "foundation/components/parsys/new",
+        IPARSYS = "foundation/components/iparsys/new",
+        PARSYS_SELECTOR = "[data-path$='/*']",
+        PLACE_HOLDER = "cq-Overlay--placeholder",
+        configCache = {};
+
+    function getDesignPath(editable){
+        var parsys = editable.getParent(),
+            designSrc = parsys.config.designDialogSrc,
+            result = {}, param;
+
+        designSrc = designSrc.substring(designSrc.indexOf("?") + 1);
+
+        designSrc.split(/&/).forEach( function(it) {
+            if (_.isEmpty(it)) {
+                return;
+            }
+            param = it.split("=");
+            result[param[0]] = param[1];
+        });
+
+        return decodeURIComponent(result.content);
+    }
+
+    function isParsys(editable){
+        return editable && (editable.type === PARSYS || editable.type === IPARSYS);
+    }
+
+    function getParsyses(){
+        var editables = gAuthor.edit.findEditables(),
+            parsys = [];
+
+        _.each(editables, function(editable){
+            if(isParsys(editable)){
+                parsys.push(editable);
+            }
+        });
+
+        return parsys;
+    }
+
+    function getColor(color){
+        color = color.trim();
+
+        if(color.indexOf("#") !== 0){
+            color = "#" + color;
+        }
+
+        return color;
+    }
+
+    function configureParsys(parsys, type){
+        if(!parsys || !parsys.getParent() || !parsys.getParent().overlay){
+            return;
+        }
+
+        var $overlay = $(parsys.getParent().overlay.dom),
+            $placeholder = $overlay.find(PARSYS_SELECTOR);
+
+        if(!$placeholder.hasClass(PLACE_HOLDER)){
+            return;
+        }
+
+        function configure(data){
+            if(_.isEmpty(data)){
+                return;
+            }
+
+            configCache[parsys.getParent().path] = data;
+
+            var color;
+
+            if(!_.isEmpty(data[ACS_PARSYS_PLACEHOLDER_TEXT])){
+                $placeholder.attr("data-text", data[ACS_PARSYS_PLACEHOLDER_TEXT]);
+            }
+
+            if(!_.isEmpty(data[ACS_PARSYS_TEXT_COLOR])){
+                $placeholder.css("color", getColor(data[ACS_PARSYS_TEXT_COLOR]));
+            }
+
+            if(!_.isEmpty(data[ACS_PARSYS_BG_COLOR])){
+                $placeholder.css("background-color", getColor(data[ACS_PARSYS_BG_COLOR]));
+            }
+
+            if(!_.isEmpty(data[ACS_PARSYS_BORDER_COLOR]) && type && (type === 'mouseover')){
+                $placeholder.css("border-color", getColor(data[ACS_PARSYS_BORDER_COLOR]));
+            }
+        }
+
+        if(_.isEmpty(configCache[parsys.getParent().path])){
+            $.ajax( getDesignPath(parsys) + ".2.json" ).done(configure);
+        }else{
+            configure(configCache[parsys.getParent().path]);
+        }
+    }
+
+    function extendParsys(event){
+        if(event.layer !== "Edit"){
+            return;
+        }
+
+        _.each(getParsyses(), function(parsys){
+            configureParsys(parsys);
+        });
+    }
+
+    $document.on('cq-layer-activated', extendParsys);
+
+    $document.on("cq-overlay-hover.cq-edit-layer", function (event) {
+        if(!event.inspectable){
+            return;
+        }
+
+        configureParsys(event.inspectable, event.originalEvent.type);
+    });
+}(jQuery, jQuery(document), Granite.author));

--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/js.txt
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/js.txt
@@ -15,3 +15,4 @@ add_dynamic_options_to_feed_importer.js
 add_language_titles_to_item_dialog.js
 icon-picker.js
 classicui-limit-parsys.js
+classicui-configure-parsys-placeholder.js

--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/classicui-configure-parsys-placeholder.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/classicui-configure-parsys-placeholder.js
@@ -42,7 +42,7 @@
 
         var resouceType = editable.params["./sling:resourceType"];
 
-        return ( resouceType === CQ.wcm.EditBase.PARSYS_NEW || resouceType === "foundation/components/iparsys/par");
+        return ( resouceType === CQ.wcm.EditBase.PARSYS_NEW || resouceType === "foundation/components/iparsys/new");
     }
 
     function getColor(color){

--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/classicui-configure-parsys-placeholder.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/classicui-configure-parsys-placeholder.js
@@ -1,0 +1,143 @@
+/*
+ * #%L
+ * ACS AEM Commons Package
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ *
+ * Extends /libs/foundation/components/parsys to configure drop zone placeholder text and colors
+ * To enable this feature set the following properties on desing node - eg. /etc/designs/geometrixx/jcr:content/contentpage/par
+ * acsParsysPlaceholderText - to replace default placeholder "Drop Components Here" with custom text eg. "Please drop images only!!!"
+ * acsParsysTextColor - placeholder text color eg. #0000FF
+ * acsParsysBackgroundColor - drop zone background color - eg.#9DB68C
+ * acsParsysBorderColor - drop zone border color - eg. #E5E500
+ */
+(function(){
+    var pathName = window.location.pathname,
+        ACS_PARSYS_PLACEHOLDER_TEXT = "acsParsysPlaceholderText",
+        ACS_PARSYS_TEXT_COLOR = "acsParsysTextColor",
+        ACS_PARSYS_BG_COLOR = "acsParsysBackgroundColor",
+        ACS_PARSYS_BORDER_COLOR = "acsParsysBorderColor";
+
+    if( ( pathName !== "/cf" ) && ( pathName.indexOf("/content") !== 0)){
+        return;
+    }
+
+    function isParsysNew(editable){
+        if(!_.isObject(editable.params) || _.isEmpty(editable.params["./sling:resourceType"])){
+            return false;
+        }
+
+        var resouceType = editable.params["./sling:resourceType"];
+
+        return ( resouceType === CQ.wcm.EditBase.PARSYS_NEW || resouceType === "foundation/components/iparsys/par");
+    }
+
+    function getColor(color){
+        color = color.trim();
+
+        if(color.indexOf("#") !== 0){
+            color = "#" + color;
+        }
+
+        return color;
+    }
+
+    function getConfiguration(editComponent) {
+        var pageInfo = CQ.utils.WCM.getPageInfo(editComponent.path),
+            designConfig = {}, cellSearchPath, parentPath, parName;
+
+        if (!pageInfo || !pageInfo.designObject) {
+            return;
+        }
+
+        try {
+            cellSearchPath = editComponent.cellSearchPath;
+            parentPath = editComponent.getParent().path;
+
+            cellSearchPath = cellSearchPath.substring(0, cellSearchPath.indexOf("|"));
+            parName = parentPath.substring(parentPath.lastIndexOf("/") + 1);
+
+            designConfig = pageInfo.designObject.content[cellSearchPath][parName];
+        } catch (err) {
+            console.log("ACS AEM Commons - Error getting parsys configuration", err);
+        }
+
+        return designConfig;
+    }
+
+    function getParsyses(){
+        var parsyses = {};
+
+        _.each(CQ.WCM.getEditables(), function(e){
+            if(!isParsysNew(e)){
+                return;
+            }
+
+            parsyses[e.path] = e;
+        });
+
+        return parsyses;
+    }
+
+    function configureParsys(){
+        var parsyses = getParsyses(), placeholder,
+            $placeholder, $pContainer, designConfig;
+
+        _.each(parsyses, function(parsys){
+            if(!parsys.emptyComponent) {
+                return;
+            }
+
+            designConfig = getConfiguration(parsys);
+
+            placeholder = parsys.emptyComponent.findByType("static")[0];
+
+            $placeholder = $(placeholder.el.dom);
+
+            $pContainer = $placeholder.closest(".cq-editrollover-insert-container");
+
+            if(designConfig[ACS_PARSYS_PLACEHOLDER_TEXT]){
+                $placeholder.html(designConfig[ACS_PARSYS_PLACEHOLDER_TEXT]);
+            }
+
+            if(designConfig[ACS_PARSYS_TEXT_COLOR]){
+                $placeholder.css("color", getColor(designConfig[ACS_PARSYS_TEXT_COLOR]));
+            }
+
+            if(designConfig[ACS_PARSYS_BG_COLOR]){
+                $pContainer.css("background-color", getColor(designConfig[ACS_PARSYS_BG_COLOR]));
+            }
+
+            if(designConfig[ACS_PARSYS_BORDER_COLOR]){
+                var color = getColor(designConfig[ACS_PARSYS_BORDER_COLOR]);
+
+                parsys.highlight.on("beforeshow", function(highlight){
+                    $("#" + highlight.id).css("background-color", color);
+                });
+            }
+        });
+    }
+
+    function handleEditMode(){
+        CQ.WCM.on("editablesready", configureParsys, this);
+    }
+
+    CQ.Ext.onReady(function () {
+        if(CQ.WCM.isEditMode()){
+            handleEditMode();
+        }
+    });
+}());


### PR DESCRIPTION
@justinedelson @davidjgonzalez - feature to configure parsys 

1) Set one or more of the following properties manually in CRX eg. /etc/designs/geometrixx/jcr:content/contentpage/rightpar

![image](https://cloud.githubusercontent.com/assets/6585493/12925297/469398f4-cf23-11e5-853b-40a9b016a378.png)

2) Classic UI

![image](https://cloud.githubusercontent.com/assets/6585493/12925417/c84ac386-cf23-11e5-9c19-fae6ccb6e829.png)

3) Touch UI

![image](https://cloud.githubusercontent.com/assets/6585493/12925444/edcca8cc-cf23-11e5-903b-ad3a07e9fd9a.png)

