### PR TITLE
Version Compare, added and removed in next version 

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImpl.java
@@ -165,7 +165,7 @@ public final class EvolutionEntryImpl implements EvolutionEntry {
                 return false;
             }
             if (isResource()) {
-                Node node = version.getLinearPredecessor().getFrozenNode().getNode(relativePath);
+                Node node = version.getLinearSuccessor().getFrozenNode().getNode(relativePath);
                 return node == null;
             } else {
                 Property prop = version.getLinearSuccessor().getFrozenNode().getProperty(relativePath);

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImpl.java
@@ -38,6 +38,7 @@ public final class EvolutionEntryImpl implements EvolutionEntry {
     private static String V_ADDED = "added";
     private static String V_CHANGED = "changed";
     private static String V_REMOVED = "removed";
+    private static String V_ADDED_REMOVED = "added-removed";
 
     private EvolutionEntryType type;
     private String name;
@@ -129,7 +130,9 @@ public final class EvolutionEntryImpl implements EvolutionEntry {
 
     @Override
     public String getStatus() {
-        if (isAdded()) {
+        if (isAdded() && isWillBeRemoved()) {
+            return V_ADDED_REMOVED;
+        } else if (isAdded()) {
             return V_ADDED;
         } else if (isWillBeRemoved()) {
             return V_REMOVED;

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImpl.java
@@ -39,6 +39,7 @@ public final class EvolutionEntryImpl implements EvolutionEntry {
     private static String V_CHANGED = "changed";
     private static String V_REMOVED = "removed";
     private static String V_ADDED_REMOVED = "added-removed";
+    private static String V_CHANGED_REMOVED = "changed-removed";
 
     private EvolutionEntryType type;
     private String name;
@@ -130,7 +131,9 @@ public final class EvolutionEntryImpl implements EvolutionEntry {
 
     @Override
     public String getStatus() {
-        if (isAdded() && isWillBeRemoved()) {
+        if (isChanged() && isWillBeRemoved()) {
+            return V_CHANGED_REMOVED;
+        } else if (isAdded() && isWillBeRemoved()) {
             return V_ADDED_REMOVED;
         } else if (isAdded()) {
             return V_ADDED;

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/clientlibs/css/app.less
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/clientlibs/css/app.less
@@ -105,6 +105,9 @@
     }
     .legend {
         width: 200px;
+        .inner-version-entry {
+            padding: 0;
+        }
     }
     .green, .status-added {
         border-right: 5px solid green;
@@ -119,6 +122,12 @@
         border-right: 2px solid red;
         .inner-version-entry {
             border-right: 3px solid green;
+        }
+    }
+    .status-changed-removed {
+        border-right: 2px solid red;
+        .inner-version-entry {
+            border-right: 3px solid orange;
         }
     }
     

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/clientlibs/css/app.less
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/clientlibs/css/app.less
@@ -86,8 +86,11 @@
     
     .version-entry{
         border-top: 1px solid grey;
-        padding: 2px;
         overflow: hidden;
+
+    }
+    .inner-version-entry {
+        padding: 2px;
     }
     span.key {
         font-weight: bold;
@@ -111,6 +114,12 @@
     }
     .orange, .status-changed {
         border-right: 5px solid orange;
+    }
+    .status-added-removed {
+        border-right: 2px solid red;
+        .inner-version-entry {
+            border-right: 3px solid green;
+        }
     }
     
     .depth-0 {

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/version-compare.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/version-compare.jsp
@@ -73,6 +73,7 @@
                                 <div class="status-added">added</div>
                                 <div class="status-changed">changed</div>
                                 <div class="status-removed">removed in next version</div>
+                                <div class="status-added-removed"><div class="inner-version-entry">added and removed in next version</div></div>
                             </div>
                         </section>
 
@@ -87,15 +88,17 @@
                                             </div>
                                             <c:forEach var="versionEntry" items="${evolutionItem.versionEntries}" varStatus="entryCounter">
                                                 <a href="#popover-${versionEntry.uniqueName}-${evoCounter.index}" data-toggle="popover" data-point-from="right" data-align-from="left">
-                                                    <div class="version-entry type-${versionEntry.resource} status-${versionEntry.status} depth-${versionEntry.depth}"
+                                                    <div class="version-entry type-${versionEntry.resource} status-${versionEntry.status}"
                                                          id="${versionEntry.uniqueName}-${evoCounter.index}" 
                                                          ${versionEntry.status == "" ? "ng-show='!app.hideUnchanged'" : ""} 
-                                                         ng-init="addConnection({'source':'${versionEntry.uniqueName}-${evoCounter.index}', 'target':'${versionEntry.uniqueName}-${evoCounter.index + 1}', 'isCurrent':${evolutionItem.current}})">    
-                                                        <span class="key"><c:out value="${versionEntry.name}"/>:</span>
-                                                        <span class="value"><c:out value="${versionEntry.valueStringShort}"/></span>
-                                                        <div id="popover-${versionEntry.uniqueName}-${evoCounter.index}" class="coral-Popover">
-                                                            <div class="coral-Popover-content u-coral-padding">
-                                                                <c:out value="${versionEntry.valueString}"/>
+                                                         ng-init="addConnection({'source':'${versionEntry.uniqueName}-${evoCounter.index}', 'target':'${versionEntry.uniqueName}-${evoCounter.index + 1}', 'isCurrent':${evolutionItem.current}})">
+                                                        <div class="inner-version-entry depth-${versionEntry.depth}">
+                                                            <span class="key"><c:out value="${versionEntry.name}"/>:</span>
+                                                            <span class="value"><c:out value="${versionEntry.valueStringShort}"/></span>
+                                                            <div id="popover-${versionEntry.uniqueName}-${evoCounter.index}" class="coral-Popover">
+                                                                <div class="coral-Popover-content u-coral-padding">
+                                                                    <c:out value="${versionEntry.valueString}"/>
+                                                                </div>
                                                             </div>
                                                         </div>
                                                     </div>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/version-compare.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/version-compare.jsp
@@ -74,6 +74,7 @@
                                 <div class="status-changed">changed</div>
                                 <div class="status-removed">removed in next version</div>
                                 <div class="status-added-removed"><div class="inner-version-entry">added and removed in next version</div></div>
+                                <div class="status-changed-removed"><div class="inner-version-entry">changed and removed in next version</div></div>
                             </div>
                         </section>
 


### PR DESCRIPTION
Hi, 

we have an issue with the version compare tool. If you add a node in one version and remove it in the next, it shows a green bar. This is ambiguous to the users. 
As a solution I have created a second bar to show two states in one version. For a better understanding please have a look on [that screenshot](https://cloud.githubusercontent.com/assets/3171535/13520702/e046de1c-e1e2-11e5-9d32-08c3c4504121.png). You can find all possible states in this screenshot: 

- added
- added and removed in next version (-> table)
- added and removed in a later version (-> text)

What do you think about it?

Beside this extension I think I've fixed a bug: [com.adobe.acs.commons.version.impl.EvolutionEntryImpl](https://github.com/Adobe-Consulting-Services/acs-aem-commons/blob/master/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImpl.java), line 165 should be getLinearSuccessor and not getLinearPredecessor. Right? 

Best regards, 
Dominik