### PR TITLE
Cache Control Header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .project
 .settings/
 target/
+.DS_Store
 
 #Intellij
 .idea/

--- a/bundle/src/main/java/com/adobe/acs/commons/http/headers/impl/DispatcherMaxAgeHeaderFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/http/headers/impl/DispatcherMaxAgeHeaderFilter.java
@@ -77,17 +77,6 @@ public class DispatcherMaxAgeHeaderFilter extends AbstractDispatcherCacheHeaderF
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    protected boolean accepts(HttpServletRequest request) {
-        
-        if (super.accepts(request)) {
-            Enumeration<String> cacheHeader = request.getHeaders(CACHE_CONTROL_NAME);
-            return cacheHeader == null || !cacheHeader.hasMoreElements();
-        }
-        return false;
-    }
-
-    @Override
     protected void doActivate(ComponentContext context) throws Exception {
         Dictionary<?, ?> properties = context.getProperties();
         maxage = PropertiesUtil.toLong(properties.get(PROP_MAX_AGE), -1);

--- a/bundle/src/test/java/com/adobe/acs/commons/http/headers/impl/DispatcherMaxAgeHeaderFilterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/http/headers/impl/DispatcherMaxAgeHeaderFilterTest.java
@@ -107,44 +107,6 @@ public class DispatcherMaxAgeHeaderFilterTest {
         assertEquals("max-age=" + maxage, filter.getHeaderValue());
     }
 
-    @Test
-    public void testAcceptsHasCacheControlHeader() throws Exception {
-
-        cachecontrol.add("Some Cache Control Header");
-
-        when(request.getHeaders(DispatcherMaxAgeHeaderFilter.CACHE_CONTROL_NAME))
-                .thenReturn(Collections.enumeration(cachecontrol));
-
-        boolean result = filter.accepts(request);
-        assertFalse(result);
-
-        verify(request).getHeaders(DispatcherMaxAgeHeaderFilter.CACHE_CONTROL_NAME);
-    }
-
-    @Test
-    public void testAcceptsNoCacheControlHeader() throws Exception {
-
-        when(request.getHeaders(DispatcherMaxAgeHeaderFilter.CACHE_CONTROL_NAME))
-                .thenReturn(Collections.enumeration(cachecontrol));
-
-        boolean result = filter.accepts(request);
-        assertTrue(result);
-
-        verify(request).getHeaders(DispatcherMaxAgeHeaderFilter.CACHE_CONTROL_NAME);
-    }
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void testAcceptsCalledParent() throws Exception {
-
-        params.put("key", "value");
-
-        boolean result = filter.accepts(request);
-        assertFalse(result);
-
-        verify(request, times(0)).getHeaders(DispatcherMaxAgeHeaderFilter.CACHE_CONTROL_NAME);
-    }
-
     @Test(expected = ConfigurationException.class)
     public void testActivateNoMaxAge() throws Exception {
         properties.remove(DispatcherMaxAgeHeaderFilter.PROP_MAX_AGE);


### PR DESCRIPTION
Don't check incoming headers when generating header response.

Fix for #798 