### PR TITLE
replaced JS Object searching

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/classicui-configure-parsys-placeholder.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/classicui-configure-parsys-placeholder.js
@@ -57,7 +57,7 @@
 
     function getConfiguration(editComponent) {
         var pageInfo = CQ.utils.WCM.getPageInfo(editComponent.path),
-            designConfig = {}, cellSearchPath, parentPath, parName;
+            designConfig = {}, cellSearchPath, cellSearchPathInfo, parentPath, parNames;
 
         if (!pageInfo || !pageInfo.designObject) {
             return;
@@ -68,9 +68,15 @@
             parentPath = editComponent.getParent().path;
 
             cellSearchPath = cellSearchPath.substring(0, cellSearchPath.indexOf("|"));
-            parName = parentPath.substring(parentPath.lastIndexOf("/") + 1);
+            parNames = parentPath.split("jcr:content/");
+            parNames = parNames[1].split("/");
+            cellSearchPathInfo = pageInfo.designObject.content[cellSearchPath];
+            for(var i=0; i < parNames.length; i++){
+                var prop = parNames[i];
+                cellSearchPathInfo = cellSearchPathInfo[prop];
+            }
 
-            designConfig = pageInfo.designObject.content[cellSearchPath][parName];
+            designConfig = cellSearchPathInfo;
         } catch (err) {
             console.log("ACS AEM Commons - Error getting parsys configuration", err);
         }


### PR DESCRIPTION
Part of reported issue: https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/805

JS Object search for ACS property fails with "undefined" in browser. 
