### PR TITLE
814: Fault occured on more pages

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
@@ -333,10 +333,9 @@
             $document.on("click", "[form=cq-sites-properties-form]", function () {
                 compositeMultiField.collectDataFromFields();
             });
-        } else if(compositeMultiField.isSitesPropertiesPage($document)) {
+        } else if(compositeMultiField.isPropertiesFormPage($document)) {
             compositeMultiField.addDataInFields();
-            var cmfFormId = $document.find(compositeMultiField.SELECTOR_FORM_SITES_PROPERTIES_PAGE).attr("id");
-            $document.on("click", ":submit[form=" + cmfFormId + "]", function () {
+            $document.on("click", ":submit[form=propertiesform]", function () {
                 compositeMultiField.collectDataFromFields();
             });
         } else if (compositeMultiField.isCreatePageWizard($document)) {

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-widgets-init.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-widgets-init.js
@@ -41,7 +41,8 @@
         SELECTOR_FORM_CQ_DIALOG: "form.cq-dialog",
         SELECTOR_FORM_SITES_PROPERTIES: "form#cq-sites-properties-form",
         SELECTOR_FORM_CREATE_PAGE: "form.cq-siteadmin-admin-createpage",
-        SELECTOR_FORM_SITES_PROPERTIES_PAGE: "form.cq-siteadmin-admin-properties",
+        SELECTOR_FORM_PROPERTIES_PAGE: "form#propertiesform",
+
 
         isSelectOne: function ($field) {
             return !_.isEmpty($field) && ($field.prop("type") === "select-one");
@@ -206,8 +207,8 @@
             return $document.find(this.SELECTOR_FORM_SITES_PROPERTIES).length === 1;
         },
 
-        isSitesPropertiesPage: function($document) {
-            return $document.find(this.SELECTOR_FORM_SITES_PROPERTIES_PAGE).length === 1;
+        isPropertiesFormPage: function($document) {
+            return $document.find(this.SELECTOR_FORM_PROPERTIES_PAGE).length === 1;
         },
 
         isCreatePageWizard: function($document) {
@@ -215,8 +216,10 @@
         },
 
         getPropertiesFormSelector: function() {
-            return this.SELECTOR_FORM_CQ_DIALOG + "," + this.SELECTOR_FORM_SITES_PROPERTIES + "," + this.SELECTOR_FORM_CREATE_PAGE + "," + this.SELECTOR_FORM_SITES_PROPERTIES_PAGE;
-        }
+            return this.SELECTOR_FORM_CQ_DIALOG + "," + this.SELECTOR_FORM_SITES_PROPERTIES + "," +
+                this.SELECTOR_FORM_CREATE_PAGE + "," + this.SELECTOR_FORM_PROPERTIES_PAGE;
+        },
+
     });
 
     if (!ACS.TouchUI.extendedMultfield) {


### PR DESCRIPTION
#830 
I've made the check more generic, more pages were affected by this bug.
For example: http://localhost:4502/libs/wcm/core/content/sites/properties.html

Now the multifield dialog is also working on other propertiesform pages.