### PR TITLE
Touch UI RTE dialog plugin should use configuration to add button to toolbar

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/rte-plugins/source/dialog-plugin.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/rte-plugins/source/dialog-plugin.js
@@ -100,7 +100,7 @@
                                             this, true, config.tooltip || "Insert TouchUI Dialog");
 
             tbGenerator.addElement(GROUP, plg.Plugin.SORT_FORMAT, this.pickerUI, 120);
-            tbGenerator.registerIcon(GROUP + "#" + INSERT_DIALOG_CONTENT_FEATURE, "coral-Icon coral-Icon--tableEdit coral-RichText--trigger");
+            tbGenerator.registerIcon(GROUP + "#" + INSERT_DIALOG_CONTENT_FEATURE, "coral-Icon coral-Icon--tableEdit");
         },
 
         execute: function (id) {

--- a/content/src/main/content/jcr_root/apps/acs-commons/rte-plugins/source/dialog-plugin.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/rte-plugins/source/dialog-plugin.js
@@ -30,6 +30,8 @@
  * 5) Set the property "dialogPath" in "insertDialogContent" to path created in step 1 eg. /apps/test-dialogs/cq:dialog
  * 6) Set the property "onsubmit" in "insertDialogContent" with listener function (executed on dialog submit)
  *      eg. <code>function(dialogData) { return '<h1>' + dialogData.heading + '</h1>'; }</code>
+ * 7) Add to the fullscreen "toolbar" property. Include "acs-commons#insertDialogContent" in the desired location
+ *      e.g. /apps/<project>/components/text/cq:editConfig/cq:inplaceEditing/inplaceEditingTextConfig/uiSettings/cui/fullscreen
  *
  */
 (function ($, $document, Handlebars) {
@@ -42,10 +44,7 @@
         GROUP = "acs-commons",
         INSERT_DIALOG_CONTENT_FEATURE = "insertDialogContent",
         INSERT_DIALOG_CONTENT_DIALOG = "insertDialogContentDialog",
-        AcsCuiToolbarBuilder,
         InsertDialogContentPluginDialog,
-        AcsDialogManager,
-        AcsToolkitImpl,
         InsertTouchUIDialogPlugin,
         InsertTouchUIDialogCmd;
 
@@ -66,36 +65,6 @@
         fui.prompt(title, message, "notice", options);
     }
 
-    //extend the toolbar builder to register plugin icon in fullscreen mode
-    AcsCuiToolbarBuilder = new Class({
-        toString: "ACSCuiToolbarBuilder",
-
-        extend: CUI.rte.ui.cui.CuiToolbarBuilder,
-
-        _getUISettings: function (options) {
-            var uiSettings = this.superClass._getUISettings(options),
-                toolbar, feature;
-
-            //insertDialogContent feature is supported in fullscreen mode only
-            if(!uiSettings.fullscreen){
-                return uiSettings;
-            }
-
-            toolbar = uiSettings.fullscreen.toolbar;
-            feature = getUISetting();
-
-            if (toolbar.indexOf(feature) === -1) {
-                toolbar.splice(3, 0, feature);
-            }
-
-            if (!this._getClassesForCommand(feature)) {
-                this.registerAdditionalClasses(feature, "coral-Icon coral-Icon--tableEdit");
-            }
-
-            return uiSettings;
-        }
-    });
-
     //popover dialog hosting iframe
     InsertDialogContentPluginDialog = new Class({
         extend: CUI.rte.ui.cui.AbstractBaseDialog,
@@ -106,44 +75,6 @@
             return INSERT_DIALOG_CONTENT_DIALOG;
         }
     });
-
-    //extend the CUI dialog manager to register popover dialog
-    AcsDialogManager = new Class({
-        toString: "ACSDialogManager",
-
-        extend: CUI.rte.ui.cui.CuiDialogManager,
-
-        create: function (dialogId, config) {
-            if (dialogId !== INSERT_DIALOG_CONTENT_DIALOG) {
-                return this.superClass.create.call(this, dialogId, config);
-            }
-
-            var context = this.editorKernel.getEditContext(),
-                $container = CUI.rte.UIUtils.getUIContainer($(context.root)),
-                dialog = new InsertDialogContentPluginDialog();
-
-            dialog.attach(config, $container, this.editorKernel, true);
-
-            return dialog;
-        }
-    });
-
-    //extend the toolkit implementation for custom toolbar builder and dialog manager
-    AcsToolkitImpl = new Class({
-        toString: "ACSToolkitImpl",
-
-        extend: CUI.rte.ui.cui.ToolkitImpl,
-
-        createToolbarBuilder: function () {
-            return new AcsCuiToolbarBuilder();
-        },
-
-        createDialogManager: function (editorKernel) {
-            return new AcsDialogManager(editorKernel);
-        }
-    });
-
-    CUI.rte.ui.ToolkitRegistry.register("cui", AcsToolkitImpl);
 
     InsertTouchUIDialogPlugin = new Class({
         toString: "TouchUIInsertDialogPlugin",
@@ -169,12 +100,14 @@
                                             this, true, config.tooltip || "Insert TouchUI Dialog");
 
             tbGenerator.addElement(GROUP, plg.Plugin.SORT_FORMAT, this.pickerUI, 120);
+            tbGenerator.registerIcon(GROUP + "#" + INSERT_DIALOG_CONTENT_FEATURE, "coral-Icon coral-Icon--tableEdit coral-RichText--trigger");
         },
 
         execute: function (id) {
             var ek = this.editorKernel,
                 dm = ek.getDialogManager(),
-                $popover, dialog, popoverConfig,
+                context = ek.getEditContext(),
+                $popover, dialog, popoverConfig, $container,
                 dialogConfig = {
                     parameters: {
                         "command": getUISetting()
@@ -198,7 +131,9 @@
                 return;
             }
 
-            dialog = this.dialog = dm.create(INSERT_DIALOG_CONTENT_DIALOG, dialogConfig);
+            $container = CUI.rte.UIUtils.getUIContainer($(context.root));
+            dialog = this.dialog = new InsertDialogContentPluginDialog();
+            dialog.attach(dialogConfig, $container, ek);
 
             dm.prepareShow(this.dialog);
 

--- a/content/src/main/content/jcr_root/apps/acs-commons/rte-plugins/source/dialog-plugin.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/rte-plugins/source/dialog-plugin.js
@@ -26,12 +26,12 @@
  *      eg. /apps/<project>/components/text/dialog/items/tab1/items/text/rtePlugins/acs-commons
  * 3) Add property "features" of type String[] and single value "insertDialogContent"
  * 4) Create nt:unstructured "insertDialogContent" under "acs-commons"
- *      eg. /libs/foundation/components/text/dialog/items/tab1/items/text/rtePlugins/acs-commons/insertDialogContent
+ *      eg. /apps/<project>/components/text/dialog/items/tab1/items/text/rtePlugins/acs-commons/insertDialogContent
  * 5) Set the property "dialogPath" in "insertDialogContent" to path created in step 1 eg. /apps/test-dialogs/cq:dialog
  * 6) Set the property "onsubmit" in "insertDialogContent" with listener function (executed on dialog submit)
  *      eg. <code>function(dialogData) { return '<h1>' + dialogData.heading + '</h1>'; }</code>
- * 7) Add to the fullscreen "toolbar" property. Include "acs-commons#insertDialogContent" in the desired location
- *      e.g. /apps/<project>/components/text/cq:editConfig/cq:inplaceEditing/inplaceEditingTextConfig/uiSettings/cui/fullscreen
+ * 7) Add to the fullscreen uiSettings "toolbar" property. Include "acs-commons#insertDialogContent" in the desired location
+ *      e.g. /apps/<project>/components/text/dialog/items/tab1/items/text/uiSettings/cui/fullscreen
  *
  */
 (function ($, $document, Handlebars) {


### PR DESCRIPTION
Removed extensions of the CUI DialogManager, ToolbarBuilder and ToolkitImpl in favour of configuration via cq:editConfig.

Here is a sample edit config:
```
<?xml version="1.0" encoding="UTF-8"?>
<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
    jcr:primaryType="cq:EditConfig">
    <cq:inplaceEditing
        jcr:primaryType="cq:InplaceEditingConfig"
        active="{Boolean}true"
        configPath="inplaceEditingTextConfig"
        editorType="text">
        <inplaceEditingTextConfig
            jcr:primaryType="cq:Widget"
            hideLabel="{Boolean}true"
            name="./text"
            xtype="richtext">
            <rtePlugins jcr:primaryType="nt:unstructured">
                <links
                    jcr:primaryType="nt:unstructured"
                    features="*"/>
                <acs-commons
                    jcr:primaryType="nt:unstructured"
                    features="[insertDialogContent]">
                    <insertDialogContent
                        jcr:primaryType="nt:unstructured"
                        dialogPath="/apps/test-dialogs/cq:dialog"
                        onsubmit="function (data) { return &quot;&lt;h1>&quot; + data.heading + &quot;&lt;/h1>&quot;; }"/>
                </acs-commons>
                <image
                    jcr:primaryType="nt:unstructured"
                    features="*"/>
            </rtePlugins>
            <uiSettings jcr:primaryType="nt:unstructured">
                <cui jcr:primaryType="nt:unstructured">
                    <inline
                        jcr:primaryType="nt:unstructured"
                        toolbar="[#format,#justify,#lists,links#modifylink,links#unlink,-,customplugin#customcommand,-,fullscreen#start,-,control#close,control#save]">
                        <popovers jcr:primaryType="nt:unstructured">
                            <format
                                jcr:primaryType="nt:unstructured"
                                icon="text"
                                items="[format#bold,format#italic,format#underline,subsuperscript#subscript,subsuperscript#superscript]"
                                ref="format"/>
                            <justify
                                jcr:primaryType="nt:unstructured"
                                icon="text"
                                items="[justify#justifyleft,justify#justifycenter,justify#justifyright]"
                                ref="justify"/>
                        </popovers>
                    </inline>
                    <fullscreen
                        jcr:primaryType="nt:unstructured"
                        toolbar="[format#bold,format#italic,format#underline,acs-commons#insertDialogContent,subsuperscript#subscript,subsuperscript#superscript,-,links#modifylink,links#unlink,links#anchor,-,fullscreen#finish]">
                        <popovers jcr:primaryType="nt:unstructured">
                            <styles
                                jcr:primaryType="nt:unstructured"
                                items="styles:getStyles:styles-pulldown"
                                ref="styles"/>
                            <paraformat
                                jcr:primaryType="nt:unstructured"
                                items="paraformat:getFormats:paraformat-pulldown"
                                ref="paraformat"/>
                        </popovers>
                    </fullscreen>
                </cui>
            </uiSettings>
        </inplaceEditingTextConfig>
    </cq:inplaceEditing>
</jcr:root>
```