### PR TITLE
Touch UI Content Fragment Issue

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-limit-parsys.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-limit-parsys.js
@@ -33,6 +33,10 @@
             designSrc = parsys.config.designDialogSrc,
             result = {}, param;
 
+        if (designSrc === undefined) {
+ +        return undefined;
+ +      }
+
         designSrc = designSrc.substring(designSrc.indexOf("?") + 1);
 
         designSrc.split(/&/).forEach( function(it) {


### PR DESCRIPTION
Fixes bug when you can't add component in a parsys between pars in a Content Fragment.