### PR TITLE
Add support for the granite Autocomplete widget as a child of multifield

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield-nodestore.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield-nodestore.js
@@ -155,8 +155,12 @@
 
                     var $field = $multifield.find("[name='./" + fKey + "']").last();
 
-                    if(_.isEmpty($field)){
-                        return;
+                    if (_.isEmpty($field)) {
+                     	$field = $multifield.find("[data-fieldname='./" + fKey + "']").last();
+
+                     	if (_.isEmpty($field)) {
+                          	return;
+                     	}
                     }
 
                     cmf.setWidgetValue($field, fValue);
@@ -229,6 +233,15 @@
 
                 if (cmf.isCheckbox($field)) {
                     value = $field.prop("checked") ? $field.val() : "";
+                }
+
+                if (cmf.isAutocomplete($field)) {
+                 	var tags = [];
+                 	var tagItems = $field.closest("ul").find("li.coral-TagList-tag");
+                 	$(tagItems).each(function (k, tagItem) {
+                 		tags[k] = $(tagItem).find("input[name='./" + name + "']").attr("value");
+                 	});
+                 	value = tags.toString();
                 }
 
                 //remove the field, so that individual values are not POSTed

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield-nodestore.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield-nodestore.js
@@ -21,89 +21,75 @@
  * Note the usage of acs-commons-nested property, value set to NODE_STORE
  *
  * <code>
- <?xml version="1.0" encoding="UTF-8"?>
- <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
- jcr:primaryType="nt:unstructured"
- jcr:title="ACS AEM Commions Multifield TouchUI Component"
- sling:resourceType="cq/gui/components/authoring/dialog"
- helpPath="en/cq/current/wcm/default_components.html#Text">
- <content
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/container">
- <layout
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"/>
- <items jcr:primaryType="nt:unstructured">
- <column
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/container">
- <items jcr:primaryType="nt:unstructured">
- <fieldset
- jcr:primaryType="nt:unstructured"
- jcr:title="Sample Dashboard"
- sling:resourceType="granite/ui/components/foundation/form/fieldset">
- <layout
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"/>
- <items jcr:primaryType="nt:unstructured">
- <column
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/container">
- <items jcr:primaryType="nt:unstructured">
- <dashboard
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/form/textfield"
- fieldDescription="Enter Dashboard name"
- fieldLabel="Dashboard name"
- name="./dashboard"/>
- <pages
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/form/multifield"
- class="full-width"
- fieldDescription="Click '+' to add a new page"
- fieldLabel="Pages">
- <field
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/form/fieldset"
- acs-commons-nested="NODE_STORE"
- name="./pages">
- <layout
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"
- method="absolute"/>
- <items jcr:primaryType="nt:unstructured">
- <column
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/container">
- <items jcr:primaryType="nt:unstructured">
- <page
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/form/textfield"
- fieldDescription="Name of Page"
- fieldLabel="Page Name"
- name="./page"/>
- <path
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/form/pathbrowser"
- fieldDescription="Select Path"
- fieldLabel="Path"
- name="./path"
- rootPath="/content"/>
- </items>
- </column>
- </items>
- </field>
- </pages>
- </items>
- </column>
- </items>
- </fieldset>
- </items>
- </column>
- </items>
- </content>
- </jcr:root>
- </code>
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+        jcr:primaryType="nt:unstructured"
+        jcr:title="ACS AEM Commions Multifield TouchUI Component"
+        sling:resourceType="cq/gui/components/authoring/dialog"
+        helpPath="en/cq/current/wcm/default_components.html#Text">
+    <content jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/foundation/container">
+        <layout jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"/>
+            <items jcr:primaryType="nt:unstructured">
+                <column jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/foundation/container">
+                <items jcr:primaryType="nt:unstructured">
+                    <fieldset jcr:primaryType="nt:unstructured"
+                            jcr:title="Sample Dashboard"
+                            sling:resourceType="granite/ui/components/foundation/form/fieldset">
+                        <layout jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"/>
+                            <items jcr:primaryType="nt:unstructured">
+                                <column jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/foundation/container"> <items jcr:primaryType="nt:unstructured">
+                                    <dashboard jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/foundation/form/textfield"
+                                            fieldDescription="Enter Dashboard name"
+                                            fieldLabel="Dashboard name"
+                                            name="./dashboard"/>
+                                    <pages jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/foundation/form/multifield"
+                                            class="full-width"
+                                            fieldDescription="Click '+' to add a new page"
+                                            fieldLabel="Pages">
+                                        <field jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/foundation/form/fieldset"
+                                                acs-commons-nested="NODE_STORE"
+                                                name="./pages">
+                                            <layout jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"
+                                                    method="absolute"/>
+                                            <items jcr:primaryType="nt:unstructured">
+                                                <column jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/foundation/container">
+                                                    <items jcr:primaryType="nt:unstructured">
+                                                        <page jcr:primaryType="nt:unstructured"
+                                                                sling:resourceType="granite/ui/components/foundation/form/textfield"
+                                                                fieldDescription="Name of Page"
+                                                                fieldLabel="Page Name"
+                                                                name="./page"/>
+                                                        <path jcr:primaryType="nt:unstructured"
+                                                                sling:resourceType="granite/ui/components/foundation/form/pathbrowser"
+                                                                fieldDescription="Select Path"
+                                                                fieldLabel="Path"
+                                                                name="./path"
+                                                                rootPath="/content"/>
+                                                    </items>
+                                                </column>
+                                            </items>
+                                        </field>
+                                    </pages>
+                                </items>
+                            </column>
+                        </items>
+                    </fieldset>
+                </items>
+            </column>
+        </items>
+    </content>
+</jcr:root>
+</code>
  */
 (function ($, $document) {
     "use strict";

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield-nodestore.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield-nodestore.js
@@ -22,89 +22,89 @@
  *
  * <code>
  <?xml version="1.0" encoding="UTF-8"?>
-    <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="nt:unstructured"
-    jcr:title="ACS AEM Commions Multifield TouchUI Component"
-    sling:resourceType="cq/gui/components/authoring/dialog"
-    helpPath="en/cq/current/wcm/default_components.html#Text">
-        <content
-        jcr:primaryType="nt:unstructured"
-        sling:resourceType="granite/ui/components/foundation/container">
-            <layout
-            jcr:primaryType="nt:unstructured"
-            sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"/>
-            <items jcr:primaryType="nt:unstructured">
-                <column
-                jcr:primaryType="nt:unstructured"
-                sling:resourceType="granite/ui/components/foundation/container">
-                    <items jcr:primaryType="nt:unstructured">
-                        <fieldset
-                        jcr:primaryType="nt:unstructured"
-                        jcr:title="Sample Dashboard"
-                        sling:resourceType="granite/ui/components/foundation/form/fieldset">
-                            <layout
-                            jcr:primaryType="nt:unstructured"
-                            sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"/>
-                            <items jcr:primaryType="nt:unstructured">
-                                <column
-                                jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/foundation/container">
-                                    <items jcr:primaryType="nt:unstructured">
-                                        <dashboard
-                                        jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="granite/ui/components/foundation/form/textfield"
-                                        fieldDescription="Enter Dashboard name"
-                                        fieldLabel="Dashboard name"
-                                        name="./dashboard"/>
-                                        <pages
-                                        jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="granite/ui/components/foundation/form/multifield"
-                                        class="full-width"
-                                        fieldDescription="Click '+' to add a new page"
-                                        fieldLabel="Pages">
-                                            <field
-                                            jcr:primaryType="nt:unstructured"
-                                            sling:resourceType="granite/ui/components/foundation/form/fieldset"
-                                            acs-commons-nested="NODE_STORE"
-                                            name="./pages">
-                                                <layout
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"
-                                                method="absolute"/>
-                                                <items jcr:primaryType="nt:unstructured">
-                                                    <column
-                                                    jcr:primaryType="nt:unstructured"
-                                                    sling:resourceType="granite/ui/components/foundation/container">
-                                                        <items jcr:primaryType="nt:unstructured">
-                                                            <page
-                                                            jcr:primaryType="nt:unstructured"
-                                                            sling:resourceType="granite/ui/components/foundation/form/textfield"
-                                                            fieldDescription="Name of Page"
-                                                            fieldLabel="Page Name"
-                                                            name="./page"/>
-                                                            <path
-                                                            jcr:primaryType="nt:unstructured"
-                                                            sling:resourceType="granite/ui/components/foundation/form/pathbrowser"
-                                                            fieldDescription="Select Path"
-                                                            fieldLabel="Path"
-                                                            name="./path"
-                                                            rootPath="/content"/>
-                                                        </items>
-                                                    </column>
-                                                </items>
-                                            </field>
-                                        </pages>
-                                    </items>
-                                </column>
-                            </items>
-                        </fieldset>
-                    </items>
-                </column>
-            </items>
-        </content>
-    </jcr:root>
-</code>
-*/
+ <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+ jcr:primaryType="nt:unstructured"
+ jcr:title="ACS AEM Commions Multifield TouchUI Component"
+ sling:resourceType="cq/gui/components/authoring/dialog"
+ helpPath="en/cq/current/wcm/default_components.html#Text">
+ <content
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/container">
+ <layout
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"/>
+ <items jcr:primaryType="nt:unstructured">
+ <column
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/container">
+ <items jcr:primaryType="nt:unstructured">
+ <fieldset
+ jcr:primaryType="nt:unstructured"
+ jcr:title="Sample Dashboard"
+ sling:resourceType="granite/ui/components/foundation/form/fieldset">
+ <layout
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"/>
+ <items jcr:primaryType="nt:unstructured">
+ <column
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/container">
+ <items jcr:primaryType="nt:unstructured">
+ <dashboard
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/form/textfield"
+ fieldDescription="Enter Dashboard name"
+ fieldLabel="Dashboard name"
+ name="./dashboard"/>
+ <pages
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/form/multifield"
+ class="full-width"
+ fieldDescription="Click '+' to add a new page"
+ fieldLabel="Pages">
+ <field
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/form/fieldset"
+ acs-commons-nested="NODE_STORE"
+ name="./pages">
+ <layout
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"
+ method="absolute"/>
+ <items jcr:primaryType="nt:unstructured">
+ <column
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/container">
+ <items jcr:primaryType="nt:unstructured">
+ <page
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/form/textfield"
+ fieldDescription="Name of Page"
+ fieldLabel="Page Name"
+ name="./page"/>
+ <path
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/form/pathbrowser"
+ fieldDescription="Select Path"
+ fieldLabel="Path"
+ name="./path"
+ rootPath="/content"/>
+ </items>
+ </column>
+ </items>
+ </field>
+ </pages>
+ </items>
+ </column>
+ </items>
+ </fieldset>
+ </items>
+ </column>
+ </items>
+ </content>
+ </jcr:root>
+ </code>
+ */
 (function ($, $document) {
     "use strict";
 
@@ -156,11 +156,11 @@
                     var $field = $multifield.find("[name='./" + fKey + "']").last();
 
                     if (_.isEmpty($field)) {
-                     	$field = $multifield.find("[data-fieldname='./" + fKey + "']").last();
+                        $field = $multifield.find("[data-fieldname='./" + fKey + "']").last();
 
-                     	if (_.isEmpty($field)) {
-                          	return;
-                     	}
+                        if (_.isEmpty($field)) {
+                            return;
+                        }
                     }
 
                     cmf.setWidgetValue($field, fValue);
@@ -236,12 +236,12 @@
                 }
 
                 if (cmf.isAutocomplete($field)) {
-                 	var tags = [];
-                 	var tagItems = $field.closest("ul").find("li.coral-TagList-tag");
-                 	$(tagItems).each(function (k, tagItem) {
-                 		tags[k] = $(tagItem).find("input[name='./" + name + "']").attr("value");
-                 	});
-                 	value = tags.toString();
+                    var tags = [];
+                    var tagItems = $field.closest("ul").find("li.coral-TagList-tag");
+                    $(tagItems).each(function (k, tagItem) {
+                        tags[k] = $(tagItem).find("input[name='./" + name + "']").attr("value");
+                    });
+                    value = tags.toString();
                 }
 
                 //remove the field, so that individual values are not POSTed

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield-nodestore.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield-nodestore.js
@@ -155,7 +155,7 @@
 
                     var $field = $multifield.find("[name='./" + fKey + "']").last();
 
-                    if (_.isEmpty($field)) {
+                    if (_.isEmpty($field) || $field.closest('ul').hasClass('js-coral-Autocomplete-tagList')) {
                         $field = $multifield.find("[data-fieldname='./" + fKey + "']").last();
 
                         if (_.isEmpty($field)) {
@@ -237,15 +237,19 @@
 
                 if (cmf.isAutocomplete($field)) {
                     var tags = [];
-                    var tagItems = $field.closest("ul").find("li.coral-TagList-tag");
-                    $(tagItems).each(function (k, tagItem) {
-                        tags[k] = $(tagItem).find("input[name='./" + name + "']").attr("value");
+                    var $tagItems = $field.closest("ul").find("li.coral-TagList-tag");
+                    $tagItems.each(function (k, tagItem) {
+                        var $inputItem = $(tagItem).find("input[name='./" + name + "']");
+                        tags[k] = $inputItem.val();
+                        $inputItem.remove();
                     });
                     value = tags.toString();
                 }
 
                 //remove the field, so that individual values are not POSTed
-                $field.remove();
+                if (!cmf.isAutocomplete($field)) {
+                    $field.remove();
+                }
 
                 $('<input />').attr('type', 'hidden')
                     .attr('name', fieldSetName + "/" + counter + "/" + name)

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield.js
@@ -22,88 +22,75 @@
  *
  * <code>
  <?xml version="1.0" encoding="UTF-8"?>
- <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
- jcr:primaryType="nt:unstructured"
- jcr:title="ACS AEM Commions Multifield TouchUI Component"
- sling:resourceType="cq/gui/components/authoring/dialog"
- helpPath="en/cq/current/wcm/default_components.html#Text">
- <content
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/container">
- <layout
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"/>
- <items jcr:primaryType="nt:unstructured">
- <column
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/container">
- <items jcr:primaryType="nt:unstructured">
- <fieldset
- jcr:primaryType="nt:unstructured"
- jcr:title="Sample Dashboard"
- sling:resourceType="granite/ui/components/foundation/form/fieldset">
- <layout
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"/>
- <items jcr:primaryType="nt:unstructured">
- <column
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/container">
- <items jcr:primaryType="nt:unstructured">
- <dashboard
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/form/textfield"
- fieldDescription="Enter Dashboard name"
- fieldLabel="Dashboard name"
- name="./dashboard"/>
- <pages
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/form/multifield"
- class="full-width"
- fieldDescription="Click '+' to add a new page"
- fieldLabel="Pages">
- <field
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/form/fieldset"
- acs-commons-nested="JSON_STORE"
- name="./pages">
- <layout
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"
- method="absolute"/>
- <items jcr:primaryType="nt:unstructured">
- <column
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/container">
- <items jcr:primaryType="nt:unstructured">
- <page
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/form/textfield"
- fieldDescription="Name of Page"
- fieldLabel="Page Name"
- name="./page"/>
- <path
- jcr:primaryType="nt:unstructured"
- sling:resourceType="granite/ui/components/foundation/form/pathbrowser"
- fieldDescription="Select Path"
- fieldLabel="Path"
- name="./path"
- rootPath="/content"/>
- </items>
- </column>
- </items>
- </field>
- </pages>
- </items>
- </column>
- </items>
- </fieldset>
- </items>
- </column>
- </items>
- </content>
- </jcr:root>
- </code>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+        jcr:primaryType="nt:unstructured"
+        jcr:title="ACS AEM Commions Multifield TouchUI Component"
+        sling:resourceType="cq/gui/components/authoring/dialog"
+        helpPath="en/cq/current/wcm/default_components.html#Text">
+    <content jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/foundation/container">
+        <layout jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"/>
+        <items jcr:primaryType="nt:unstructured">
+            <column jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/foundation/container">
+                <items jcr:primaryType="nt:unstructured">
+                    <fieldset jcr:primaryType="nt:unstructured"
+                            jcr:title="Sample Dashboard"
+                            sling:resourceType="granite/ui/components/foundation/form/fieldset">
+                        <layout jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"/>
+                        <items jcr:primaryType="nt:unstructured">
+                            <column jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/foundation/container">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <dashboard jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/foundation/form/textfield"
+                                            fieldDescription="Enter Dashboard name"
+                                            fieldLabel="Dashboard name"
+                                            name="./dashboard"/>
+                                    <pages jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/foundation/form/multifield"
+                                            class="full-width"
+                                            fieldDescription="Click '+' to add a new page"
+                                            fieldLabel="Pages">
+                                        <field jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/foundation/form/fieldset"
+                                                acs-commons-nested="JSON_STORE"
+                                                name="./pages">
+                                            <layout jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"
+                                                    method="absolute"/>
+                                            <items jcr:primaryType="nt:unstructured">
+                                                <column jcr:primaryType="nt:unstructured"
+                                                        sling:resourceType="granite/ui/components/foundation/container">
+                                                    <items jcr:primaryType="nt:unstructured">
+                                                        <page jcr:primaryType="nt:unstructured"
+                                                                sling:resourceType="granite/ui/components/foundation/form/textfield"
+                                                                fieldDescription="Name of Page"
+                                                                fieldLabel="Page Name"
+                                                                name="./page"/>
+                                                        <path jcr:primaryType="nt:unstructured"
+                                                                sling:resourceType="granite/ui/components/foundation/form/pathbrowser"
+                                                                fieldDescription="Select Path"
+                                                                fieldLabel="Path"
+                                                                name="./path"
+                                                                rootPath="/content"/>
+                                                    </items>
+                                                </column>
+                                            </items>
+                                        </field>
+                                    </pages>
+                                </items>
+                            </column>
+                        </items>
+                    </fieldset>
+                </items>
+            </column>
+        </items>
+    </content>
+</jcr:root>
+</code>
  */
 (function ($, $document) {
     "use strict";

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield.js
@@ -136,6 +136,7 @@
                 return;
             }
 
+
             $fieldSets.each(function (i, fieldSet) {
                 if(!cmf.isJsonStore($(fieldSet).data(cmf.ACS_COMMONS_NESTED))){
                     return;
@@ -153,10 +154,10 @@
 
                     //a setTimeout may be needed
                     _.each(record, function (value, key) {
-                        var $item = $multifield.find("[name='./" + key + "']");
+                        var $item = $multifield.find("[name='./" + key + "']").last();
 
-                        if (_.isEmpty($item)) {
-                            $item = $multifield.find("[data-fieldname='./" + key + "']").last();
+                        if (_.isEmpty($item) || $item.closest('ul').hasClass('js-coral-Autocomplete-tagList')) {
+                            $item = $multifield.find("ul[data-fieldname='./" + key + "']").last();
 
                             if (_.isEmpty($item)) {
                                 return;
@@ -195,10 +196,10 @@
                         }
 
                         _.each(record, function (rValue, rKey) {
-                            $field = $($fieldSets[i]).find("[name='./" + rKey + "']");
+                            $field = $($fieldSets[i]).find("[name='./" + rKey + "']").last();
 
-                            if (_.isEmpty($field)) {
-                                $field = $($fieldSets[i]).find("[data-fieldname='./" + rKey + "']").last();
+                            if (_.isEmpty($field) || $field.closest('ul').hasClass('js-coral-Autocomplete-tagList')) {
+                                $field = $($fieldSets[i]).find("ul[data-fieldname='./" + rKey + "']").last();
                             }
 
                             if (_.isArray(rValue) && !_.isEmpty(rValue)) {
@@ -238,9 +239,11 @@
 
             if (this.isAutocomplete($field)) {
                 var tags = [];
-                var tagItems = $field.closest("ul").find("li.coral-TagList-tag");
-                $(tagItems).each(function (k, tagItem) {
-                    tags[k] = $(tagItem).find("input[name='./" + name + "']").attr("value");
+                var $tagItems = $field.closest("ul").find("li.coral-TagList-tag");
+                $tagItems.each(function (k, tagItem) {
+                    var $inputItem = $(tagItem).find("input[name='./" + name + "']");
+                    tags[k] = $inputItem.val();
+                    $inputItem.remove();
                 });
 
                 value = tags.toString();
@@ -249,7 +252,9 @@
             record[name] = value;
 
             //remove the field, so that individual values are not POSTed
-            $field.remove();
+            if (!this.isAutocomplete($field)) {
+                $field.remove();
+            }
         },
 
         //for getting the nested multifield data as js objects

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield.js
@@ -22,89 +22,89 @@
  *
  * <code>
  <?xml version="1.0" encoding="UTF-8"?>
-    <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
-    jcr:primaryType="nt:unstructured"
-    jcr:title="ACS AEM Commions Multifield TouchUI Component"
-    sling:resourceType="cq/gui/components/authoring/dialog"
-    helpPath="en/cq/current/wcm/default_components.html#Text">
-        <content
-        jcr:primaryType="nt:unstructured"
-        sling:resourceType="granite/ui/components/foundation/container">
-            <layout
-            jcr:primaryType="nt:unstructured"
-            sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"/>
-            <items jcr:primaryType="nt:unstructured">
-                <column
-                jcr:primaryType="nt:unstructured"
-                sling:resourceType="granite/ui/components/foundation/container">
-                    <items jcr:primaryType="nt:unstructured">
-                        <fieldset
-                        jcr:primaryType="nt:unstructured"
-                        jcr:title="Sample Dashboard"
-                        sling:resourceType="granite/ui/components/foundation/form/fieldset">
-                            <layout
-                            jcr:primaryType="nt:unstructured"
-                            sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"/>
-                            <items jcr:primaryType="nt:unstructured">
-                                <column
-                                jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/foundation/container">
-                                    <items jcr:primaryType="nt:unstructured">
-                                        <dashboard
-                                        jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="granite/ui/components/foundation/form/textfield"
-                                        fieldDescription="Enter Dashboard name"
-                                        fieldLabel="Dashboard name"
-                                        name="./dashboard"/>
-                                        <pages
-                                        jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="granite/ui/components/foundation/form/multifield"
-                                        class="full-width"
-                                        fieldDescription="Click '+' to add a new page"
-                                        fieldLabel="Pages">
-                                            <field
-                                            jcr:primaryType="nt:unstructured"
-                                            sling:resourceType="granite/ui/components/foundation/form/fieldset"
-                                            acs-commons-nested="JSON_STORE"
-                                            name="./pages">
-                                                <layout
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"
-                                                method="absolute"/>
-                                                <items jcr:primaryType="nt:unstructured">
-                                                    <column
-                                                    jcr:primaryType="nt:unstructured"
-                                                    sling:resourceType="granite/ui/components/foundation/container">
-                                                        <items jcr:primaryType="nt:unstructured">
-                                                            <page
-                                                            jcr:primaryType="nt:unstructured"
-                                                            sling:resourceType="granite/ui/components/foundation/form/textfield"
-                                                            fieldDescription="Name of Page"
-                                                            fieldLabel="Page Name"
-                                                            name="./page"/>
-                                                            <path
-                                                            jcr:primaryType="nt:unstructured"
-                                                            sling:resourceType="granite/ui/components/foundation/form/pathbrowser"
-                                                            fieldDescription="Select Path"
-                                                            fieldLabel="Path"
-                                                            name="./path"
-                                                            rootPath="/content"/>
-                                                        </items>
-                                                    </column>
-                                                </items>
-                                            </field>
-                                        </pages>
-                                    </items>
-                                </column>
-                            </items>
-                        </fieldset>
-                    </items>
-                </column>
-            </items>
-        </content>
-    </jcr:root>
-</code>
-*/
+ <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+ jcr:primaryType="nt:unstructured"
+ jcr:title="ACS AEM Commions Multifield TouchUI Component"
+ sling:resourceType="cq/gui/components/authoring/dialog"
+ helpPath="en/cq/current/wcm/default_components.html#Text">
+ <content
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/container">
+ <layout
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"/>
+ <items jcr:primaryType="nt:unstructured">
+ <column
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/container">
+ <items jcr:primaryType="nt:unstructured">
+ <fieldset
+ jcr:primaryType="nt:unstructured"
+ jcr:title="Sample Dashboard"
+ sling:resourceType="granite/ui/components/foundation/form/fieldset">
+ <layout
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"/>
+ <items jcr:primaryType="nt:unstructured">
+ <column
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/container">
+ <items jcr:primaryType="nt:unstructured">
+ <dashboard
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/form/textfield"
+ fieldDescription="Enter Dashboard name"
+ fieldLabel="Dashboard name"
+ name="./dashboard"/>
+ <pages
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/form/multifield"
+ class="full-width"
+ fieldDescription="Click '+' to add a new page"
+ fieldLabel="Pages">
+ <field
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/form/fieldset"
+ acs-commons-nested="JSON_STORE"
+ name="./pages">
+ <layout
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"
+ method="absolute"/>
+ <items jcr:primaryType="nt:unstructured">
+ <column
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/container">
+ <items jcr:primaryType="nt:unstructured">
+ <page
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/form/textfield"
+ fieldDescription="Name of Page"
+ fieldLabel="Page Name"
+ name="./page"/>
+ <path
+ jcr:primaryType="nt:unstructured"
+ sling:resourceType="granite/ui/components/foundation/form/pathbrowser"
+ fieldDescription="Select Path"
+ fieldLabel="Path"
+ name="./path"
+ rootPath="/content"/>
+ </items>
+ </column>
+ </items>
+ </field>
+ </pages>
+ </items>
+ </column>
+ </items>
+ </fieldset>
+ </items>
+ </column>
+ </items>
+ </content>
+ </jcr:root>
+ </code>
+ */
 (function ($, $document) {
     "use strict";
 
@@ -153,9 +153,9 @@
 
                     //a setTimeout may be needed
                     _.each(record, function (value, key) {
-                   		var $item = $multifield.find("[name='./" + key + "']");
+                        var $item = $multifield.find("[name='./" + key + "']");
 
-                    	if (_.isEmpty($item)) {
+                        if (_.isEmpty($item)) {
                             $item = $multifield.find("[data-fieldname='./" + key + "']").last();
 
                             if (_.isEmpty($item)) {
@@ -197,11 +197,11 @@
                         _.each(record, function (rValue, rKey) {
                             $field = $($fieldSets[i]).find("[name='./" + rKey + "']");
 
-                    		if (_.isEmpty($field)) {
-                     			$field = $($fieldSets[i]).find("[data-fieldname='./" + rKey + "']").last();
-                  		   	}
-                  		   	
-                           	if (_.isArray(rValue) && !_.isEmpty(rValue)) {
+                            if (_.isEmpty($field)) {
+                                $field = $($fieldSets[i]).find("[data-fieldname='./" + rKey + "']").last();
+                            }
+
+                            if (_.isArray(rValue) && !_.isEmpty(rValue)) {
                                 fillNestedFields($($fieldSets[i]).find("[data-init='multifield']"), rValue);
                             } else {
                                 cmf.setWidgetValue($field, rValue);
@@ -237,13 +237,13 @@
             }
 
             if (this.isAutocomplete($field)) {
-             	var tags = [];
-               	var tagItems = $field.closest("ul").find("li.coral-TagList-tag");
-              	$(tagItems).each(function (k, tagItem) {
-               		tags[k] = $(tagItem).find("input[name='./" + name + "']").attr("value");
-               	});
+                var tags = [];
+                var tagItems = $field.closest("ul").find("li.coral-TagList-tag");
+                $(tagItems).each(function (k, tagItem) {
+                    tags[k] = $(tagItem).find("input[name='./" + name + "']").attr("value");
+                });
 
-               	value = tags.toString();
+                value = tags.toString();
             }
 
             record[name] = value;
@@ -263,10 +263,10 @@
                 record = {};
 
                 $fields.each(function (j, field) {
-                		if (!record[$(field).attr('name').substring(2)]) {
-	                    cmf.fillValue($(field), record);
-                		}
-                 });
+                    if (!record[$(field).attr('name').substring(2)]) {
+                        cmf.fillValue($(field), record);
+                    }
+                });
 
                 if (!$.isEmptyObject(record)) {
                     records.push(record);

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-composite-multifield.js
@@ -153,7 +153,17 @@
 
                     //a setTimeout may be needed
                     _.each(record, function (value, key) {
-                        cmf.setWidgetValue($($multifield.find("[name='./" + key + "']")[index]), value);
+                   		var $item = $multifield.find("[name='./" + key + "']");
+
+                    	if (_.isEmpty($item)) {
+                            $item = $multifield.find("[data-fieldname='./" + key + "']").last();
+
+                            if (_.isEmpty($item)) {
+                                return;
+                            }
+                        }
+
+                        cmf.setWidgetValue($($item), value);
                     });
                 });
             }
@@ -187,7 +197,11 @@
                         _.each(record, function (rValue, rKey) {
                             $field = $($fieldSets[i]).find("[name='./" + rKey + "']");
 
-                            if (_.isArray(rValue) && !_.isEmpty(rValue)) {
+                    		if (_.isEmpty($field)) {
+                     			$field = $($fieldSets[i]).find("[data-fieldname='./" + rKey + "']").last();
+                  		   	}
+                  		   	
+                           	if (_.isArray(rValue) && !_.isEmpty(rValue)) {
                                 fillNestedFields($($fieldSets[i]).find("[data-init='multifield']"), rValue);
                             } else {
                                 cmf.setWidgetValue($field, rValue);
@@ -222,6 +236,16 @@
                 value = $field.prop("checked") ? $field.val() : "";
             }
 
+            if (this.isAutocomplete($field)) {
+             	var tags = [];
+               	var tagItems = $field.closest("ul").find("li.coral-TagList-tag");
+              	$(tagItems).each(function (k, tagItem) {
+               		tags[k] = $(tagItem).find("input[name='./" + name + "']").attr("value");
+               	});
+
+               	value = tags.toString();
+            }
+
             record[name] = value;
 
             //remove the field, so that individual values are not POSTed
@@ -239,8 +263,10 @@
                 record = {};
 
                 $fields.each(function (j, field) {
-                    cmf.fillValue($(field), record);
-                });
+                		if (!record[$(field).attr('name').substring(2)]) {
+	                    cmf.fillValue($(field), record);
+                		}
+                 });
 
                 if (!$.isEmptyObject(record)) {
                     records.push(record);

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-widgets-init.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-widgets-init.js
@@ -79,6 +79,24 @@
             $field.parent().find(".coral-RichText-editable.coral-RichText").empty().append(value);
         },
 
+        isAutocomplete: function($field) {
+       		return !_.isEmpty($field) && ($field.find("ul").hasClass("js-coral-Autocomplete-tagList") || $field.closest("ul").hasClass("js-coral-Autocomplete-tagList"));
+       	},
+
+        setAutocomplete: function($field,value) {
+        		var tagsArray = value.split(',');
+
+			var $tagList = CUI.Widget.fromElement(CUI.TagList,$field);
+
+			if ($tagList) {
+				$(tagsArray).each(function(i,item) {
+            	    		var selectedItem = $field.closest(".coral-Form-fieldwrapper").find("li[data-value='" + item + "']");
+
+            			$tagList._appendItem({"display":selectedItem.text(),"value":item});
+            		});
+			}
+        },
+
         setWidgetValue: function ($field, value) {
             if (_.isEmpty($field)) {
                 return;
@@ -92,6 +110,8 @@
                 this.setRichTextField($field, value);
             } else if (this.isDateField($field)) {
                 this.setDateField($field, value);
+            } else if (this.isAutocomplete($field)) {
+            		this.setAutocomplete($field,value);
             } else {
                 $field.val(value);
             }

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-widgets-init.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-widgets-init.js
@@ -80,21 +80,21 @@
         },
 
         isAutocomplete: function($field) {
-       		return !_.isEmpty($field) && ($field.find("ul").hasClass("js-coral-Autocomplete-tagList") || $field.closest("ul").hasClass("js-coral-Autocomplete-tagList"));
-       	},
+            return !_.isEmpty($field) && ($field.find("ul").hasClass("js-coral-Autocomplete-tagList") || $field.closest("ul").hasClass("js-coral-Autocomplete-tagList"));
+        },
 
         setAutocomplete: function($field,value) {
-        		var tagsArray = value.split(',');
+            var tagsArray = value.split(',');
 
-			var $tagList = CUI.Widget.fromElement(CUI.TagList,$field);
+            var $tagList = CUI.Widget.fromElement(CUI.TagList,$field);
 
-			if ($tagList) {
-				$(tagsArray).each(function(i,item) {
-            	    		var selectedItem = $field.closest(".coral-Form-fieldwrapper").find("li[data-value='" + item + "']");
+            if ($tagList) {
+                $(tagsArray).each(function(i,item) {
+                    var selectedItem = $field.closest(".coral-Form-fieldwrapper").find("li[data-value='" + item + "']");
 
-            			$tagList._appendItem({"display":selectedItem.text(),"value":item});
-            		});
-			}
+                    $tagList._appendItem({"display":selectedItem.text(),"value":item});
+                });
+            }
         },
 
         setWidgetValue: function ($field, value) {
@@ -111,7 +111,7 @@
             } else if (this.isDateField($field)) {
                 this.setDateField($field, value);
             } else if (this.isAutocomplete($field)) {
-            		this.setAutocomplete($field,value);
+                this.setAutocomplete($field,value);
             } else {
                 $field.val(value);
             }
@@ -137,7 +137,7 @@
 
         addCompositeMultifieldValidator: function(){
             var fieldErrorEl = $("<span class='coral-Form-fielderror coral-Icon coral-Icon--alert coral-Icon--sizeS' " +
-                                "data-init='quicktip' data-quicktip-type='error' />"),
+                    "data-init='quicktip' data-quicktip-type='error' />"),
                 cmf = this,
                 selector = "[" + cmf.DATA_ACS_COMMONS_NESTED + "] >* input, [" + cmf.DATA_ACS_COMMONS_NESTED + "] >* textarea";
 

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-widgets-init.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-widgets-init.js
@@ -84,15 +84,17 @@
         },
 
         setAutocomplete: function($field,value) {
+            var cmf = this;
+
             var tagsArray = value.split(',');
 
             var $tagList = CUI.Widget.fromElement(CUI.TagList,$field);
 
             if ($tagList) {
-                $(tagsArray).each(function(i,item) {
-                    var selectedItem = $field.closest(".coral-Form-fieldwrapper").find("li[data-value='" + item + "']");
+                $(tagsArray).each(function (i, item) {
+                    var selectedItem = $field.closest(cmf.CFFW).find("li[data-value='" + item + "']");
 
-                    $tagList._appendItem({"display":selectedItem.text(),"value":item});
+                    $tagList._appendItem({"display": selectedItem.text(), "value": item});
                 });
             }
         },


### PR DESCRIPTION
…ltifield

The AEM tags widget (the autocomplete widget) did not work under a multifield.  Added support for this, as the naming and structure of that particular widget is a bit different than most widgets.

The existing items (that display in the dialog) are stored in a &lt;ul&gt;, not the traditional value attribute.