### PR TITLE
fix compatibility of touchui widgets throwing errors in 6.0

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-configure-parsys-placeholder.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-configure-parsys-placeholder.js
@@ -40,6 +40,10 @@
             designSrc = parsys.config.designDialogSrc,
             result = {}, param;
 
+        if (designSrc === undefined) {
+            return undefined;
+        }
+
         designSrc = designSrc.substring(designSrc.indexOf("?") + 1);
 
         designSrc.split(/&/).forEach( function(it) {
@@ -93,6 +97,8 @@
         }
 
         function configure(data){
+            var designPath;
+
             if(_.isEmpty(data)){
                 return;
             }
@@ -119,7 +125,10 @@
         }
 
         if(_.isEmpty(configCache[parsys.getParent().path])){
-            $.ajax( getDesignPath(parsys) + ".2.json" ).done(configure);
+            designPath = getDesignPath(parsys);
+            if (designPath !== undefined) {
+                $.ajax( designPath + ".2.json" ).done(configure);
+            }
         }else{
             configure(configCache[parsys.getParent().path]);
         }

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-limit-parsys.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-limit-parsys.js
@@ -100,42 +100,46 @@
 
     function extendComponentDrop(){
         var dropController = gAuthor.ui.dropController,
+            compDragDrop;
+
+        if (dropController !== undefined) {
             compDragDrop = dropController.get(gAuthor.Component.prototype.getTypeName());
 
-        //handle drop action
-        compDragDrop.handleDrop = function(dropFn){
-            return function (event) {
-                if(!isWithinLimit(event.currentDropTarget.targetEditable)){
-                    return;
-                }
+            //handle drop action
+            compDragDrop.handleDrop = function(dropFn){
+                return function (event) {
+                    if(!isWithinLimit(event.currentDropTarget.targetEditable)){
+                        return;
+                    }
 
-                return dropFn.call(this, event);
-            };
-        }(compDragDrop.handleDrop);
+                    return dropFn.call(this, event);
+                };
+            }(compDragDrop.handleDrop);
 
-        //handle insert action
-        gAuthor.edit.actions.openInsertDialog = function(openDlgFn){
-            return function (editable) {
-                if(!isWithinLimit(editable)){
-                    return;
-                }
+            //handle insert action
+            gAuthor.edit.actions.openInsertDialog = function(openDlgFn){
+                return function (editable) {
+                    if(!isWithinLimit(editable)){
+                        return;
+                    }
 
-                return openDlgFn.call(this, editable);
-            };
-        }(gAuthor.edit.actions.openInsertDialog);
+                    return openDlgFn.call(this, editable);
+                };
+            }(gAuthor.edit.actions.openInsertDialog);
 
-        //handle paste action
-        var insertAction = gAuthor.edit.Toolbar.defaultActions.INSERT;
+            //handle paste action
+            var insertAction = gAuthor.edit.Toolbar.defaultActions.INSERT;
 
-        insertAction.handler = function(insertHandlerFn){
-            return function(editableBefore, param, target){
-                if(!isWithinLimit(editableBefore)){
-                    return;
-                }
+            insertAction.handler = function(insertHandlerFn){
+                return function(editableBefore, param, target){
+                    if(!isWithinLimit(editableBefore)){
+                        return;
+                    }
 
-                return insertHandlerFn.call(this, editableBefore, param, target);
-            };
-        }(insertAction.handler);
+                    return insertHandlerFn.call(this, editableBefore, param, target);
+                };
+            }(insertAction.handler);
+        }
     }
 
     $(extendComponentDrop);


### PR DESCRIPTION
@schoudry this was reported in gitter. I think this change just disabled these features in 6.0 when the JS objects aren't defined.