### PR TITLE
#677 fix2

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-configure-parsys-placeholder.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-configure-parsys-placeholder.js
@@ -126,7 +126,7 @@
     }
 
     function extendParsys(event){
-        if(event.layer !== "Edit"){
+        if(event.layer !== "Edit" || !gAuthor){
             return;
         }
 
@@ -138,7 +138,7 @@
     $document.on('cq-layer-activated', extendParsys);
 
     $document.on("cq-overlay-hover.cq-edit-layer", function (event) {
-        if(!event.inspectable){
+        if(!event.inspectable || !gAuthor){
             return;
         }
 

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-limit-parsys.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-limit-parsys.js
@@ -23,6 +23,7 @@
  * eg. to limit the components to 4 on rightpar of /content/geometrixx/en.html
  * set acsComponentsLimit=4 on /etc/designs/geometrixx/jcr:content/homepage/rightpar
  */
+Granite.author = Granite.author || {};
 (function ($, $document, gAuthor) {
     "use strict";
 
@@ -60,6 +61,7 @@
     }
 
     function getChildEditables(parsys){
+        gAuthor.edit = gAuthor.edit || {};
         var editables = gAuthor.edit.findEditables(),
             children = [], parent;
 
@@ -99,8 +101,14 @@
     }
 
     function extendComponentDrop(){
-        var dropController = gAuthor.ui.dropController,
-            compDragDrop = dropController.get(gAuthor.Component.prototype.getTypeName());
+        gAuthor.ui = gAuthor.ui || {};
+        gAuthor.ui.dropController = gAuthor.ui.dropController || {};
+        gAuthor.ui.dropController.get = gAuthor.ui.dropController.get || function(){return};
+        gAuthor.Component = gAuthor.Component || {};
+        gAuthor.Component.prototype = gAuthor.Component.prototype || {};
+        gAuthor.Component.prototype.getTypeName = gAuthor.Component.prototype.getTypeName || function(){return};
+        var dropController = gAuthor.ui.dropController;
+        var compDragDrop = dropController.get(gAuthor.Component.prototype.getTypeName()) || {};
 
         //handle drop action
         compDragDrop.handleDrop = function(dropFn){
@@ -112,7 +120,9 @@
                 return dropFn.call(this, event);
             };
         }(compDragDrop.handleDrop);
-
+        gAuthor.edit = gAuthor.edit || {};
+        gAuthor.edit.actions = gAuthor.edit.actions || {};
+        gAuthor.edit.actions.openInsertDialog = gAuthor.edit.actions.openInsertDialog || {};
         //handle insert action
         gAuthor.edit.actions.openInsertDialog = function(openDlgFn){
             return function (editable) {
@@ -124,6 +134,11 @@
             };
         }(gAuthor.edit.actions.openInsertDialog);
 
+
+        gAuthor.edit = gAuthor.edit || {};
+        gAuthor.edit.Toolbar = gAuthor.edit.Toolbar || {};
+        gAuthor.edit.Toolbar.defaultActions = gAuthor.edit.Toolbar.defaultActions || {};
+        gAuthor.edit.Toolbar.defaultActions.INSERT = gAuthor.edit.Toolbar.defaultActions.INSERT || {};
         //handle paste action
         var insertAction = gAuthor.edit.Toolbar.defaultActions.INSERT;
 

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-limit-parsys.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-limit-parsys.js
@@ -99,7 +99,7 @@
     }
 
     function extendComponentDrop(){
-        if(!gAuthor || !gAuthor.ui || !gAuthor.ui.dropController){
+        if(!gAuthor || !gAuthor.ui || !gAuthor.ui.dropController || !gAuthor.edit || !gAuthor.edit.actions){
           return;
         }
         var dropController = gAuthor.ui.dropController,

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-limit-parsys.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-limit-parsys.js
@@ -23,7 +23,6 @@
  * eg. to limit the components to 4 on rightpar of /content/geometrixx/en.html
  * set acsComponentsLimit=4 on /etc/designs/geometrixx/jcr:content/homepage/rightpar
  */
-Granite.author = Granite.author || {};
 (function ($, $document, gAuthor) {
     "use strict";
 
@@ -61,7 +60,6 @@ Granite.author = Granite.author || {};
     }
 
     function getChildEditables(parsys){
-        gAuthor.edit = gAuthor.edit || {};
         var editables = gAuthor.edit.findEditables(),
             children = [], parent;
 
@@ -101,14 +99,11 @@ Granite.author = Granite.author || {};
     }
 
     function extendComponentDrop(){
-        gAuthor.ui = gAuthor.ui || {};
-        gAuthor.ui.dropController = gAuthor.ui.dropController || {};
-        gAuthor.ui.dropController.get = gAuthor.ui.dropController.get || function(){return};
-        gAuthor.Component = gAuthor.Component || {};
-        gAuthor.Component.prototype = gAuthor.Component.prototype || {};
-        gAuthor.Component.prototype.getTypeName = gAuthor.Component.prototype.getTypeName || function(){return};
-        var dropController = gAuthor.ui.dropController;
-        var compDragDrop = dropController.get(gAuthor.Component.prototype.getTypeName()) || {};
+        if(!gAuthor || !gAuthor.ui || !gAuthor.ui.dropController){
+          return;
+        }
+        var dropController = gAuthor.ui.dropController,
+            compDragDrop = dropController.get(gAuthor.Component.prototype.getTypeName());
 
         //handle drop action
         compDragDrop.handleDrop = function(dropFn){
@@ -120,9 +115,7 @@ Granite.author = Granite.author || {};
                 return dropFn.call(this, event);
             };
         }(compDragDrop.handleDrop);
-        gAuthor.edit = gAuthor.edit || {};
-        gAuthor.edit.actions = gAuthor.edit.actions || {};
-        gAuthor.edit.actions.openInsertDialog = gAuthor.edit.actions.openInsertDialog || {};
+
         //handle insert action
         gAuthor.edit.actions.openInsertDialog = function(openDlgFn){
             return function (editable) {
@@ -134,11 +127,6 @@ Granite.author = Granite.author || {};
             };
         }(gAuthor.edit.actions.openInsertDialog);
 
-
-        gAuthor.edit = gAuthor.edit || {};
-        gAuthor.edit.Toolbar = gAuthor.edit.Toolbar || {};
-        gAuthor.edit.Toolbar.defaultActions = gAuthor.edit.Toolbar.defaultActions || {};
-        gAuthor.edit.Toolbar.defaultActions.INSERT = gAuthor.edit.Toolbar.defaultActions.INSERT || {};
         //handle paste action
         var insertAction = gAuthor.edit.Toolbar.defaultActions.INSERT;
 


### PR DESCRIPTION
this is a better fix for #677  where we check if Granite.author and some of it's properties are truthy or falsy and return accordingly.

The best solution would be to move  the touchui-limit-parsys to it's own clientlib and add the correct dependencies to it to ensure proper loading order. I have tried doing that but wasn't very successful in finding the exact dependencies needed.