### PR TITLE
Fix for AEM 6.2 Touch UI JSON Store Multifield, not displaying graphic icon select

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/authoring/vendor/jquery.fonticonpicker/jquery.fonticonpicker.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/authoring/vendor/jquery.fonticonpicker/jquery.fonticonpicker.js
@@ -50,11 +50,11 @@
                                                  '</div>' +
                                                  '<div class="selector-popup" style="display: none;">' + ((this.settings.hasSearch) ?
                                                          '<div class="selector-search">' +
-                                                                 '<input type="text" name="" value="" placeholder="Search icon" class="icons-search-input"/>' +
+                                                                 '<input type="text" value="" placeholder="Search icon" class="icons-search-input"/>' +
                                                                  '<i class="fip-icon-search"></i>' +
                                                          '</div>' : '') +
                                                          '<div class="selector-category">' +
-                                                                 '<select name="" class="icon-category-select" style="display: none">' +
+                                                                 '<select class="icon-category-select" style="display: none">' +
                                                                  '</select>' +
                                                          '</div>' +
                                                          '<div class="fip-icons-container"></div>' +

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/graphiciconselect/render.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/graphiciconselect/render.jsp
@@ -194,6 +194,7 @@ Select
 
     attrs.add("id", cfg.get("id", String.class));
     attrs.addClass(cfg.get("class", String.class));
+    attrs.addClass("coral-Select");
     attrs.addRel(cfg.get("rel", String.class));
     attrs.add("title", i18n.getVar(cfg.get("title", String.class)));
     attrs.addOther("collision", "none");
@@ -232,7 +233,11 @@ Select
         opAttrs.addClass(optionCfg.get("class", String.class));
         opAttrs.addRel(optionCfg.get("rel", String.class));
         opAttrs.add("title", i18n.getVar(optionCfg.get("title", String.class)));
-        opAttrs.add("value", value);
+        if(value.trim().startsWith("fa") || value.equalsIgnoreCase("")){
+          opAttrs.add("value", value);
+        }else{
+            opAttrs.add("value", "fa " +value);
+        }
         opAttrs.addDisabled(optionCfg.get("disabled", false));
         opAttrs.addOthers(optionCfg.getProperties(), "id", "class", "rel", "title", "value", "text", "disabled", "selected", "group");
 

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-widgets-init.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-widgets-init.js
@@ -48,8 +48,13 @@
 
         setSelectOne: function ($field, value) {
             var select = $field.closest(".coral-Select").data("select");
-
-            if (select) {
+            if(!select){
+                var dataInit = $field.closest('.coral-Select').data('init');
+                if(dataInit === 'graphiciconselect'){
+                    $field.val(value);
+                    $field.closest('.coral-Form-field').find('.selected-icon i').removeClass().addClass(value);
+                }
+            }else{
                 select.setValue(value);
             }
         },


### PR DESCRIPTION
added automatic addition of fa prefix if missing from generic list used, removed empty name attributes in jquery.iconpicker.js since it was causing error when multifield saves value to JSON_STORE, added check in touch ui widgets init to determine if graphiciconselect this will set the icon correctly in the mutlitifield on render
