### PR TITLE
Indicators might not appear in certain WCMModes

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/AemEnvironmentIndicatorFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/AemEnvironmentIndicatorFilter.java
@@ -105,6 +105,7 @@ public class AemEnvironmentIndicatorFilter implements Filter {
     public static final String PROP_TITLE_PREFIX = "browser-title-prefix";
     
     
+    private static final String[] DEFAULT_EXCLUDED_WCMMODES = {"DISABLED"};
     @Property (label = "Excluded WCM modes",
     		description = "Do not display the indicator when these WCM modes",
     		cardinality = Integer.MAX_VALUE)
@@ -151,10 +152,10 @@ public class AemEnvironmentIndicatorFilter implements Filter {
         if (excludedWCMModes != null) {
         	// Test for configured WCM modes, where the indicators are not displayed
         	WCMMode wcmmode = extractFromRequest (request);
-        	log.info("extracted wcm mode = {}", wcmmode.name());
         	for (String m : excludedWCMModes) {
-        		if (wcmmode.equals(WCMMode.valueOf(m))) {
+        		if (WCMMode.valueOf(m).equals(wcmmode)) {
         			doInclude = false;
+        			break;
         		}
         	}
         }
@@ -253,7 +254,7 @@ public class AemEnvironmentIndicatorFilter implements Filter {
             filterRegistration = ctx.getBundleContext().registerService(Filter.class.getName(), this, filterProps);
         }
         
-        excludedWCMModes = PropertiesUtil.toStringArray(config.get(PROP_EXCLUDED_WCMMODES));
+        excludedWCMModes = PropertiesUtil.toStringArray(config.get(PROP_EXCLUDED_WCMMODES),DEFAULT_EXCLUDED_WCMMODES);
     }
 
 

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/AemEnvironmentIndicatorFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/AemEnvironmentIndicatorFilter.java
@@ -2,6 +2,7 @@ package com.adobe.acs.commons.wcm.impl;
 
 import com.adobe.acs.commons.util.BufferingResponse;
 import com.adobe.granite.xss.XSSAPI;
+import com.day.cq.wcm.api.WCMMode;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.text.StrLookup;
@@ -102,6 +103,14 @@ public class AemEnvironmentIndicatorFilter implements Filter {
             description = "A prefix to add to the browser tab/window title; <THIS VALUE> | <ORIGINAL DOC TITLE>",
             value = DEFAULT_TITLE_PREFIX)
     public static final String PROP_TITLE_PREFIX = "browser-title-prefix";
+    
+    
+    @Property (label = "Excluded WCM modes",
+    		description = "Do not display the indicator when these WCM modes",
+    		cardinality = Integer.MAX_VALUE)
+    public static final String PROP_EXCLUDED_WCMMODES = "excluded-wcm-modes";
+    private String[] excludedWCMModes;
+    
 
 
     private static final String[] REJECT_PATH_PREFIXES = new String[]{
@@ -137,11 +146,23 @@ public class AemEnvironmentIndicatorFilter implements Filter {
         final BufferingResponse capturedResponse = new BufferingResponse(response);
 
         filterChain.doFilter(request, capturedResponse);
+        
+        boolean doInclude = true;
+        if (excludedWCMModes != null) {
+        	// Test for configured WCM modes, where the indicators are not displayed
+        	WCMMode wcmmode = extractFromRequest (request);
+        	log.info("extracted wcm mode = {}", wcmmode.name());
+        	for (String m : excludedWCMModes) {
+        		if (wcmmode.equals(WCMMode.valueOf(m))) {
+        			doInclude = false;
+        		}
+        	}
+        }
 
         // Get contents
         final String contents = capturedResponse.getContents();
 
-        if (contents != null && StringUtils.contains(response.getContentType(), "html")) {
+        if (doInclude && contents != null && StringUtils.contains(response.getContentType(), "html")) {
 
             final int bodyIndex = contents.indexOf("</body>");
 
@@ -231,6 +252,8 @@ public class AemEnvironmentIndicatorFilter implements Filter {
             filterProps.put("pattern", ".*");
             filterRegistration = ctx.getBundleContext().registerService(Filter.class.getName(), this, filterProps);
         }
+        
+        excludedWCMModes = PropertiesUtil.toStringArray(config.get(PROP_EXCLUDED_WCMMODES));
     }
 
 
@@ -244,4 +267,13 @@ public class AemEnvironmentIndicatorFilter implements Filter {
         // Reset CSS variable
         css = "";
     }
+    
+    // extract the WCMMode from the request; we cannot use
+    // WCMMode.fromRequest(), because this is not a SlingHttpServletRequest
+    private WCMMode extractFromRequest (HttpServletRequest request) {	
+    	
+        return (WCMMode) request.getAttribute(
+                WCMMode.REQUEST_ATTRIBUTE_NAME);
+    }
+    
 }


### PR DESCRIPTION
WCMModes can be configured where the EnvironmentIndicators don't appear. Is mostly useful for PREVIEW and DISABLED modes (see #699)