### PR TITLE
Add the workflow initiator to a wfInitator variable for emails

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/email/process/impl/SendTemplatedEmailConstants.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/email/process/impl/SendTemplatedEmailConstants.java
@@ -62,4 +62,10 @@ public final class SendTemplatedEmailConstants {
      * as: <code>${wfStepTitle}</code>
      */
     public static final String WF_STEP_TITLE = "wfStepTitle";
+
+    /**
+     * name of the workflow initiator To be used in the template
+     * as: <code>${wfInitiator}</code>
+     */
+    public static final String WF_INITIATOR = "wfInitiator";
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/email/process/impl/SendTemplatedEmailProcess.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/email/process/impl/SendTemplatedEmailProcess.java
@@ -257,7 +257,9 @@ public class SendTemplatedEmailProcess implements WorkflowProcess {
      * {@link com.adobe.acs.commons.email.process.impl.SendTemplatedEmailConstants#WF_MODEL_TITLE
      * WF_MODEL_TITLE} and adds the Workflow Step Title:
      * {@link com.adobe.acs.commons.email.process.impl.SendTemplatedEmailConstants#WF_STEP_TITLE
-     * WF_STEP_TITLE} Protected so that implementing classes can override and
+     * WF_STEP_TITLE}
+     * {@link com.adobe.acs.commons.email.process.impl.SendTemplatedEmailConstants#WF_INITIATOR
+     * WF_INITIATOR} Protected so that implementing classes can override and
      * add additional parameters.
      * 
      * @param workItem
@@ -274,6 +276,8 @@ public class SendTemplatedEmailProcess implements WorkflowProcess {
             wfParams.put(SendTemplatedEmailConstants.WF_STEP_TITLE, workItem.getNode().getTitle());
             wfParams.put(SendTemplatedEmailConstants.WF_MODEL_TITLE, workItem.getWorkflow().getWorkflowModel()
                     .getTitle());
+            // Set workflow initiator
+            wfParams.put(SendTemplatedEmailConstants.WF_INITIATOR, workItem.getWorkflow().getInitiator());
         } catch (Exception e) {
             log.warn("Error getting workflow title and workflow step title {}", e);
         }


### PR DESCRIPTION
Should resolve #424 "Send Templated E-Mail Workflow Process add Initiator ID" issue.

I've not got email setup locally to fully test though.