### PR TITLE
HttpCache - ResourceType Include based caching

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/HttpCacheConfig.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/HttpCacheConfig.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
 @ProviderType
 public interface HttpCacheConfig {
 
-    public enum FilterScope {
+    enum FilterScope {
         REQUEST,
         INCLUDE
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/HttpCacheConfigImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/HttpCacheConfigImpl.java
@@ -28,7 +28,6 @@ import com.adobe.acs.commons.httpcache.keys.CacheKey;
 import com.adobe.acs.commons.httpcache.keys.CacheKeyFactory;
 import com.adobe.acs.commons.httpcache.store.HttpCacheStore;
 import com.adobe.acs.commons.httpcache.util.UserUtils;
-import com.sun.tools.internal.ws.wsdl.document.jaxws.Exception;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.felix.scr.annotations.Activate;

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/HttpCacheConfigImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/HttpCacheConfigImpl.java
@@ -28,6 +28,7 @@ import com.adobe.acs.commons.httpcache.keys.CacheKey;
 import com.adobe.acs.commons.httpcache.keys.CacheKeyFactory;
 import com.adobe.acs.commons.httpcache.store.HttpCacheStore;
 import com.adobe.acs.commons.httpcache.util.UserUtils;
+import com.sun.tools.internal.ws.wsdl.document.jaxws.Exception;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.felix.scr.annotations.Activate;
@@ -165,9 +166,9 @@ public class HttpCacheConfigImpl implements HttpCacheConfig {
     @Property(label = "Filter scope",
             description = "Specify the scope of this HttpCacheConfig in the scope of the Sling Servlet Filter processing chain.",
             options = {
-                    @PropertyOption(name = "Request",
+                    @PropertyOption(name = FILTER_SCOPE_REQUEST,
                             value = FILTER_SCOPE_REQUEST),
-                    @PropertyOption(name = "Include",
+                    @PropertyOption(name = FILTER_SCOPE_INCLUDE,
                             value = FILTER_SCOPE_INCLUDE)
             },
             value = DEFAULT_FILTER_SCOPE)
@@ -236,7 +237,7 @@ public class HttpCacheConfigImpl implements HttpCacheConfig {
 
         order = PropertiesUtil.toInteger(configs.get(PROP_ORDER), DEFAULT_ORDER);
 
-        filterScope = FilterScope.valueOf(PropertiesUtil.toString(PROP_FILTER_SCOPE, DEFAULT_FILTER_SCOPE).toUpperCase());
+        filterScope = FilterScope.valueOf(PropertiesUtil.toString(configs.get(PROP_FILTER_SCOPE), DEFAULT_FILTER_SCOPE).toUpperCase());
 
         // PIDs of cache handling rules.
         cacheHandlingRulesPid = new ArrayList<String>(Arrays.asList(PropertiesUtil.toStringArray(configs.get

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/ResourceTypeHttpCacheConfigExtension.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/ResourceTypeHttpCacheConfigExtension.java
@@ -137,15 +137,13 @@ public class ResourceTypeHttpCacheConfigExtension implements HttpCacheConfigExte
      * The ResourceTypeCacheKey is a custom CacheKey bound to this particular factory.
      */
     class ResourceTypeCacheKey extends AbstractCacheKey implements CacheKey {
-        private String resourcePath;
-
         public ResourceTypeCacheKey(SlingHttpServletRequest request, HttpCacheConfig cacheConfig) throws
                 HttpCacheKeyCreationException {
-            this.resourcePath = request.getResource().getPath();
+            super(request, cacheConfig);
         }
 
         public ResourceTypeCacheKey(String uri, HttpCacheConfig cacheConfig) throws HttpCacheKeyCreationException {
-            this.resourcePath = new PathInfo(uri).getResourcePath();
+            super(uri, cacheConfig);
         }
 
         @Override
@@ -155,17 +153,23 @@ public class ResourceTypeHttpCacheConfigExtension implements HttpCacheConfigExte
             }
 
             ResourceTypeCacheKey that = (ResourceTypeCacheKey) o;
-            return new EqualsBuilder().append(resourcePath, that.resourcePath).isEquals();
+            return new EqualsBuilder()
+                    .append(getUri(), that.getUri())
+                    .append(getAuthenticationRequirement(), that.getAuthenticationRequirement())
+                    .isEquals();
         }
 
         @Override
         public int hashCode() {
-            return new HashCodeBuilder(17, 37).append(resourcePath).toHashCode();
+            return new HashCodeBuilder(17, 37)
+                    .append(getUri())
+                    .append(getAuthenticationRequirement()).toHashCode();
         }
 
         @Override
         public String toString() {
-            return this.resourcePath;
+            return this.resourcePath + " [AUTH_REQ:" + getAuthenticationRequirement() + "]";
+
         }
 
         @Override

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/ResourceTypeHttpCacheConfigExtension.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/ResourceTypeHttpCacheConfigExtension.java
@@ -27,7 +27,6 @@ import com.adobe.acs.commons.httpcache.keys.AbstractCacheKey;
 import com.adobe.acs.commons.httpcache.keys.CacheKey;
 import com.adobe.acs.commons.httpcache.keys.CacheKeyFactory;
 import com.adobe.acs.commons.util.ParameterUtil;
-import com.day.cq.commons.PathInfo;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.felix.scr.annotations.Activate;

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/ResourceTypeHttpCacheConfigExtension.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/ResourceTypeHttpCacheConfigExtension.java
@@ -135,7 +135,7 @@ public class ResourceTypeHttpCacheConfigExtension implements HttpCacheConfigExte
     /**
      * The ResourceTypeCacheKey is a custom CacheKey bound to this particular factory.
      */
-    class ResourceTypeCacheKey extends AbstractCacheKey implements CacheKey {
+    static class ResourceTypeCacheKey extends AbstractCacheKey implements CacheKey {
         public ResourceTypeCacheKey(SlingHttpServletRequest request, HttpCacheConfig cacheConfig) throws
                 HttpCacheKeyCreationException {
             super(request, cacheConfig);

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImpl.java
@@ -114,8 +114,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class HttpCacheEngineImpl extends AnnotatedStandardMBean implements HttpCacheEngine, HttpCacheEngineMBean {
     private static final Logger log = LoggerFactory.getLogger(HttpCacheConfigImpl.class);
 
-    private static final String REQUEST_ATTR_IS_REQUEST_CACHEABLE = "acs-commons--http-cache--global-rules--is-request-cacheable";
-
     /** Method name that binds cache configs */
     static final String METHOD_NAME_TO_BIND_CONFIG = "httpCacheConfig";
     /** Thread safe list to contain the registered HttpCacheConfig references. */
@@ -298,11 +296,6 @@ public class HttpCacheEngineImpl extends AnnotatedStandardMBean implements HttpC
     public boolean isRequestCacheable(SlingHttpServletRequest request, HttpCacheConfig cacheConfig) throws
             HttpCacheRepositoryAccessException {
 
-        // Only evaluate global rules once
-        //if (request.getAttribute(REQUEST_ATTR_IS_REQUEST_CACHEABLE) != null) {
-        //    return (Boolean) request.getAttribute(REQUEST_ATTR_IS_REQUEST_CACHEABLE);
-        //}
-
         // Execute custom rules.
         for (final Map.Entry<String, HttpCacheHandlingRule> entry : cacheHandlingRules.entrySet()) {
             // Apply rule if it's a configured global or cache-config tied rule.
@@ -314,14 +307,12 @@ public class HttpCacheEngineImpl extends AnnotatedStandardMBean implements HttpC
                                 .getRequestURL(), rule.getClass().getName());
                     }
                     // Only a single rule need to fail to cause the caching mechanism to be by-passed
-                    request.setAttribute(REQUEST_ATTR_IS_REQUEST_CACHEABLE, Boolean.FALSE);
                     return false;
                 }
             }
         }
 
         // All rules have accepted this request, so request is cache-able.
-        request.setAttribute(REQUEST_ATTR_IS_REQUEST_CACHEABLE, Boolean.TRUE);
         return true;
     }
 
@@ -405,7 +396,6 @@ public class HttpCacheEngineImpl extends AnnotatedStandardMBean implements HttpC
 
         // Copy the cached data into the servlet output stream.
         try {
-            // TODO CHECK THIS OUTPUTSTREAM TO WRITER
             IOUtils.copy(cacheContent.getInputDataStream(), response.getWriter());
             if (log.isDebugEnabled()) {
                 log.debug("Response delivered from cache for the url [ {} ]", request.getRequestURI());
@@ -435,7 +425,7 @@ public class HttpCacheEngineImpl extends AnnotatedStandardMBean implements HttpC
             cacheConfig) throws HttpCacheKeyCreationException, HttpCacheDataStreamException,
             HttpCachePersistenceException {
 
-        // TODO - This can be made asynchronous to avoid performance penality on response cache.
+        // TODO - This can be made asynchronous to avoid performance penalty on response cache.
 
         CacheContent cacheContent = null;
         try {

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/filter/impl/HttpCacheRequestFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/filter/impl/HttpCacheRequestFilter.java
@@ -57,7 +57,7 @@ public class HttpCacheRequestFilter extends AbstractHttpCacheFilter implements F
             cardinality = ReferenceCardinality.MANDATORY_UNARY,
             target = "(httpcache.config.filter-scope=REQUEST)"
     )
-    private HttpCacheConfig inludeScopeCacheConfigs;
+    private HttpCacheConfig requestScopeCacheConfigs;
 
 
     @Override

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/keys/AbstractCacheKey.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/keys/AbstractCacheKey.java
@@ -22,6 +22,7 @@ package com.adobe.acs.commons.httpcache.keys;
 
 import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;
 import com.day.cq.commons.PathInfo;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.sling.api.SlingHttpServletRequest;
 
 public abstract class AbstractCacheKey {
@@ -54,6 +55,13 @@ public abstract class AbstractCacheKey {
         }
 
         return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(getUri())
+                .append(getAuthenticationRequirement()).toHashCode();
     }
 
     public String getAuthenticationRequirement() {

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/keys/AbstractCacheKey.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/keys/AbstractCacheKey.java
@@ -20,7 +20,28 @@
 
 package com.adobe.acs.commons.httpcache.keys;
 
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;
+import com.day.cq.commons.PathInfo;
+import org.apache.sling.api.SlingHttpServletRequest;
+
 public abstract class AbstractCacheKey {
+
+    protected String authenticationRequirement;
+    protected String uri;
+    protected String resourcePath;
+
+    public AbstractCacheKey(SlingHttpServletRequest request, HttpCacheConfig cacheConfig) {
+        this.authenticationRequirement = cacheConfig.getAuthenticationRequirement();
+        this.uri = request.getRequestURI();
+        this.resourcePath = request.getResource().getPath();
+    }
+
+
+    public AbstractCacheKey(String uri, HttpCacheConfig cacheConfig) {
+        this.authenticationRequirement = cacheConfig.getAuthenticationRequirement();
+        this.uri = uri;
+        this.resourcePath = new PathInfo(uri).getResourcePath();
+    }
 
     @Override
     public boolean equals(Object o) {
@@ -33,5 +54,13 @@ public abstract class AbstractCacheKey {
         }
 
         return true;
+    }
+
+    public String getAuthenticationRequirement() {
+        return authenticationRequirement;
+    }
+
+    public String getUri() {
+        return uri;
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/mem/impl/MemHttpCacheStoreImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/mem/impl/MemHttpCacheStoreImpl.java
@@ -113,12 +113,21 @@ public class MemHttpCacheStoreImpl extends AbstractGuavaCacheMBean<CacheKey, Mem
         }
         if (ttl != DEFAULT_TTL) {
             // If ttl is present, attach it to guava cache configuration.
-            cache = CacheBuilder.newBuilder().maximumWeight(maxSizeInMb * MEGABYTE).expireAfterWrite(ttl, TimeUnit
-                    .SECONDS).removalListener(new MemCacheEntryRemovalListener()).recordStats().build();
+            cache = CacheBuilder.newBuilder()
+                    .maximumWeight(maxSizeInMb * MEGABYTE)
+                    .weigher(new MemCacheEntryWeigher())
+                    .expireAfterWrite(ttl, TimeUnit.SECONDS)
+                    .removalListener(new MemCacheEntryRemovalListener())
+                    .recordStats()
+                    .build();
         } else {
             // If ttl is absent, go only with the maximum weight condition.
-            cache = CacheBuilder.newBuilder().maximumWeight(maxSizeInMb * MEGABYTE).weigher(new MemCacheEntryWeigher
-                    ()).removalListener(new MemCacheEntryRemovalListener()).recordStats().build();
+            cache = CacheBuilder.newBuilder()
+                    .maximumWeight(maxSizeInMb * MEGABYTE)
+                    .weigher(new MemCacheEntryWeigher())
+                    .removalListener(new MemCacheEntryRemovalListener())
+                    .recordStats()
+                    .build();
         }
 
         log.info("MemHttpCacheStoreImpl activated / modified.");


### PR DESCRIPTION
Augments HttpCache to support Include-based caching. Major changes

1) Added a OSGi Property to HttpCacheConfigImpl that selects the Filter Scope (REQUEST, INCLUDE), defaults to REQUEST as that it the current state.
2) Added a ResourceTypeHttpCacheConfigExtension that caches based on the resource path; currently does not support selector/extensions/suffixes.
* Restrictable by content path regex, example: /content/.*/jcr:content/footer/.* and by ResourceType (via resource.getResourceType())
3) Minors enhancements to the Mbeans to give more visibility.

REQUEST and INCLUDES can work together, and the INCLUDES work in a russian-doll stacking manner.

The Filters (Request, Include) are only enabled if at least 1 of CacheConfig exists for that scope.

/cc @Sivaramvt, @YegorKozlov, @steffenrosi 