### PR TITLE
Content traversing workflows - Synthetic WF and Replication w Options

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/util/WorkflowHelper.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/WorkflowHelper.java
@@ -1,0 +1,47 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.util;
+
+import aQute.bnd.annotation.ProviderType;
+import com.day.cq.workflow.WorkflowSession;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.ResourceResolver;
+
+@ProviderType
+public interface WorkflowHelper {
+    String PROCESS_ARGS = "PROCESS_ARGS";
+
+    /**
+     * Convenience method for getting a ResourceResolver object from a Granite based Workflow Process.
+     *
+     * @param workflowSession the granite workflow session
+     * @return the associated ResourceResolver object
+     */
+    ResourceResolver getResourceResolver(com.adobe.granite.workflow.WorkflowSession workflowSession);
+
+    /**
+     * Convenience method for getting a ResourceResolver object from a CQ based Workflow Process.
+     *
+     * @param workflowSession the CQ workflow session
+     * @return the associated ResourceResolver object
+     */
+    ResourceResolver getResourceResolver(WorkflowSession workflowSession) throws LoginException;
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/util/impl/WorkflowHelperImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/impl/WorkflowHelperImpl.java
@@ -1,0 +1,61 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.util.impl;
+
+import com.adobe.acs.commons.util.WorkflowHelper;
+import com.day.cq.workflow.WorkflowSession;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceResolverFactory;
+import org.apache.sling.jcr.resource.JcrResourceConstants;
+
+import javax.jcr.Session;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@Service
+public class WorkflowHelperImpl implements WorkflowHelper {
+
+    @Reference
+    private ResourceResolverFactory resourceResolverFactory;
+
+    /**
+     * @{inheritDoc}
+     **/
+    @Override
+    public final ResourceResolver getResourceResolver(com.adobe.granite.workflow.WorkflowSession workflowSession) {
+        return workflowSession.adaptTo(ResourceResolver.class);
+    }
+
+    /**
+     * @{inheritDoc}
+     **/
+    @Override
+    public final ResourceResolver getResourceResolver(WorkflowSession workflowSession) throws LoginException {
+        final Map<String, Object> authInfo = new HashMap<String, Object>();
+        authInfo.put(JcrResourceConstants.AUTHENTICATION_INFO_SESSION, workflowSession.getSession());
+        return resourceResolverFactory.getResourceResolver(authInfo);
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/util/visitors/ContentVisitor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/visitors/ContentVisitor.java
@@ -1,0 +1,77 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.util.visitors;
+
+import com.day.cq.dam.api.DamConstants;
+import com.day.cq.wcm.api.NameConstants;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.jackrabbit.JcrConstants;
+import org.apache.sling.api.resource.AbstractResourceVisitor;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.jcr.resource.JcrResourceConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ContentVisitor<T extends ResourceRunnable> extends AbstractResourceVisitor {
+    private static final Logger log = LoggerFactory.getLogger(ContentVisitor.class);
+
+    private final String[] DEFAULT_CONTAINER_TYPES = {JcrResourceConstants.NT_SLING_FOLDER, JcrResourceConstants.NT_SLING_ORDERED_FOLDER, JcrConstants.NT_FOLDER};
+    private final String[] DEFAULT_CONTENT_TYPES = {NameConstants.NT_PAGE, DamConstants.NT_DAM_ASSET};
+
+    private final T runnable;
+    private final String[] contentTypes;
+    private final String[] containerTypes;
+
+    public ContentVisitor(T runnable) {
+        this.runnable = runnable;
+        this.containerTypes = DEFAULT_CONTAINER_TYPES;
+        this.contentTypes = DEFAULT_CONTENT_TYPES;
+    }
+    public ContentVisitor(T runnable, String[] containerTypes, String[] contentTypes) {
+        this.runnable = runnable;
+        this.containerTypes = containerTypes;
+        this.contentTypes = contentTypes;
+    }
+
+    @Override
+    public void accept(Resource resource) {
+        if (resource != null) {
+            final String primaryType = resource.getValueMap().get(JcrConstants.JCR_PRIMARYTYPE, String.class);
+
+            if (ArrayUtils.contains(containerTypes, primaryType) || ArrayUtils.contains(contentTypes, primaryType)) {
+                super.accept(resource);
+            }
+        }
+    }
+
+    @Override
+    protected void visit(Resource resource) {
+        try {
+            final String primaryType = resource.getValueMap().get(JcrConstants.JCR_PRIMARYTYPE, String.class);
+
+            if (ArrayUtils.contains(contentTypes, primaryType)) {
+                runnable.run(resource);
+            }
+        } catch (Exception e) {
+            log.error("An error occurred while visiting resource [ {} ]", resource.getPath(), e);
+        }
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/util/visitors/ResourceRunnable.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/visitors/ResourceRunnable.java
@@ -2,14 +2,14 @@
  * #%L
  * ACS AEM Commons Bundle
  * %%
- * Copyright (C) 2013 Adobe
+ * Copyright (C) 2016 Adobe
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,10 +17,19 @@
  * limitations under the License.
  * #L%
  */
-/**
- * Miscellaneous Utilities.
- */
-@Version("2.2.0")
-package com.adobe.acs.commons.util;
 
-import aQute.bnd.annotation.Version;
+package com.adobe.acs.commons.util.visitors;
+
+import aQute.bnd.annotation.ConsumerType;
+import org.apache.sling.api.resource.Resource;
+
+@ConsumerType
+public interface ResourceRunnable {
+
+    /**
+     * Perform the work on the provided resource.
+     * @param resource the resource
+     * @throws Exception
+     */
+    void run(Resource resource) throws Exception;
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/util/visitors/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/visitors/package-info.java
@@ -2,14 +2,14 @@
  * #%L
  * ACS AEM Commons Bundle
  * %%
- * Copyright (C) 2013 Adobe
+ * Copyright (C) 2016 Adobe
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,7 @@
 /**
  * Miscellaneous Utilities.
  */
-@Version("2.2.0")
-package com.adobe.acs.commons.util;
+@Version("1.0.0")
+package com.adobe.acs.commons.util.visitors;
 
 import aQute.bnd.annotation.Version;

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/process/impl/ReplicateWithOptionsWorkflowProcess.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/process/impl/ReplicateWithOptionsWorkflowProcess.java
@@ -1,0 +1,164 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.workflow.process.impl;
+
+import com.adobe.acs.commons.fam.ThrottledTaskRunner;
+import com.adobe.acs.commons.util.ParameterUtil;
+import com.adobe.acs.commons.util.WorkflowHelper;
+import com.adobe.acs.commons.util.visitors.ContentVisitor;
+import com.adobe.acs.commons.util.visitors.ResourceRunnable;
+import com.adobe.acs.commons.workflow.WorkflowPackageManager;
+import com.day.cq.replication.ReplicationActionType;
+import com.day.cq.replication.ReplicationOptions;
+import com.day.cq.replication.Replicator;
+import com.day.cq.workflow.WorkflowException;
+import com.day.cq.workflow.WorkflowSession;
+import com.day.cq.workflow.exec.WorkItem;
+import com.day.cq.workflow.exec.WorkflowProcess;
+import com.day.cq.workflow.metadata.MetaDataMap;
+import org.apache.commons.lang.StringUtils;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.Session;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Component(
+        metatype = true,
+        label = "ACS AEM Commons - Workflow Process - Replicate with Options",
+        description = "Replicates the content based on the process arg replication configuration using FAM,"
+)
+@Properties({
+        @Property(
+                label = "Workflow Label",
+                name = "process.label",
+                value = "Replicate with Options",
+                description = "Replicates the content based on the process arg replication configuration (serial execution)"
+        )
+})
+@Service
+public class ReplicateWithOptionsWorkflowProcess implements WorkflowProcess {
+    private static final Logger log = LoggerFactory.getLogger(ReplicateWithOptionsWorkflowProcess.class);
+
+    private static final String ARG_TRAVERSE_TREE = "traverseTree";
+    private static final String ARG_REPLICATION_ACTION_TYPE = "replicationActionType";
+    private static final String ARG_REPLICATION_SYNCHRONOUS = "synchronous";
+    private static final String ARG_REPLICATION_SUPPRESS_VERSIONS = "suppressVersions";
+
+    @Reference
+    private WorkflowPackageManager workflowPackageManager;
+
+    @Reference
+    private Replicator replicator;
+
+    @Reference
+    private ThrottledTaskRunner throttledTaskRunner;
+
+    @Reference
+    private WorkflowHelper workflowHelper;
+
+    @Override
+    public void execute(WorkItem workItem, WorkflowSession workflowSession, MetaDataMap metaDataMap) throws WorkflowException {
+        ResourceResolver resourceResolver = null;
+
+        try {
+            resourceResolver = workflowHelper.getResourceResolver(workflowSession);
+            final String originalPayload = (String) workItem.getWorkflowData().getPayload();
+            final List<String> payloads = workflowPackageManager.getPaths(resourceResolver, originalPayload);
+            final ProcessArgs processArgs = new ProcessArgs(metaDataMap);
+
+            final AtomicInteger count = new AtomicInteger(0);
+
+            // Anonymous inner class to facilitate counting of processed payloads
+            final ResourceRunnable replicatorRunnable = new ResourceRunnable() {
+                @Override
+                public void run(final Resource resource) throws Exception {
+                    throttledTaskRunner.waitForLowCpuAndLowMemory();
+                    replicator.replicate(resource.getResourceResolver().adaptTo(Session.class),
+                            processArgs.getReplicationActionType(),
+                            resource.getPath(),
+                            processArgs.getReplicationOptions());
+                }
+            };
+
+            final ContentVisitor visitor = new ContentVisitor(replicatorRunnable);
+
+            for (final String payload : payloads) {
+                final Resource resource = resourceResolver.getResource(payload);
+
+                if (processArgs.isTraverseTree()) {
+                    // Traverse the tree
+                    visitor.accept(resource);
+                } else {
+                    // Only execute on the provided payload
+                    replicatorRunnable.run(resource);
+                }
+            }
+
+            log.info("Synthetic Workflow Wrapper processed [ {} ] total payloads", count.get());
+        } catch (Exception e) {
+            throw new WorkflowException(e);
+        }
+    }
+
+    /**
+     * ProcessArgs parsed from the WF metadata map
+     */
+    private static class ProcessArgs {
+        private ReplicationActionType replicationActionType = null;
+        private ReplicationOptions replicationOptions = new ReplicationOptions();
+        private boolean traverseTree = false;
+
+        public ProcessArgs(MetaDataMap map) throws WorkflowException {
+            String[] lines = StringUtils.split(map.get(WorkflowHelper.PROCESS_ARGS, ""), System.lineSeparator());
+            Map<String, String> data = ParameterUtil.toMap(lines, "=");
+
+            traverseTree = Boolean.parseBoolean(data.get(ARG_TRAVERSE_TREE));
+            replicationActionType = ReplicationActionType.fromName(data.get(ARG_REPLICATION_ACTION_TYPE));
+            if (replicationActionType == null) {
+                throw new WorkflowException("Unable to parse the replicationActionType from the Workflow Porcess Args");
+            }
+            replicationOptions.setSynchronous(Boolean.parseBoolean(data.get(ARG_REPLICATION_SYNCHRONOUS)));
+            replicationOptions.setSuppressVersions(Boolean.parseBoolean(data.get(ARG_REPLICATION_SUPPRESS_VERSIONS)));
+        }
+
+        public ReplicationActionType getReplicationActionType() {
+            return replicationActionType;
+        }
+
+        public ReplicationOptions getReplicationOptions() {
+            return replicationOptions;
+        }
+
+        public boolean isTraverseTree() {
+            return traverseTree;
+        }
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/process/impl/SyntheticWrapperWorkflowProcess.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/process/impl/SyntheticWrapperWorkflowProcess.java
@@ -1,0 +1,161 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.workflow.process.impl;
+
+import com.adobe.acs.commons.fam.ThrottledTaskRunner;
+import com.adobe.acs.commons.util.ParameterUtil;
+import com.adobe.acs.commons.util.WorkflowHelper;
+import com.adobe.acs.commons.util.visitors.ContentVisitor;
+import com.adobe.acs.commons.util.visitors.ResourceRunnable;
+import com.adobe.acs.commons.workflow.synthetic.SyntheticWorkflowModel;
+import com.adobe.acs.commons.workflow.synthetic.SyntheticWorkflowRunner;
+import com.day.cq.workflow.WorkflowException;
+import com.day.cq.workflow.WorkflowSession;
+import com.day.cq.workflow.exec.WorkItem;
+import com.day.cq.workflow.exec.WorkflowProcess;
+import com.day.cq.workflow.metadata.MetaDataMap;
+import org.apache.commons.lang.StringUtils;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Component(
+        metatype = true,
+        label = "ACS AEM Commons - Workflow Process - Synthetic Workflow Wrapper Process",
+        description = "Executes an AEM Workflow model as a Synthetic Workflow using FAM"
+)
+@Properties({
+        @Property(
+                label = "Workflow Label",
+                name = "process.label",
+                value = "Synthetic Workflow Wrapper",
+                description = "Executes an AEM Workflow model as a Synthetic Workflow (serial execution)"
+        )
+})
+@Service
+public class SyntheticWrapperWorkflowProcess implements WorkflowProcess {
+    private static final Logger log = LoggerFactory.getLogger(SyntheticWrapperWorkflowProcess.class);
+    private static final String ARG_TRAVERSE_TREE = "traverseTree";
+    private static final String ARG_SAVE_INTERVAL = "saveInterval";
+    private static final String ARG_WORKFLOW_MODEL_ID = "workflowModelId";
+
+    @Reference
+    private SyntheticWorkflowRunner syntheticWorkflowRunner;
+
+    @Reference
+    private ThrottledTaskRunner throttledTaskRunner;
+
+    @Reference
+    private WorkflowHelper workflowHelper;
+
+    @Override
+    public void execute(WorkItem workItem, WorkflowSession workflowSession, MetaDataMap metaDataMap) throws WorkflowException {
+        ResourceResolver resourceResolver = null;
+
+        final String payload = (String) workItem.getWorkflowData().getPayload();
+        final ProcessArgs processArgs = new ProcessArgs(metaDataMap);
+
+        try {
+            resourceResolver = workflowHelper.getResourceResolver(workflowSession);
+            final SyntheticWorkflowModel syntheticWorkflowModel = syntheticWorkflowRunner.getSyntheticWorkflowModel(resourceResolver, processArgs.getWorkflowModelId(), true);
+
+            final AtomicInteger count = new AtomicInteger(0);
+
+            // Anonymous inner class to facilitate counting of processed payloads
+            final ResourceRunnable syntheticRunnable = new ResourceRunnable() {
+                @Override
+                public void run(final Resource resource) throws java.lang.Exception {
+                    throttledTaskRunner.waitForLowCpuAndLowMemory();
+                    syntheticWorkflowRunner.execute(resource.getResourceResolver(), resource.getPath(), syntheticWorkflowModel, false, false);
+
+                    // Commit as needed
+                    if (processArgs.getSaveInterval() > 0
+                            && count.incrementAndGet() % processArgs.getSaveInterval() == 0
+                            && resource.getResourceResolver().hasChanges()) {
+                        resource.getResourceResolver().commit();
+                    }
+                }
+            };
+
+            final ContentVisitor visitor = new ContentVisitor(syntheticRunnable);
+            final Resource resource = resourceResolver.getResource(payload);
+
+            if (processArgs.isTraverseTree()) {
+                visitor.accept(resource);
+            } else {
+                syntheticRunnable.run(resource);
+            }
+
+            if (processArgs.getSaveInterval() > 0 && resourceResolver.hasChanges()) {
+                // Commit any stranglers
+                resourceResolver.commit();
+            }
+        } catch (Exception e) {
+            throw new WorkflowException(e);
+        }
+    }
+
+
+    private  static class ProcessArgs {
+        private boolean traverseTree = false;
+        private String workflowModelId;
+        int saveInterval;
+
+        public ProcessArgs(MetaDataMap map) throws WorkflowException {
+            String[] lines = StringUtils.split(map.get(WorkflowHelper.PROCESS_ARGS, ""), System.lineSeparator());
+            Map<String, String> data = ParameterUtil.toMap(lines, "=");
+
+            traverseTree = Boolean.parseBoolean(data.get(ARG_TRAVERSE_TREE));
+            workflowModelId = data.get(ARG_WORKFLOW_MODEL_ID);
+            try {
+                saveInterval = Integer.parseInt(data.get(ARG_SAVE_INTERVAL));
+            } catch (NumberFormatException e) {
+                log.warn("Could not parse int from [ {} ]", data.get(ARG_SAVE_INTERVAL));
+                saveInterval = 100;
+            }
+
+            if (StringUtils.isBlank(workflowModelId)) {
+                throw new WorkflowException("Unable to parse the workflowModelId from the Workflow Process Args");
+            }
+        }
+
+        public String getWorkflowModelId() {
+            return workflowModelId;
+        }
+
+        public boolean isTraverseTree() {
+            return traverseTree;
+        }
+
+        public int getSaveInterval() {
+            return saveInterval;
+        }
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/util/visitors/ContentVisitorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/visitors/ContentVisitorTest.java
@@ -1,0 +1,126 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.util.visitors;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.apache.jackrabbit.JcrConstants;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.HashMap;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+public class ContentVisitorTest {
+    @Mock
+    Resource resource;
+
+    ValueMap properties = new ValueMapDecorator(new HashMap<String, Object>());
+
+    @Spy
+    ResourceRunnable runnable = new TestRunnable();
+
+    @Before
+    public void setUp() throws Exception {
+        when(resource.getValueMap()).thenReturn(properties);
+        when(resource.listChildren()).thenReturn(IteratorUtils.EMPTY_LIST_ITERATOR);
+    }
+
+    @Test
+    public void accept_ContainerSlingFolder() throws Exception {
+        properties.put(JcrConstants.JCR_PRIMARYTYPE, "sling:Folder");
+
+        ContentVisitor visitor = spy(new ContentVisitor(runnable));
+        visitor.accept(resource);
+        verify(visitor, times(1)).visit(resource);
+    }
+
+    @Test
+    public void accept_ContainerNtFolder() throws Exception {
+        properties.put(JcrConstants.JCR_PRIMARYTYPE, "nt:folder");
+
+        ContentVisitor visitor = spy(new ContentVisitor(runnable));
+        visitor.accept(resource);
+        verify(visitor, times(1)).visit(resource);
+    }
+
+    @Test
+    public void accept_ContainerSlingOrderedFolder() throws Exception {
+        properties.put(JcrConstants.JCR_PRIMARYTYPE, "sling:OrderedFolder");
+
+        ContentVisitor visitor = spy(new ContentVisitor(runnable));
+        visitor.accept(resource);
+        verify(visitor, times(1)).visit(resource);
+    }
+
+    @Test
+    public void accept_ContainerInvalid() throws Exception {
+        properties.put(JcrConstants.JCR_PRIMARYTYPE, "nt:unstructured");
+
+        ContentVisitor visitor = spy(new ContentVisitor(runnable));
+        visitor.accept(resource);
+        verify(visitor, times(0)).visit(resource);
+    }
+
+    @Test
+    public void accept_ContentDAMAsset() throws Exception {
+        properties.put(JcrConstants.JCR_PRIMARYTYPE, "dam:Asset");
+
+        ContentVisitor visitor = new ContentVisitor(runnable);
+        visitor.accept(resource);
+        verify(runnable, times(1)).run(resource);
+    }
+
+    @Test
+    public void accept_ContentCqPage() throws Exception {
+        properties.put(JcrConstants.JCR_PRIMARYTYPE, "cq:Page");
+
+        ContentVisitor visitor = new ContentVisitor(runnable);
+        visitor.accept(resource);
+        verify(runnable, times(1)).run(resource);
+    }
+
+    @Test
+    public void accept_ContentInvalid() throws Exception {
+        properties.put(JcrConstants.JCR_PRIMARYTYPE, "oak:Unstructured");
+
+        ContentVisitor visitor = new ContentVisitor(runnable);
+        visitor.accept(resource);
+        verify(runnable, times(0)).run(resource);
+    }
+
+    private class TestRunnable implements ResourceRunnable {
+        @Override
+        public void run(Resource resource) throws Exception {
+        }
+    }
+}


### PR DESCRIPTION
This PR contains mechanics to support Content Traversing workflows. This is useful in AEM 6.2 as WF Folders can now be selected for applying Workflow to.

* Content Visitor - Walks Page or Asset trees looking for cq:Pages and dam:Assets to process.

* SyntheticWorkflowWrapper - WF Process that executes a param WF Model as Synthetic WF. Allows for easy execution of Synth WF via normal WF UIs though does require invocation of a WF. Can be used to traverse content trees.

* Replication w Options - performs a Content Traversing replication w replication options passed in via PROCESS_ARGS