### PR TITLE
added stylesheet inliner for emails

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/StylesheetInlinerTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/StylesheetInlinerTransformerFactory.java
@@ -1,0 +1,200 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.rewriter.impl;
+
+import java.io.CharArrayWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.felix.scr.annotations.Activate;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Deactivate;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.rewriter.ProcessingComponentConfiguration;
+import org.apache.sling.rewriter.ProcessingContext;
+import org.apache.sling.rewriter.Transformer;
+import org.apache.sling.rewriter.TransformerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+
+import com.adobe.acs.commons.rewriter.AbstractTransformer;
+import com.adobe.granite.ui.clientlibs.HtmlLibrary;
+import com.adobe.granite.ui.clientlibs.HtmlLibraryManager;
+import com.adobe.granite.ui.clientlibs.LibraryType;
+
+/**
+ * ACS AEM Commons - Stylesheet inliner removes stylesheet links the output adds
+ * them as <style> elements. Links found in <head> are added to the beginning of
+ * <body>, whereas those in <body> are included where they're found.
+ */
+@Component(
+        metatype = true, 
+        label = "Stylesheet Inliner Transformer Factory", 
+        description = "Sling Rewriter Transformer Factory which inlines CSS references")
+@Properties({ 
+    @Property( name = "pipeline.type", value = StylesheetInlinerTransformerFactory.SELECTOR, propertyPrivate = true) } )
+@Service(value = { TransformerFactory.class })
+public final class StylesheetInlinerTransformerFactory implements TransformerFactory {
+
+    public static final String SELECTOR = "inline-css";
+    
+    private static final String NEWLINE = "\n";
+    private static final String STYLE = "style";
+    private static final String BODY = "body";
+    private static final String HEAD = "head";
+
+    private static final Logger log = LoggerFactory.getLogger(StylesheetInlinerTransformerFactory.class);
+
+    @Reference
+    private HtmlLibraryManager htmlLibraryManager;
+
+
+    public Transformer createTransformer() {
+        return new CSSInlinerTransformer();
+    }
+
+    private class CSSInlinerTransformer extends AbstractTransformer {
+
+        protected boolean enabled = false;
+        protected boolean inHead = false;
+        protected List<String> stylesheetsInHead = new ArrayList<String>();
+        private SlingHttpServletRequest slingRequest;
+
+        @Override
+        public void init(ProcessingContext context, ProcessingComponentConfiguration config) throws IOException {
+            super.init(context, config);
+            slingRequest = context.getRequest();
+
+            String[] selectors = slingRequest.getRequestPathInfo().getSelectors();
+
+            if (selectors.length > 0) {
+                enabled = Arrays.asList(selectors).contains(SELECTOR);
+                if (enabled) {
+                    log.info("Inlining Stylesheet references for {}", slingRequest.getRequestURL().toString());
+                }
+            }
+        }
+
+        public void startElement(final String namespaceURI, final String localName, final String qName,
+                final Attributes attrs) throws SAXException {
+            if (enabled) {
+                try {
+                    if (isCSS(localName, attrs)) {
+                        String sheet = attrs.getValue("", "href");
+                        if (inHead) {
+                            stylesheetsInHead.add(sheet);
+                        } else {
+                            log.debug("Inlining stylesheet link found in BODY: '{}'", sheet);
+                            inlineSheet(namespaceURI, sheet);
+                        }
+                    } else {
+                        getContentHandler().startElement(namespaceURI, localName, qName, attrs);
+
+                        if (localName.equalsIgnoreCase(HEAD)) {
+                            inHead = true;
+                        } else if (localName.equalsIgnoreCase(BODY)) {
+
+                            // add each of the accumulated stylesheet references
+                            for (String sheet : stylesheetsInHead) {
+                                log.debug("Inlining sheet found in HEAD: '{}'", sheet);
+                                inlineSheet(namespaceURI, sheet);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    log.error("Exception in stylesheet inliner", e);
+                    throw new SAXException(e);
+                }
+            } else {
+                getContentHandler().startElement(namespaceURI, localName, qName, attrs);
+            }
+        }
+
+        private void inlineSheet(final String namespaceURI, String s) throws Exception {
+            InputStream inputStream = null;
+
+            String withoutExtension = s.substring(0, s.indexOf(LibraryType.CSS.extension));
+            HtmlLibrary library = htmlLibraryManager.getLibrary(LibraryType.CSS, withoutExtension);
+            if (library != null) {
+                inputStream = library.getInputStream();
+            } else {
+                Resource resource = slingRequest.getResourceResolver().getResource(s);
+
+                if (resource != null) {
+                    inputStream = resource.adaptTo(InputStream.class);
+                }
+            }
+
+            if (inputStream != null) {
+                InputStreamReader isr = new InputStreamReader(inputStream);
+
+                CharArrayWriter caw = new CharArrayWriter(inputStream.available());
+                caw.write(NEWLINE);
+                int read = -1;
+                while ((read = isr.read()) > -1) {
+                    caw.write(read);
+                }
+                getContentHandler().startElement(namespaceURI, STYLE, null, new AttributesImpl());
+                getContentHandler().characters(caw.toCharArray(), 0, caw.size());
+                super.endElement(namespaceURI, STYLE, null);
+            }
+        }
+
+        @Override
+        public void endElement(String uri, String localName, String qName) throws SAXException {
+            if (inHead && localName.equalsIgnoreCase(HEAD)) {
+                inHead = false;
+            }
+            super.endElement(uri, localName, qName);
+        }
+    }
+
+    private static boolean isCSS(final String elementName, final Attributes attrs) {
+        final String rel = attrs.getValue("", "rel");
+        final String type = attrs.getValue("", "type");
+        final String href = attrs.getValue("", "href");
+
+        return StringUtils.equals("link", elementName) && StringUtils.equals(rel, "stylesheet")
+                && StringUtils.equals(type, LibraryType.CSS.contentType) && StringUtils.startsWith(href, "/")
+                && !StringUtils.startsWith(href, "//") && StringUtils.endsWith(href, LibraryType.CSS.extension);
+    }
+
+    @Activate
+    protected void activate(Map<String, Object> props) {
+    }
+
+    @Deactivate
+    protected void deactivate() {
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/StylesheetInlinerTransformerFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/StylesheetInlinerTransformerFactoryTest.java
@@ -1,0 +1,286 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.rewriter.impl;
+
+import static org.mockito.AdditionalMatchers.not;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+import java.util.Collections;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.request.RequestPathInfo;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.rewriter.ProcessingComponentConfiguration;
+import org.apache.sling.rewriter.ProcessingContext;
+import org.apache.sling.rewriter.Transformer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+
+import com.adobe.granite.ui.clientlibs.HtmlLibrary;
+import com.adobe.granite.ui.clientlibs.HtmlLibraryManager;
+import com.adobe.granite.ui.clientlibs.LibraryType;
+
+import junitx.util.PrivateAccessor;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StylesheetInlinerTransformerFactoryTest {
+    
+
+    @Mock
+    private HtmlLibraryManager htmlLibraryManager;
+
+    @Mock
+    private HtmlLibrary htmlLibrary;
+
+    @Mock
+    private ContentHandler handler;
+    
+    @Mock
+    private ProcessingContext processingContext;
+    
+    @Mock
+    private SlingHttpServletRequest slingRequest;
+    
+    @Mock
+    private ResourceResolver resourceResolver;
+    
+    @Mock 
+    private Resource resource;
+    
+    @Mock
+    private RequestPathInfo requestPathInfo;
+
+    
+    private StylesheetInlinerTransformerFactory factory;
+    
+    private Transformer transformer;
+
+    private Attributes empty = new AttributesImpl();
+    
+    private final String CLIENTLIB_PATH = "/etc/clientlibs/test";
+    private final String CSS_RESOURCE_PATH = "/etc/assets/somecss";
+    private final String NON_EXISTING_PATH = "/etc/assets/doesntexist";
+    
+    private static final String CSS_CONTENTS = "div {display:block;}";
+    
+    private static final String TEST_DATA = "some test data";
+    
+    private static final String CSS_CONTENTS_WITH_LINEFEED = "\n" + CSS_CONTENTS;
+
+    @Before
+    public void setUp() throws Throwable {
+        factory = new StylesheetInlinerTransformerFactory();
+        PrivateAccessor.setField(factory, "htmlLibraryManager", htmlLibraryManager);
+        factory.activate(Collections.<String, Object>emptyMap());
+
+        when(htmlLibrary.getInputStream()).thenReturn(new java.io.ByteArrayInputStream(CSS_CONTENTS.getBytes()));
+        when(htmlLibraryManager.getLibrary(eq(LibraryType.CSS), eq(CLIENTLIB_PATH))).thenReturn(htmlLibrary);
+        when(htmlLibraryManager.getLibrary(eq(LibraryType.CSS), not(eq(CLIENTLIB_PATH)))).thenReturn(null);
+        when( requestPathInfo.getSelectors()).thenReturn(new String[] {StylesheetInlinerTransformerFactory.SELECTOR} );
+        when( slingRequest.getRequestPathInfo()).thenReturn(requestPathInfo);
+        when( slingRequest.getRequestURL()).thenReturn(new StringBuffer("testing"));
+        when(resource.adaptTo(eq(InputStream.class))).thenReturn(new java.io.ByteArrayInputStream(CSS_CONTENTS.getBytes()));
+        when(resourceResolver.getResource(eq(CSS_RESOURCE_PATH + ".css" ))).thenReturn(resource);
+        when(resourceResolver.getResource(eq(NON_EXISTING_PATH))).thenReturn(null);
+        when(slingRequest.getResourceResolver()).thenReturn(resourceResolver);
+        when(processingContext.getRequest()).thenReturn(slingRequest);
+        
+        transformer = factory.createTransformer();
+        PrivateAccessor.invoke(transformer, "init", 
+                new Class[] {ProcessingContext.class, ProcessingComponentConfiguration.class}, 
+                new Object[] {processingContext, null} );
+        transformer.setContentHandler(handler);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        reset(htmlLibraryManager, htmlLibrary, handler);
+        transformer = null;
+    }
+
+    @Test
+    public void testNoop() throws Exception {
+
+        startHeadSection(empty);
+        startBodySection(empty);
+        endBodySection();
+
+        verify(handler).startElement(isNull(String.class), eq("html"), isNull(String.class), eq(empty));
+        verify(handler).startElement(isNull(String.class), eq("head"), isNull(String.class), eq(empty));
+        verify(handler).endElement(isNull(String.class), eq("head"), isNull(String.class));
+        verify(handler).startElement(isNull(String.class), eq("body"), isNull(String.class), eq(empty));
+        verify(handler).endElement(isNull(String.class), eq("body"), isNull(String.class));
+        verify(handler).endElement(isNull(String.class), eq("html"), isNull(String.class));
+    }
+
+    
+    @Test
+    public void testClientLibReferenceInHead() throws Exception {
+
+        startHeadSection(empty);
+        addStylesheetLink(CLIENTLIB_PATH);
+        startBodySection(empty);
+        endBodySection();
+
+        verify(handler).startElement(isNull(String.class), eq("html"), isNull(String.class), eq(empty));
+        verify(handler).startElement(isNull(String.class), eq("head"), isNull(String.class), eq(empty));
+        verify(handler).endElement(isNull(String.class), eq("head"), isNull(String.class));
+        verify(handler).startElement(isNull(String.class), eq("body"), isNull(String.class), eq(empty));
+        verify(handler).startElement(isNull(String.class), eq("style"), isNull(String.class), any(org.xml.sax.Attributes.class));
+        verify(handler).characters(CSS_CONTENTS_WITH_LINEFEED.toCharArray(), 0, CSS_CONTENTS_WITH_LINEFEED.length());
+        verify(handler).endElement(isNull(String.class), eq("style"), isNull(String.class));
+        verify(handler).endElement(isNull(String.class), eq("body"), isNull(String.class));
+        verify(handler).endElement(isNull(String.class), eq("html"), isNull(String.class));
+    }
+
+    
+    @Test
+    public void testClientLibReferenceInBody() throws Exception {
+
+        startHeadSection(empty);
+        startBodySection(empty);
+        addDiv(empty);
+        addStylesheetLink(CLIENTLIB_PATH);
+        endBodySection();
+
+        verify(handler).startElement(isNull(String.class), eq("html"), isNull(String.class), eq(empty));
+        verify(handler).startElement(isNull(String.class), eq("head"), isNull(String.class), eq(empty));
+        verify(handler).endElement(isNull(String.class), eq("head"), isNull(String.class));
+        verify(handler).startElement(isNull(String.class), eq("body"), isNull(String.class), eq(empty));
+        verifyDiv();
+        verify(handler).startElement(isNull(String.class), eq("style"), isNull(String.class), any(org.xml.sax.Attributes.class));
+        verify(handler).characters(CSS_CONTENTS_WITH_LINEFEED.toCharArray(), 0, CSS_CONTENTS_WITH_LINEFEED.length());
+        verify(handler).endElement(isNull(String.class), eq("style"), isNull(String.class));
+        verify(handler).endElement(isNull(String.class), eq("body"), isNull(String.class));
+        verify(handler).endElement(isNull(String.class), eq("html"), isNull(String.class));
+    }
+
+
+    @Test
+    public void testResourceReferenceInHead() throws Exception {
+
+        startHeadSection(empty);
+        addStylesheetLink(CSS_RESOURCE_PATH);
+        startBodySection(empty);
+        endBodySection();
+
+        verify(handler).startElement(isNull(String.class), eq("html"), isNull(String.class), eq(empty));
+        verify(handler).startElement(isNull(String.class), eq("head"), isNull(String.class), eq(empty));
+        verify(handler).endElement(isNull(String.class), eq("head"), isNull(String.class));
+        verify(handler).startElement(isNull(String.class), eq("body"), isNull(String.class), eq(empty));
+        verify(handler).startElement(isNull(String.class), eq("style"), isNull(String.class), any(org.xml.sax.Attributes.class));
+        verify(handler).characters(CSS_CONTENTS_WITH_LINEFEED.toCharArray(), 0, CSS_CONTENTS_WITH_LINEFEED.length());
+        verify(handler).endElement(isNull(String.class), eq("style"), isNull(String.class));
+        verify(handler).endElement(isNull(String.class), eq("body"), isNull(String.class));
+        verify(handler).endElement(isNull(String.class), eq("html"), isNull(String.class));
+    }
+
+    @Test
+    public void testResourceReferenceInBody() throws Exception {
+
+        startHeadSection(empty);
+        startBodySection(empty);
+        addDiv(empty);
+        addStylesheetLink(CSS_RESOURCE_PATH);
+        endBodySection();
+
+        verify(handler).startElement(isNull(String.class), eq("html"), isNull(String.class), eq(empty));
+        verify(handler).startElement(isNull(String.class), eq("head"), isNull(String.class), eq(empty));
+        verify(handler).endElement(isNull(String.class), eq("head"), isNull(String.class));
+        verify(handler).startElement(isNull(String.class), eq("body"), isNull(String.class), eq(empty));
+        verifyDiv();
+        verify(handler).startElement(isNull(String.class), eq("style"), isNull(String.class), any(org.xml.sax.Attributes.class));
+        verify(handler).characters(CSS_CONTENTS_WITH_LINEFEED.toCharArray(), 0, CSS_CONTENTS_WITH_LINEFEED.length());
+        verify(handler).endElement(isNull(String.class), eq("style"), isNull(String.class));
+        verify(handler).endElement(isNull(String.class), eq("body"), isNull(String.class));
+        verify(handler).endElement(isNull(String.class), eq("html"), isNull(String.class));
+    }
+
+
+    @Test
+    public void testNonExistingResource() throws Exception {
+
+        startHeadSection(empty);
+        addStylesheetLink(NON_EXISTING_PATH);
+        startBodySection(empty);
+        endBodySection();
+
+        verify(handler).startElement(isNull(String.class), eq("html"), isNull(String.class), eq(empty));
+        verify(handler).startElement(isNull(String.class), eq("head"), isNull(String.class), eq(empty));
+        verify(handler).endElement(isNull(String.class), eq("head"), isNull(String.class));
+        verify(handler).startElement(isNull(String.class), eq("body"), isNull(String.class), eq(empty));
+        verify(handler).endElement(isNull(String.class), eq("body"), isNull(String.class));
+        verify(handler).endElement(isNull(String.class), eq("html"), isNull(String.class));
+    }
+
+
+    private void endBodySection() throws SAXException {
+        transformer.endElement(null, "body", null);
+        transformer.endElement(null, "html", null);
+    }
+
+    private void startBodySection(Attributes atts) throws SAXException {
+        transformer.endElement(null, "head", null);
+        transformer.startElement(null, "body", null, atts);
+    }
+
+    private void addDiv(Attributes atts) throws SAXException {
+        transformer.startElement(null, "div", null, atts);
+        transformer.characters( TEST_DATA.toCharArray(), 0, TEST_DATA.length());
+        transformer.endElement(null, "div", null);
+    }
+    private void verifyDiv() throws SAXException {
+        verify(handler).startElement(isNull(String.class), eq("div"), isNull(String.class), eq(empty));
+        verify(handler).characters(TEST_DATA.toCharArray(), 0, TEST_DATA.length());
+        verify(handler).endElement(isNull(String.class), eq("div"), isNull(String.class));
+    }
+
+    private void startHeadSection(Attributes atts) throws SAXException {
+        transformer.startElement(null, "html", null, atts);
+        transformer.startElement(null, "head", null, atts);
+    }
+
+    private void addStylesheetLink(String path) throws SAXException {
+        final AttributesImpl in = new AttributesImpl();
+        in.addAttribute("", "href", "", "CDATA", path + ".css");
+        in.addAttribute("", "type", "", "CDATA", "text/css");
+        in.addAttribute("", "rel", "", "CDATA", "stylesheet");
+
+        transformer.startElement(null, "link", null, in);
+        transformer.endElement(null, "link", null);
+    }
+}
+


### PR DESCRIPTION
When using AEM's output for html emails, inlining styles in <style> elements (instead) adds support for additional email clients. See https://www.campaignmonitor.com/css/.

Aside from adding the rewriter to the rewriter pipeline, an "inline-css" selector must be present to cause the transformation.