### PR TITLE
implementation of a factory for HttpClient Executor/Request objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ notifications:
 branches:
   except:
     - feature/6.2-compatibility
+    - feature/httpcomponentsfactory

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -51,7 +51,6 @@
                         <Bundle-Activator>com.adobe.acs.commons.util.impl.Activator</Bundle-Activator>
                         <Bundle-SymbolicName>com.adobe.acs.acs-aem-commons-bundle</Bundle-SymbolicName>
                         <Import-Package>
-                        	
                             com.adobe.cq.dialogconversion;resolution:=optional,
                             sun.misc.*;resolution:=optional,
                             org.apache.sling.models.annotations.*;resolution:=optional, <!-- the used class InjectionStrategy is only since Sling Models API 1.2 -->
@@ -92,6 +91,10 @@
     </build>
 
     <dependencies>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient-osgi</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.compendium</artifactId>
@@ -263,6 +266,12 @@
             <version>1.4</version>
             <scope>test</scope>
          </dependency>
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-netty</artifactId>
+            <version>3.10.4</version>
+            <scope>test</scope>
+        </dependency>
         <!-- sling-api used in AEM 6.0-->
         <dependency>
             <groupId>org.apache.sling</groupId>

--- a/bundle/src/main/java/com/adobe/acs/commons/http/HttpClientFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/http/HttpClientFactory.java
@@ -1,0 +1,84 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.http;
+
+import org.apache.http.client.fluent.Executor;
+import org.apache.http.client.fluent.Request;
+
+/**
+ * Factory for building pre-configured HttpClient Fluent Executor and Request objects
+ * based a configure host, port and (optionally) username/password.
+ *
+ * Factories will generally be accessed by service lookup using the factory.name property.
+ */
+public interface HttpClientFactory {
+
+    /**
+     * Get the configured Executor object from this factory.
+     *
+     * @return an Executor object
+     */
+    Executor getExecutor();
+
+    /**
+     * Create a GET request using the base hostname and port defined in the factory configuration.
+     *
+     * @param partialUrl the portion of the URL after the port (and slash)
+     *
+     * @return a fluent Request object
+     */
+    Request get(String partialUrl);
+
+    /**
+     * Create a PUT request using the base hostname and port defined in the factory configuration.
+     *
+     * @param partialUrl the portion of the URL after the port (and slash)
+     *
+     * @return a fluent Request object
+     */
+    Request put(String partialUrl);
+
+    /**
+     * Create a POST request using the base hostname and port defined in the factory configuration.
+     *
+     * @param partialUrl the portion of the URL after the port (and slash)
+     *
+     * @return a fluent Request object
+     */
+    Request post(String partialUrl);
+
+    /**
+     * Create a DELETE request using the base hostname and port defined in the factory configuration.
+     *
+     * @param partialUrl the portion of the URL after the port (and slash)
+     *
+     * @return a fluent Request object
+     */
+    Request delete(String partialUrl);
+
+    /**
+     * Create a OPTIONS request using the base hostname and port defined in the factory configuration.
+     *
+     * @param partialUrl the portion of the URL after the port (and slash)
+     *
+     * @return a fluent Request object
+     */
+    Request options(String partialUrl);
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/http/JsonObjectResponseHandler.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/http/JsonObjectResponseHandler.java
@@ -1,0 +1,60 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.http;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.ResponseHandler;
+import org.apache.http.impl.client.BasicResponseHandler;
+import org.apache.sling.commons.json.JSONException;
+import org.apache.sling.commons.json.JSONObject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+
+/**
+ * Converts response to a JSON Object.
+ */
+public class JsonObjectResponseHandler implements ResponseHandler<JSONObject> {
+
+    private BasicResponseHandler handler = new BasicResponseHandler();
+
+    @Override
+    public JSONObject handleResponse(HttpResponse httpResponse) throws
+            ClientProtocolException, IOException {
+        String json = handler.handleResponse(httpResponse);
+        if (json == null) {
+            return null;
+        }
+        try {
+            return new JSONObject(json);
+        } catch (JSONException e) {
+            JSONObject jsonObject = new JSONObject();
+            try {
+                jsonObject.put("error", e.getMessage());
+            } catch (JSONException e1) {
+            }
+            return jsonObject;
+        }
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/http/impl/HttpClientFactoryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/http/impl/HttpClientFactoryImpl.java
@@ -37,8 +37,8 @@ import java.util.Map;
 
 
 @Component(
-        label = "Http Components Fluent Executor Factory",
-        description = "Http Components Fluent Executor Factory", immediate = false,
+        label = "ACS AEM Commons - Http Components Fluent Executor Factory",
+        description = "ACS AEM Commons - Http Components Fluent Executor Factory",
         configurationFactory = true, policy = ConfigurationPolicy.REQUIRE)
 @Service
 @Property(label = "Factory Name", description = "Name of this factory", name = "factory.name")

--- a/bundle/src/main/java/com/adobe/acs/commons/http/impl/HttpClientFactoryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/http/impl/HttpClientFactoryImpl.java
@@ -1,0 +1,144 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.http.impl;
+
+import com.adobe.acs.commons.http.HttpClientFactory;
+import org.apache.felix.scr.annotations.*;
+import org.apache.http.HttpHost;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.fluent.Executor;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
+import org.apache.http.conn.ssl.SSLContextBuilder;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.sling.commons.osgi.PropertiesUtil;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Map;
+
+
+@Component(
+        label = "Http Components Fluent Executor Factory",
+        description = "Http Components Fluent Executor Factory", immediate = false,
+        configurationFactory = true, policy = ConfigurationPolicy.REQUIRE)
+@Service
+@Property(label = "Factory Name", description = "Name of this factory", name = "factory.name")
+public class HttpClientFactoryImpl implements HttpClientFactory {
+    public static final boolean DEFAULT_USE_SSL = false;
+    public static final boolean DEFAULT_DISABLE_CERT_CHECK = false;
+
+    @Property(label = "host name", description = "host name")
+    private static final String PROP_HOST_DOMAIN = "hostname";
+
+
+    @Property(label = "port", description = "port")
+    private static final String PROP_GATEWAY_PORT = "port";
+
+    @Property(label = "Use SSL", description = "Select it if only using https connection for calls.", boolValue = DEFAULT_USE_SSL)
+    private static final String PROP_USE_SSL = "use.ssl";
+
+    @Property(label = "Disable certificate check", description = "If selected it will disable certificate check for the SSL connection.",
+            boolValue = DEFAULT_DISABLE_CERT_CHECK)
+    private static final String PROP_DISABLE_CERT_CHECK = "disable.certificate.check";
+
+    @Property(label = "username", description = "username")
+    private static final String PROP_USERNAME = "username";
+
+
+    @Property(label = "password", description = "password")
+    private static final String PROP_PASSWORD = "password";
+
+    private Executor executor;
+    private String baseUrl;
+
+    @Activate
+    protected void activate(Map<String, Object> config) throws Exception {
+        boolean useSSL = PropertiesUtil.toBoolean(config.get(PROP_USE_SSL), DEFAULT_USE_SSL);
+        boolean disableCertCheck = PropertiesUtil.toBoolean(config.get(PROP_DISABLE_CERT_CHECK), DEFAULT_DISABLE_CERT_CHECK);
+
+        String scheme = useSSL ? "https" : "http";
+        String hostname = PropertiesUtil.toString(config.get(PROP_HOST_DOMAIN), null);
+        int port = PropertiesUtil.toInteger(config.get(PROP_GATEWAY_PORT), 0);
+
+        if (hostname == null || port == 0) {
+            throw new IllegalArgumentException("Configuration not valid. Both host and port must be provided.");
+        }
+
+        baseUrl = String.format("%s://%s:%s", scheme, hostname, port);
+
+        if (useSSL && disableCertCheck) {
+            HttpClient client = HttpClients.custom().
+                    setHostnameVerifier(new AllowAllHostnameVerifier()).
+                    setSslcontext(new SSLContextBuilder().loadTrustMaterial(null, new TrustStrategy() {
+                        public boolean isTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
+                            return true;
+                        }
+                    }).build()).build();
+            executor = Executor.newInstance();
+        } else {
+            executor = Executor.newInstance();
+        }
+
+        String username = PropertiesUtil.toString(config.get(PROP_USERNAME), null);
+        String password = PropertiesUtil.toString(config.get(PROP_PASSWORD), null);
+        if (username != null && password != null) {
+            HttpHost httpHost = new HttpHost(hostname, port);
+            executor.auth(httpHost, username, password).authPreemptive(httpHost);
+        }
+    }
+
+    @Override
+    public Executor getExecutor() {
+        return executor;
+    }
+
+    @Override
+    public Request get(String partialUrl) {
+        String url = baseUrl + partialUrl;
+        return Request.Get(url);
+    }
+
+    @Override
+    public Request post(String partialUrl) {
+        String url = baseUrl + partialUrl;
+        return Request.Post(url);
+    }
+
+    @Override
+    public Request put(String partialUrl) {
+        String url = baseUrl + partialUrl;
+        return Request.Put(url);
+    }
+
+    @Override
+    public Request delete(String partialUrl) {
+        String url = baseUrl + partialUrl;
+        return Request.Delete(url);
+    }
+
+    @Override
+    public Request options(String partialUrl) {
+        String url = baseUrl + partialUrl;
+        return Request.Options(url);
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/http/impl/HttpClientFactoryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/http/impl/HttpClientFactoryImpl.java
@@ -34,6 +34,7 @@ import org.apache.http.osgi.services.HttpClientBuilderFactory;
 import org.apache.sling.commons.osgi.PropertiesUtil;
 
 import javax.net.ssl.SSLContext;
+import java.io.IOException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Map;
@@ -132,9 +133,13 @@ public class HttpClientFactoryImpl implements HttpClientFactory {
     }
 
     @Deactivate
-    protected void deactivate() throws Exception {
+    protected void deactivate() {
         if (httpClient != null) {
-            httpClient.close();
+            try {
+                httpClient.close();
+            } catch (final IOException e) {
+                // do nothing
+            }
         }
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/http/impl/HttpClientFactoryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/http/impl/HttpClientFactoryImpl.java
@@ -31,6 +31,7 @@ import org.apache.http.conn.ssl.SSLContextBuilder;
 import org.apache.http.conn.ssl.TrustStrategy;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.osgi.services.HttpClientBuilderFactory;
 import org.apache.sling.commons.osgi.PropertiesUtil;
 
 import javax.net.ssl.SSLContext;
@@ -57,7 +58,6 @@ public class HttpClientFactoryImpl implements HttpClientFactory {
     @Property(label = "host name", description = "host name")
     private static final String PROP_HOST_DOMAIN = "hostname";
 
-
     @Property(label = "port", description = "port")
     private static final String PROP_GATEWAY_PORT = "port";
 
@@ -71,7 +71,6 @@ public class HttpClientFactoryImpl implements HttpClientFactory {
     @Property(label = "Username", description = "Username for requests (using basic authentication)")
     private static final String PROP_USERNAME = "username";
 
-
     @Property(label = "Password", description = "Password for requests (using basic authentication)")
     private static final String PROP_PASSWORD = "password";
 
@@ -80,6 +79,9 @@ public class HttpClientFactoryImpl implements HttpClientFactory {
 
     @Property(label = "Connect Timeout", description = "Connect timeout in milliseconds", intValue = DEFAULT_CONNECT_TIMEOUT)
     private static final String PROP_CONNECT_TIMEOUT = "conn.timeout";
+
+    @Reference
+    private HttpClientBuilderFactory httpClientBuilderFactory;
 
     private Executor executor;
     private String baseUrl;
@@ -102,7 +104,7 @@ public class HttpClientFactoryImpl implements HttpClientFactory {
         int connectTimeout = PropertiesUtil.toInteger(config.get(PROP_CONNECT_TIMEOUT), DEFAULT_CONNECT_TIMEOUT);
         int soTimeout = PropertiesUtil.toInteger(config.get(PROP_SO_TIMEOUT), DEFAULT_SOCKET_TIMEOUT);
 
-        HttpClientBuilder builder = HttpClients.custom();
+        HttpClientBuilder builder = httpClientBuilderFactory.newBuilder();
 
         RequestConfig requestConfig = RequestConfig.custom()
                 .setConnectTimeout(connectTimeout)

--- a/bundle/src/main/java/com/adobe/acs/commons/http/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/http/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/**
+ * Http Injectors.
+ */
+@aQute.bnd.annotation.Version("1.0.0")
+package com.adobe.acs.commons.http;

--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,12 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient-osgi</artifactId>
+                <version>4.3.4</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.12</version>


### PR DESCRIPTION
This pull request replaces #478 with the following changes:

* Removed StringResponseHandler as that functionality already exists in HttpClient.
* Refactored JsonObjectResponseHandler (which was renamed to reflect that it handles JSON objects, not arbitrary JSON) to use the BasicResponseHandler to do the String extraction from the response.
* Added factory.name configuration option to actually find the configured factories from other OSGi components.
* Remove Jackson-based response handler as that seemed to be incompatible with AEM 6.2 (it can always be added later)
* Implemented relaxed SSL cert checking (it was configurable but not actually implemented)
* Misc. code cleanup and formatting.