### PR TITLE
Check for serverN folders before adding root workflow instances folder

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/removal/impl/WorkflowInstanceRemoverImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/removal/impl/WorkflowInstanceRemoverImpl.java
@@ -444,20 +444,19 @@ public final class WorkflowInstanceRemoverImpl implements WorkflowInstanceRemove
         final Resource root = resourceResolver.getResource(WORKFLOW_INSTANCES_PATH);
         final Iterator<Resource> itr = root.listChildren();
 
-        boolean addedRoot = false;
+        boolean rootContainsDatedFolders = false;
 
         while (itr.hasNext()) {
             Resource resource = itr.next();
 
             if (NN_SERVER_FOLDER_PATTERN.matcher(resource.getName()).matches()) {
                 folders.add(resource);
-            } else if (!addedRoot && NN_DATE_FOLDER_PATTERN.matcher(resource.getName()).matches()) {
-                folders.add(root);
-                addedRoot = true;
+            } else if (!rootContainsDatedFolders && NN_DATE_FOLDER_PATTERN.matcher(resource.getName()).matches()) {
+                rootContainsDatedFolders = true;
             }
         }
 
-        if (folders.isEmpty()) {
+        if (folders.isEmpty() && rootContainsDatedFolders) {
             folders.add(root);
         }
 


### PR DESCRIPTION
This PR is to resolve #663.

The root folder was being added to the workflow instances folder before all the folders had been checked for serverN folders.  This was causing serverN
folders to be compared with dated folders causing a number format exception in the folder comparator.  This will ignore dated folders in the root if there is a serverN folder found.

If the desired behaviour should be to add the `/etc/workflow/instances` and the child serverN folders as roots, but ignore serverN as a child then it might be necessary to reintroduce [this change](https://github.com/Adobe-Consulting-Services/acs-aem-commons/commit/d4bd3483ac741a30946e9d105bf6aa2afb1bc76a#diff-67307694f86fa5353d0239ec52ff2ce9L223) removed in a merge.