### PR TITLE
Fix for issue 814 (ACS Commons Multifield in Touch UI Page Properties)

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
@@ -333,6 +333,12 @@
             $document.on("click", "[form=cq-sites-properties-form]", function () {
                 compositeMultiField.collectDataFromFields();
             });
+        } else if(compositeMultiField.isSitesPropertiesPage($document)) {
+            compositeMultiField.addDataInFields();
+            var cmfFormId = $document.find(compositeMultiField.SELECTOR_FORM_SITES_PROPERTIES_PAGE).attr("id");
+            $document.on("click", ":submit[form=" + cmfFormId + "]", function () {
+                compositeMultiField.collectDataFromFields();
+            });
         } else if (compositeMultiField.isCreatePageWizard($document)) {
             $document.on("click", ".foundation-wizard-control[type='submit']", function () {
                 compositeMultiField.collectDataFromFields();

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-widgets-init.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-widgets-init.js
@@ -41,6 +41,7 @@
         SELECTOR_FORM_CQ_DIALOG: "form.cq-dialog",
         SELECTOR_FORM_SITES_PROPERTIES: "form#cq-sites-properties-form",
         SELECTOR_FORM_CREATE_PAGE: "form.cq-siteadmin-admin-createpage",
+        SELECTOR_FORM_SITES_PROPERTIES_PAGE: "form.cq-siteadmin-admin-properties",
 
         isSelectOne: function ($field) {
             return !_.isEmpty($field) && ($field.prop("type") === "select-one");
@@ -205,12 +206,16 @@
             return $document.find(this.SELECTOR_FORM_SITES_PROPERTIES).length === 1;
         },
 
+        isSitesPropertiesPage: function($document) {
+            return $document.find(this.SELECTOR_FORM_SITES_PROPERTIES_PAGE).length === 1;
+        },
+
         isCreatePageWizard: function($document) {
             return $document.find(this.SELECTOR_FORM_CREATE_PAGE).length == 1;
         },
 
         getPropertiesFormSelector: function() {
-            return this.SELECTOR_FORM_CQ_DIALOG + "," + this.SELECTOR_FORM_SITES_PROPERTIES + "," + this.SELECTOR_FORM_CREATE_PAGE;
+            return this.SELECTOR_FORM_CQ_DIALOG + "," + this.SELECTOR_FORM_SITES_PROPERTIES + "," + this.SELECTOR_FORM_CREATE_PAGE + "," + this.SELECTOR_FORM_SITES_PROPERTIES_PAGE;
         }
     });
 


### PR DESCRIPTION
#814 occured due to a wrong detection of the edit properties page in AEM (http://localhost:4502/libs/wcm/core/content/sites/properties.html).

Added a new check for this specific page (so we don't interfere with the checks in place).