### PR TITLE
Missing Design causes JS Error

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/classicui-configure-parsys-placeholder.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/classicui-configure-parsys-placeholder.js
@@ -102,6 +102,9 @@
             }
 
             designConfig = getConfiguration(parsys);
+            if (!designConfig) {
+              return;
+            }
 
             placeholder = parsys.emptyComponent.findByType("static")[0];
 


### PR DESCRIPTION
When there's no design node for a parsys; there's an error trying to read the configuration properties. If no design exists; skip to next parsys defintion.