### PR TITLE
#894 - Correct determination of STALE WF status

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/removal/impl/WorkflowInstanceRemoverImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/removal/impl/WorkflowInstanceRemoverImpl.java
@@ -205,31 +205,6 @@ public final class WorkflowInstanceRemoverImpl implements WorkflowInstanceRemove
 
                         checkedCount++;
 
-                        /*
-                        Workflow workflow = null;
-                        try {
-                            workflow = workflowSession.getWorkflow(instance.getPath());
-                            if (workflow == null) {
-                                throw new WorkflowException(String.format("Workflow instance object is null for [ %s]", instance.getPath()));
-                            }
-                        } catch (WorkflowException e) {
-                            log.warn("Unable to locate Workflow Instance for [ {} ]. Skipping... ", instance.getPath(), e);
-                            continue;
-                        }
-
-                        final String status = getStatus(workflow, instance);
-                        final String model = workflow.getWorkflowModel().getId();
-
-                        final Calendar startTime = Calendar.getInstance();
-                        startTime.setTime(workflow.getTimeStarted());
-
-                        String payload = null;
-                        if ("JCR_PATH".equals(workflow.getWorkflowData().getPayloadType())) {
-                            payload = (String) workflow.getWorkflowData().getPayload();
-                            log.debug("Checking Workflow instance [ {} ] with payload [ {} ]", workflow.getId(), payload);
-                        }
-                        */
-
                         final String status = getStatus(instance);
                         final String model = properties.get(PN_MODEL_ID, String.class);
                         final Calendar startTime = properties.get(PN_STARTED_AT, Calendar.class);

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/removal/impl/WorkflowInstanceRemoverImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/removal/impl/WorkflowInstanceRemoverImpl.java
@@ -20,16 +20,7 @@
 
 package com.adobe.acs.commons.workflow.bulk.removal.impl;
 
-import com.adobe.acs.commons.workflow.bulk.removal.WorkflowInstanceRemover;
-import com.adobe.acs.commons.workflow.bulk.removal.WorkflowRemovalException;
-import com.adobe.acs.commons.workflow.bulk.removal.WorkflowRemovalForceQuitException;
-import com.adobe.acs.commons.workflow.bulk.removal.WorkflowRemovalMaxDurationExceededException;
-import com.adobe.acs.commons.workflow.bulk.removal.WorkflowRemovalStatus;
-
-import com.day.cq.workflow.WorkflowException;
-import com.day.cq.workflow.WorkflowService;
-import com.day.cq.workflow.WorkflowSession;
-import com.day.cq.workflow.exec.Workflow;
+import com.adobe.acs.commons.workflow.bulk.removal.*;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.felix.scr.annotations.*;
@@ -44,16 +35,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeSet;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;


### PR DESCRIPTION
Prior to this fix the code looked at JUST the Workflow instance's status property, which works for everything except RUNNING and STALE (STALE workflows are RUNNING workflows with job IDs but not matching jobs).

This fix correctly determines the STALE state.

Fixed #894 
