### PR TITLE
adding path regular expression render condition. Issue #692

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/granite/ui/components/renderconditions/path/path.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/granite/ui/components/renderconditions/path/path.jsp
@@ -1,0 +1,50 @@
+<%--
+  #%L
+  ACS AEM Commons Package
+  %%
+  Copyright (C) 2013 Adobe
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  --%><%--
+  ==============================================================================
+
+  Path Regular Expression Rendercondition
+
+   A condition that takes a path regular expression for the decision.
+
+  /**
+   * The expression to evaluate.
+   */
+  - path (String) = /content/geometrixx/.*
+
+  ==============================================================================
+
+--%><%
+%><%@include file="/libs/granite/ui/global.jsp" %><%
+%><%@page session="false"
+          import="com.adobe.granite.ui.components.Config,
+                  com.adobe.granite.ui.components.rendercondition.RenderCondition,
+                  com.adobe.granite.ui.components.rendercondition.SimpleRenderCondition" %>
+<%
+    Config cfg = cmp.getConfig();
+    String pathRegex = cfg.get("path", String.class);
+    boolean vote = false;
+    if (pathRegex != null) {
+        String suffix = slingRequest.getRequestPathInfo().getSuffix();
+        if (suffix != null) {
+            vote = suffix.matches(pathRegex);
+        }
+    }
+    request.setAttribute(RenderCondition.class.getName(), new SimpleRenderCondition(vote));
+%>


### PR DESCRIPTION
Sample rendercondition node would look something like 

`<rendercondition
                                jcr:primaryType="nt:unstructured"
                                sling:resourceType="acs-commons/granite/ui/components/renderconditions/path"
                                path="/content/geometrixx/.*"/>`