### PR TITLE
884 - Configure Parsys Placeholder error message fix

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/classicui-configure-parsys-placeholder.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/classicui-configure-parsys-placeholder.js
@@ -31,6 +31,7 @@
         ACS_PARSYS_BG_COLOR = "acsParsysBackgroundColor",
         ACS_PARSYS_BORDER_COLOR = "acsParsysBorderColor";
 
+
     if( ( pathName !== "/cf" ) && ( pathName.indexOf("/content") !== 0)){
         return;
     }
@@ -70,12 +71,18 @@
             cellSearchPath = cellSearchPath.substring(0, cellSearchPath.indexOf("|"));
             parNames = parentPath.split("jcr:content/");
             parNames = parNames[1].split("/");
-            cellSearchPathInfo = pageInfo.designObject.content[cellSearchPath];
-            for(var i=0; i < parNames.length; i++){
-                var prop = parNames[i];
-                cellSearchPathInfo = cellSearchPathInfo[prop];
-            }
 
+            cellSearchPathInfo = pageInfo.designObject.content[cellSearchPath];
+
+            if (cellSearchPathInfo) {
+                for(var i=0; i < parNames.length; i++){
+                    var prop = parNames[i];
+                    cellSearchPathInfo = cellSearchPathInfo[prop];
+                }
+            } else {
+                // This is not an unusual condition and as this is feature is "on by default" we should not clutter the Console w/ messages.
+                // console.log('No cellSearchPath of [ ' + cellSearchPath + ' ] could be found for this Path's design');
+            }
             designConfig = cellSearchPathInfo;
         } catch (err) {
             console.log("ACS AEM Commons - Error getting parsys configuration", err);
@@ -88,28 +95,30 @@
         var parsyses = {};
 
         _.each(CQ.WCM.getEditables(), function(e){
-            if(!isParsysNew(e)){
-                return;
+            if (isParsysNew(e)) {
+                this[e.path] = e;
             }
-
-            parsyses[e.path] = e;
-        });
+        }, parsyses);
 
         return parsyses;
     }
 
     function configureParsys(){
-        var parsyses = getParsyses(), placeholder,
-            $placeholder, $pContainer, designConfig;
+        var placeholder,
+            $placeholder,
+            $pContainer,
+            designConfig,
+            parsyses = getParsyses();
 
-        _.each(parsyses, function(parsys){
+        _.each(parsyses, function(parsys) {
             if(!parsys.emptyComponent) {
                 return;
             }
 
             designConfig = getConfiguration(parsys);
+
             if (!designConfig) {
-              return;
+                return;
             }
 
             placeholder = parsys.emptyComponent.findByType("static")[0];
@@ -150,3 +159,6 @@
         }
     });
 }());
+
+
+


### PR DESCRIPTION
Fixes #844 

Adds a check to see if the cellSearchPath is exists before attempting to see if it contains a parsys config. Its not unusual that all cellSearchPaths will not exist, and since this feature is "on by default" we should not worry people with console.log errors.

Ideally this feature is off by default, but I expect that ship has sailed until the next major release.
