### PR TITLE
Contextual pathbrowser field

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/PageRootProvider.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/PageRootProvider.java
@@ -10,9 +10,18 @@ import org.apache.sling.api.resource.Resource;
 @ConsumerType
 public interface PageRootProvider {
     /**
-     * Returns the root page for the provided resource. The root page is selected via the regex provided in the PageRootProviderImpl's OSGi configuration.
-     * @param resource
-     * @return
+     * Returns the root page for the provided resource. The root page is selected
+     * via the regex(es) provided in the PageRootProviderImpl's OSGi configuration.
+     * @param resource The Resource for which to return the root page
+     * @return Root page
      */
     Page getRootPage(Resource resource);
+
+    /**
+     * Returns the root path for the provided resource path. The root path is selected
+     * via the regex(es) provided in the PageRootProviderImpl's OSGi configuration.
+     * @param resourcePath The path for which to return the root path
+     * @return Root path
+     */
+    String getRootPagePath(String resourcePath);
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderImpl.java
@@ -71,24 +71,26 @@ public class PageRootProviderImpl implements PageRootProvider {
             } else if (!rootPage.isValid()) {
                 log.debug("Page Root invalid at [ {} ]", pagePath);
             } else {
-                log.debug("Page Root found at [ {} ]", pagePath);
                 return rootPage;
             }
         }
 
-        log.debug("Resource path does not include the configured page root path.");
         return null;
     }
 
-    protected String getRootPagePath(String resourcePath) {
+    @Override
+    public String getRootPagePath(String resourcePath) {
         for (Pattern pattern : pageRootPatterns) {
             final Matcher matcher = pattern.matcher(resourcePath);
 
             if (matcher.find()) {
-                return matcher.group(1);
+                String rootPath = matcher.group(1);
+                log.debug("Page Root found at [ {} ]", rootPath);
+                return rootPath;
             }
         }
 
+        log.debug("Resource path does not include the configured page root path.");
         return null;
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Miscellaneous WCM Utilities.
  */
-@aQute.bnd.annotation.Version("1.3.0")
+@aQute.bnd.annotation.Version("2.0.0")
 package com.adobe.acs.commons.wcm;

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/contextualpathbrowser/.context.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/contextualpathbrowser/.context.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"
+    sling:resourceSuperType="granite/ui/components/foundation/form/pathbrowser"/>

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/contextualpathbrowser/contextualpathbrowser.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/contextualpathbrowser/contextualpathbrowser.jsp
@@ -1,0 +1,55 @@
+<%--
+  #%L
+  ACS AEM Commons Package
+  %%
+  Copyright (C) 2016 Adobe
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+--%><%
+%><%@include file="/libs/granite/ui/global.jsp" %><%
+%><%@page session="false" %><%
+%><%@ page import="com.adobe.acs.commons.wcm.PageRootProvider" %><%
+%><%@ page import="java.util.Map" %><%
+%><%@ page import="java.util.HashMap" %><%
+%><%@ page import="org.apache.sling.api.request.RequestDispatcherOptions" %><%
+%><%@ page import="org.apache.sling.api.resource.Resource"%><%
+%><%@ page import="org.apache.sling.api.resource.ResourceWrapper" %><%
+%><%@ page import="org.apache.sling.api.resource.ValueMap" %><%
+%><%@ page import="org.apache.sling.api.wrappers.ValueMapDecorator" %><%
+%><%
+    String contentPath = slingRequest.getRequestPathInfo().getSuffix();
+
+    String rootPath = null;
+    PageRootProvider pageRootProvider = sling.getService(PageRootProvider.class);
+    if (pageRootProvider != null) {
+        rootPath = pageRootProvider.getRootPagePath(contentPath);
+    }
+
+    Map<String, Object> mergedProperties = new HashMap<String, Object>();
+    mergedProperties.putAll(resource.getValueMap());
+    mergedProperties.put("rootPath", rootPath != null ? rootPath : "/");
+    final ValueMap newValueMap = new ValueMapDecorator(mergedProperties);
+
+    Resource resourceWrapper = new ResourceWrapper(resource) {
+        @Override
+        public ValueMap getValueMap() {
+            return newValueMap;
+        }
+    };
+
+    RequestDispatcherOptions options = new RequestDispatcherOptions();
+    options.setForceResourceType("/libs/granite/ui/components/foundation/form/pathbrowser");
+    RequestDispatcher dispatcher = slingRequest.getRequestDispatcher(resourceWrapper, options);
+    dispatcher.include(slingRequest, slingResponse);
+%>


### PR DESCRIPTION
Add a contextual pathbrowser field for working on multi-site platforms, so that authors can be limited to selecting paths within the current site.

Currently supports TouchUI only.