### PR TITLE
fix issue #677

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-limit-parsys.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-limit-parsys.js
@@ -23,6 +23,7 @@
  * eg. to limit the components to 4 on rightpar of /content/geometrixx/en.html
  * set acsComponentsLimit=4 on /etc/designs/geometrixx/jcr:content/homepage/rightpar
  */
+ window.Granite.author = window.Granite.author || {};
 (function ($, $document, gAuthor) {
     "use strict";
 


### PR DESCRIPTION
fix for limit_parysys which breaks in AEM 6.1 SP1 because Granite.Author is undefined