### PR TITLE
added missing locale parameter

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/genericlists/impl/GenericListImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/genericlists/impl/GenericListImpl.java
@@ -135,7 +135,7 @@ public final class GenericListImpl implements GenericList {
     public String lookupTitle(String value, Locale locale) {
         Item item = valueMapping.get(value);
         if (item != null) {
-            return item.getTitle();
+            return item.getTitle(locale);
         } else {
             return null;
         }


### PR DESCRIPTION
Fix for issue https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/804 - The method lookupTitle in GenericList does not correctly localize the title.