### PR TITLE
invalidate references in httpcache

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/invalidator/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/invalidator/package-info.java
@@ -24,7 +24,7 @@
  * invalidates the cache. For a typical implementation, invalidation event could be custom supplied based on the cache
  * config invalidation requirements. A sample implementation based on sling eventing is provided.
  */
-@aQute.bnd.annotation.Version("1.0.0")
+@aQute.bnd.annotation.Version("1.1.0")
 package com.adobe.acs.commons.httpcache.invalidator;
 
 


### PR DESCRIPTION
httpcache should support invalidation of references. 
Suppose Page A prints title of Page B, e.g. via the List component. User loads Page A and it gets into the httpcache.  At some point of time the title of Page B changes and then user loads Page A  again.  The problem with the current implementation is that the user will get stale data with the old title because cache invalidation is not cascade.  

the logic should be as follows:
1. invalidate the resource
2. find all references of the given resource and invalidate them. 
For #2 we can use com.day.cq.wcm.commons.ReferenceSearch to find all pages that reference the given path. 