### PR TITLE
Fixed showhide for checkbox/select in multifield. Fixes #889

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
@@ -391,7 +391,7 @@
             function showTarget(parentMultifieldInput, target, value){
                 parentMultifieldInput.find(target).filter("[data-showhidetargetvalue='" + value + "']").each(function() {
                     $(this).removeClass('hide'); //If target is a container, it unhides the container
-                    $(this).closest('.coral-Form-fieldwrapper').removeClass('hide'); // Unhides the target field wrapper. Thus, hiding label, quicktip etc.
+                    $(this).closest('.coral-Form-fieldwrapper').removeClass('hide'); // Unhides the target field wrapper. Thus, displaying label, quicktip etc.
                 });
             }
         } 

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
@@ -328,7 +328,7 @@
         showHideFields: function () {
             var cmf = this, $fieldSets = $("[" + cmf.DATA_ACS_COMMONS_NESTED + "][class='coral-Form-fieldset']");
 
-            $fieldSets.find(".cq-dialog-multifield-dropdown-showhide, .cq-dialog-multifield-checkbox-showhide").each(function(i, element) {
+            $fieldSets.find("[data-cq-dialog-multifield-dropdown-showhide], [data-cq-dialog-multifield-checkbox-showhide]").each(function(i, element) {
                 // if there is already an inital value make sure the according target element becomes visible
                 cmf.showHide(element);
             });
@@ -345,20 +345,19 @@
                 case "select":
                     var widget = $(element).data("select");
                     if (widget) {
-                        // get the selector to find the target elements. its stored as data-.. attribute
-                        target = $(element).data("cqDialogMultifieldDropdownShowhideTarget");
                         // get the selected value
                         value =  widget.getValue();
                     }
                     break;
                 case "checkbox":
-                    // get the selector to find the target elements. its stored as data-.. attribute
-                    target = $(element).data("cqDialogMultifieldCheckboxShowhideTarget");
                     // get the selected value
                     value = $(element).prop('checked');
                     
             }
 
+            // get the selector to find the target elements. its stored as data-.. attribute
+        	target = $(element).data("cq-dialog-showhide-target");
+            
             if (target) {
                 var parentMultifieldInput= $(element).closest("li.coral-Multifield-input");
                 hideUnselectedElements(parentMultifieldInput, target);
@@ -426,12 +425,12 @@
         }
         
         //Dropdown selection changed. Show Hide target widgets 
-        $(document).on("selected", ".cq-dialog-multifield-dropdown-showhide", function(e) {
+        $(document).on("selected", "[data-cq-dialog-multifield-dropdown-showhide]", function(e) {
             compositeMultiField.showHide($(this));
         });
 
         //Checkbox state changed. Show Hide target widgets 
-        $(document).on("change", ".cq-dialog-multifield-checkbox-showhide", function(e) {
+        $(document).on("change", "[data-cq-dialog-multifield-checkbox-showhide]", function(e) {
             compositeMultiField.showHide($(this));
         });
     });

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
@@ -116,6 +116,7 @@
                 setTimeout(function(){
                     cmf.addCompositeMultifieldRemoveListener($multifield);
                     cmf.addCompositeMultifieldValidator();
+                    cmf.showHideNewRowFields($multifield);
                 }, 500);
             });
 
@@ -329,6 +330,15 @@
             var cmf = this, $fieldSets = $("[" + cmf.DATA_ACS_COMMONS_NESTED + "][class='coral-Form-fieldset']");
 
             $fieldSets.find("[data-cq-dialog-multifield-dropdown-showhide], [data-cq-dialog-multifield-checkbox-showhide]").each(function(i, element) {
+                // if there is already an inital value make sure the according target element becomes visible
+                cmf.showHide(element);
+            });
+        },
+        
+        //Show-Hide widgets when a new row is added to multifield
+        showHideNewRowFields: function ($multifield) {
+        	var cmf = this;
+            $multifield.find("[data-cq-dialog-multifield-dropdown-showhide], [data-cq-dialog-multifield-checkbox-showhide]").each(function(i, element) {
                 // if there is already an inital value make sure the according target element becomes visible
                 cmf.showHide(element);
             });

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
@@ -361,7 +361,7 @@
 
             if (target) {
                 var parentMultifieldInput= $(element).closest("li.coral-Multifield-input");
-                hideUnselectedElements(parentMultifieldInput, target, value);
+                hideUnselectedElements(parentMultifieldInput, target);
                 showTarget(parentMultifieldInput, target, value);
             }
             
@@ -380,7 +380,7 @@
             }
             
             // make sure all unselected target elements are hidden.
-            function hideUnselectedElements(parentMultifieldInput, target, value){
+            function hideUnselectedElements(parentMultifieldInput, target){
                 parentMultifieldInput.find(target).not(".hide").each(function() {
                     $(this).addClass('hide'); //If target is a container, it hides the container
                     $(this).closest('.coral-Form-fieldwrapper').addClass('hide'); // Hides the target field wrapper. Thus, hiding label, quicktip etc.

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
@@ -398,7 +398,7 @@
             
             // unhide the target element that contains the selected value as data-showhidetargetvalue attribute
             function showTarget(parentMultifieldInput, target, value){
-                parentMultifieldInput.find(target).filter("[data-showhidetargetvalue='" + value + "']").each(function() {
+                parentMultifieldInput.find(target).filter("[data-showhidetargetvalue*='" + value + "']").each(function() {
                     $(this).removeClass('hide'); //If target is a container, it unhides the container
                     $(this).closest('.coral-Form-fieldwrapper').removeClass('hide'); // Unhides the target field wrapper. Thus, displaying label, quicktip etc.
                 });


### PR DESCRIPTION
Enhancement to the acs-commons multifield component. It enables show/hide of multiple dialog fields based on the toggling of checkbox & select fields. The state of the checkbox/select would only effect the current row of multifield.

How to use:
1. Select Field
- add the empty property cq-dialog-multifield-dropdown-showhide to the dropdown/select element
- add the data attribute cq-dialog-showhide-target to the dropdown/select element, value should be the
  selector, usually a specific class name, to find all possible target elements that can be shown/hidden.
- add the target class to each target component that can be shown/hidden
- add the class hidden to each target component to make them initially hidden
- add the attribute showhidetargetvalue to each target component, the value should equal the value of the select
  option that will unhide this element.
  
2. Checkbox Field
- add the empty property cq-dialog-multifield-checkbox-showhide to the checkbox element
- add the data attribute cq-dialog-showhide-target to the checkbox element, value should be the
  selector, usually a specific class name, to find all possible target elements that can be shown/hidden.
- add the target class to each target component that can be shown/hidden
- add the class hidden to each target component to make them initially hidden
- add the attribute showhidetargetvalue to each target component, the value should equal to:
	'true', if the field is to be displayed when Checkbox is selected.
	'false', if the field is to be displayed when Checkbox is unselected.
