### PR TITLE
#904 - Node Exists query builder predicate

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/search/impl/NodeExistsPredicateEvaluator.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/search/impl/NodeExistsPredicateEvaluator.java
@@ -70,7 +70,12 @@ public class NodeExistsPredicateEvaluator extends AbstractPredicateEvaluator imp
 
     @Override
     public final boolean canFilter(final Predicate predicate, final EvaluationContext context) {
-        return !predicate.getParameters().isEmpty();
+        if (predicate.getParameters().isEmpty()
+                || (predicate.getParameters().size() == 1 && predicate.getParameters().get(OR) != null)) {
+            return false;
+        } else {
+            return true;
+        }
     }
 
     @Override

--- a/bundle/src/main/java/com/adobe/acs/commons/search/impl/NodeExistsPredicateEvaluator.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/search/impl/NodeExistsPredicateEvaluator.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.search.impl;
 
 import com.day.cq.search.Predicate;

--- a/bundle/src/main/java/com/adobe/acs/commons/search/impl/NodeExistsPredicateEvaluator.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/search/impl/NodeExistsPredicateEvaluator.java
@@ -1,0 +1,131 @@
+package com.adobe.acs.commons.search.impl;
+
+import com.day.cq.search.Predicate;
+import com.day.cq.search.eval.AbstractPredicateEvaluator;
+import com.day.cq.search.eval.EvaluationContext;
+import com.day.cq.search.eval.PredicateEvaluator;
+import org.apache.commons.lang.StringUtils;
+import org.apache.felix.scr.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.query.Row;
+import java.util.Map;
+
+/**
+ * This AEM QueryBuilder predicate checks if a JCR node exists, or doesn't exist, off the provided relative path.
+ *
+ * There are 3 configurations:
+ *
+ * nodeExists.or = true | false (defaults to false)
+ * -- When nodeExists.or = false (the default), all .exists and .notexists conditions for this predicate are AND'd together to determine if the result node is included.
+ *
+ * nodeExists.#_exists = relative path (relative from the result node) to another node. This relative path mush exist for this expression to return true
+ * -- Multiple exists conditions can be present and need to be prefixed via the usual `#_exists` syntax.
+ *
+ * nodeExists.#_notexists = relative path (relative from the result node) to another node. This relative path mush NOT exist for this expression to return true
+ * -- Multiple exists conditions can be present and need to be prefixed via the usual `#_notexists` syntax.
+ *
+ * nodeExists.or=true
+ * nodeExists.exists=jcr:content/renditions/original
+ * nodeExists.2_exists=jcr:content/renditions/cq5dam.thumbnail.48.48.png
+ * nodeExists.1_notexists=jcr:content/renditions/cq5dam.web.1280.1280.png
+ * nodeExists.2_notexists=jcr:content/renditions/cq5dam.web.600.400.png
+ */
+@Component(
+        factory="com.day.cq.search.eval.PredicateEvaluator/nodeExists"
+)
+public class NodeExistsPredicateEvaluator extends AbstractPredicateEvaluator implements PredicateEvaluator {
+    private static final Logger log = LoggerFactory.getLogger(NodeExistsPredicateEvaluator.class);
+
+    public static final String OR = "or";
+    public static final String EXISTS_REL_PATH = "exists";
+    public static final String NOT_EXISTS_REL_PATH = "notexists";
+
+    @Override
+    public boolean canXpath(Predicate predicate, EvaluationContext context) {
+        return false;
+    }
+
+    @Override
+    public boolean canFilter(Predicate predicate, EvaluationContext context) {
+        return !predicate.getParameters().isEmpty();
+    }
+
+    @Override
+    public boolean isFiltering(final Predicate predicate, final EvaluationContext context) {
+        // .canFilter(..) has replaced isFiltering(..)
+        return this.canFilter(predicate, context);
+    }
+
+    @Override
+    public final boolean includes(Predicate predicate, Row row, EvaluationContext context) {
+        boolean or = predicate.getBool(OR);
+
+        if (log.isDebugEnabled()) {
+            log.debug("NodeExistsPredicatorEvaluator evaluating as [ {} ]", or ? "OR" : "AND");
+        }
+
+        for (final Map.Entry<String, String> entry : predicate.getParameters().entrySet()) {
+            boolean ruleIncludes = false;
+
+            String operation = entry.getKey();
+            if (StringUtils.contains(operation, "_")) {
+                operation = StringUtils.substringAfterLast(entry.getKey(), "_");
+            }
+
+            try {
+                if (EXISTS_REL_PATH.equals(operation)) {
+                    ruleIncludes = row.getNode().hasNode(entry.getValue());
+                } else if (NOT_EXISTS_REL_PATH.equals(operation)){
+                    ruleIncludes = !row.getNode().hasNode(entry.getValue());
+                } else if (!OR.equals(operation)){
+                    log.debug("Invalid operation [ {} ]", operation);
+                }
+
+                // Return quickly from the evaluation loop
+                if (or && ruleIncludes) {
+                    // If OR condition; return true on the first condition match
+                    if (log.isDebugEnabled()) {
+                        log.debug("Including [ {} ] based on [ {}  -> {} ] as part of [ OR ]",
+                                new String[] { row.getPath(), operation, entry.getValue() });
+                    }
+                    return true;
+                } else if (!or && !ruleIncludes) {
+                    // If AND condition; return true on the first condition failure
+                    if (log.isDebugEnabled()) {
+                        log.debug("Excluding [ {} ] based on [ {}  -> {} ] as part of [ AND ]",
+                                new String[] { row.getPath(), operation, entry.getValue() });
+                    }
+
+                    return false;
+                }
+            } catch (RepositoryException e) {
+                log.error("Unable to check if Node [ {} : {} ] via the nodeExists QueryBuilder predicate", new String[]{ entry.getKey(), entry.getValue() }, e);
+            }
+        }
+
+        if (or) {
+            // For ORs, if a true condition was met in the loop, the method would have already returned true, so must be false.
+            if (log.isDebugEnabled()) {
+                try {
+                    log.debug("Excluding [ {} ] based on NOT matching conditions as part of [ OR ]", row.getPath());
+                } catch (RepositoryException e) {
+                    log.error("Could not obtain path from for Result row in predicate evaluator", e);
+                }
+            }
+            return false;
+        } else {
+            // If ANDs, if a false condition was met in the loop, the method would have already returned false, so must be true.
+            if (log.isDebugEnabled()) {
+                try {
+                    log.debug("Include [ {} ] based on ALL matching conditions as part of [ AND ]", row.getPath());
+                } catch (RepositoryException e) {
+                    log.error("Could not obtain path from for Result row in predicate evaluator", e);
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/search/impl/NodeExistsPredicateEvaluator.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/search/impl/NodeExistsPredicateEvaluator.java
@@ -54,7 +54,7 @@ import java.util.Map;
  * nodeExists.2_notexists=jcr:content/renditions/cq5dam.web.600.400.png
  */
 @Component(
-        factory="com.day.cq.search.eval.PredicateEvaluator/nodeExists"
+        factory = "com.day.cq.search.eval.PredicateEvaluator/nodeExists"
 )
 public class NodeExistsPredicateEvaluator extends AbstractPredicateEvaluator implements PredicateEvaluator {
     private static final Logger log = LoggerFactory.getLogger(NodeExistsPredicateEvaluator.class);
@@ -64,27 +64,31 @@ public class NodeExistsPredicateEvaluator extends AbstractPredicateEvaluator imp
     public static final String NOT_EXISTS_REL_PATH = "notexists";
 
     @Override
-    public boolean canXpath(Predicate predicate, EvaluationContext context) {
+    public final boolean canXpath(final Predicate predicate, final EvaluationContext context) {
         return false;
     }
 
     @Override
-    public boolean canFilter(Predicate predicate, EvaluationContext context) {
+    public final boolean canFilter(final Predicate predicate, final EvaluationContext context) {
         return !predicate.getParameters().isEmpty();
     }
 
     @Override
-    public boolean isFiltering(final Predicate predicate, final EvaluationContext context) {
+    public final boolean isFiltering(final Predicate predicate, final EvaluationContext context) {
         // .canFilter(..) has replaced isFiltering(..)
         return this.canFilter(predicate, context);
     }
 
     @Override
-    public final boolean includes(Predicate predicate, Row row, EvaluationContext context) {
+    public final boolean includes(final Predicate predicate, final Row row, final EvaluationContext context) {
         boolean or = predicate.getBool(OR);
 
         if (log.isDebugEnabled()) {
-            log.debug("NodeExistsPredicatorEvaluator evaluating as [ {} ]", or ? "OR" : "AND");
+            if (or) {
+                log.debug("NodeExistsPredicatorEvaluator evaluating as [ OR ]");
+            } else {
+                log.debug("NodeExistsPredicatorEvaluator evaluating as [ AND ]");
+            }
         }
 
         for (final Map.Entry<String, String> entry : predicate.getParameters().entrySet()) {
@@ -98,9 +102,9 @@ public class NodeExistsPredicateEvaluator extends AbstractPredicateEvaluator imp
             try {
                 if (EXISTS_REL_PATH.equals(operation)) {
                     ruleIncludes = row.getNode().hasNode(entry.getValue());
-                } else if (NOT_EXISTS_REL_PATH.equals(operation)){
+                } else if (NOT_EXISTS_REL_PATH.equals(operation)) {
                     ruleIncludes = !row.getNode().hasNode(entry.getValue());
-                } else if (!OR.equals(operation)){
+                } else if (!OR.equals(operation)) {
                     log.debug("Invalid operation [ {} ]", operation);
                 }
 
@@ -109,20 +113,20 @@ public class NodeExistsPredicateEvaluator extends AbstractPredicateEvaluator imp
                     // If OR condition; return true on the first condition match
                     if (log.isDebugEnabled()) {
                         log.debug("Including [ {} ] based on [ {}  -> {} ] as part of [ OR ]",
-                                new String[] { row.getPath(), operation, entry.getValue() });
+                                new String[] {row.getPath(), operation, entry.getValue()});
                     }
                     return true;
                 } else if (!or && !ruleIncludes) {
                     // If AND condition; return true on the first condition failure
                     if (log.isDebugEnabled()) {
                         log.debug("Excluding [ {} ] based on [ {}  -> {} ] as part of [ AND ]",
-                                new String[] { row.getPath(), operation, entry.getValue() });
+                                new String[] {row.getPath(), operation, entry.getValue()});
                     }
 
                     return false;
                 }
             } catch (RepositoryException e) {
-                log.error("Unable to check if Node [ {} : {} ] via the nodeExists QueryBuilder predicate", new String[]{ entry.getKey(), entry.getValue() }, e);
+                log.error("Unable to check if Node [ {} : {} ] via the nodeExists QueryBuilder predicate", new String[]{entry.getKey(), entry.getValue()}, e);
             }
         }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/search/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/search/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/**
+ * This package provides Search relation functionality
+ */
+@Version("1.0.0")
+package com.adobe.acs.commons.search;
+
+import aQute.bnd.annotation.Version;

--- a/bundle/src/test/java/com/adobe/acs/commons/search/impl/NodeExistsPredicateEvaluatorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/search/impl/NodeExistsPredicateEvaluatorTest.java
@@ -1,0 +1,129 @@
+package com.adobe.acs.commons.search.impl;
+
+import com.day.cq.search.Predicate;
+import com.day.cq.search.eval.EvaluationContext;
+import com.day.cq.search.eval.PredicateEvaluator;
+import org.apache.jackrabbit.JcrConstants;
+import org.apache.jackrabbit.commons.JcrUtils;
+import org.apache.sling.testing.mock.jcr.MockJcr;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.jcr.Node;
+import javax.jcr.Session;
+import javax.jcr.query.Row;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class NodeExistsPredicateEvaluatorTest {
+    PredicateEvaluator predicateEvaluator = new NodeExistsPredicateEvaluator();
+
+    Session session;
+
+    Node node;
+
+    Map<String, String> predicateParams;
+
+    @Mock
+    Predicate predicate;
+
+    @Mock
+    Row row;
+
+    @Mock
+    EvaluationContext evaluationContext;
+
+    @Before
+    public void setUp() throws Exception {
+        predicateParams = new HashMap<String, String>();
+
+        session = MockJcr.newSession();
+
+        node = JcrUtils.getOrCreateByPath("/content/asset.pdf", JcrConstants.NT_UNSTRUCTURED, session);
+
+        JcrUtils.getOrCreateByPath("/content/asset.pdf/jcr:content/renditions/rendition-1", JcrConstants.NT_UNSTRUCTURED, session);
+        JcrUtils.getOrCreateByPath("/content/asset.pdf/jcr:content/renditions/rendition-2", JcrConstants.NT_UNSTRUCTURED, session);
+        JcrUtils.getOrCreateByPath("/content/asset.pdf/jcr:content/renditions/rendition-3", JcrConstants.NT_UNSTRUCTURED, session);
+        JcrUtils.getOrCreateByPath("/content/asset.pdf/jcr:content/renditions/rendition-4", JcrConstants.NT_UNSTRUCTURED, session);
+        JcrUtils.getOrCreateByPath("/content/asset.pdf/jcr:content/renditions/rendition-5", JcrConstants.NT_UNSTRUCTURED, session);
+
+        when(row.getNode()).thenReturn(node);
+        when(predicate.getParameters()).thenReturn(predicateParams);
+    }
+
+
+    @Test
+    public void includes_AndIncludes() throws Exception {
+        when(predicate.getBool(NodeExistsPredicateEvaluator.OR)).thenReturn(false);
+
+        predicateParams.put("exists", "./jcr:content/renditions/rendition-1");
+        predicateParams.put("2_exists", "jcr:content/renditions/rendition-2");
+        predicateParams.put("3_exists", "jcr:content/renditions/rendition-3");
+        predicateParams.put("notexists", "jcr:content/renditions/rendition-99");
+        predicateParams.put("1_notexists", "null");
+
+        assertTrue(predicateEvaluator.includes(predicate, row, evaluationContext));
+    }
+
+    @Test
+    public void includes_AndExcludes() throws Exception {
+        when(predicate.getBool(NodeExistsPredicateEvaluator.OR)).thenReturn(false);
+
+        predicateParams.put("exists", "jcr:content/renditions/rendition-1");
+        predicateParams.put("two_exists", "./jcr:content/renditions/rendition-2");
+        predicateParams.put("3_exists", "jcr:content/renditions/rendition-3");
+        predicateParams.put("notexists", "jcr:content/renditions/rendition-99");
+        predicateParams.put("1_notexists", "null");
+        predicateParams.put("exists", "jcr:content/renditions/rendition-100");
+
+        assertFalse(predicateEvaluator.includes(predicate, row, evaluationContext));
+    }
+
+    @Test
+    public void includes_AndEmpty() throws Exception {
+        when(predicate.getBool(NodeExistsPredicateEvaluator.OR)).thenReturn(false);
+
+        assertTrue(predicateEvaluator.includes(predicate, row, evaluationContext));
+    }
+
+    @Test
+    public void includes_OrIncludes() throws Exception {
+        when(predicate.getBool(NodeExistsPredicateEvaluator.OR)).thenReturn(true);
+
+        predicateParams.put("exists", "./jcr:content/renditions/rendition-x");
+        predicateParams.put("2_exists", "jcr:content/renditions/rendition-y");
+        predicateParams.put("3_exists", "jcr:content/renditions/rendition-z");
+        predicateParams.put("notexists", "null");
+
+        assertTrue(predicateEvaluator.includes(predicate, row, evaluationContext));
+    }
+
+    @Test
+    public void includes_OrExcludes() throws Exception {
+        when(predicate.getBool(NodeExistsPredicateEvaluator.OR)).thenReturn(true);
+
+        predicateParams.put("exists", "./jcr:content/renditions/rendition-w");
+        predicateParams.put("2_exists", "jcr:content/renditions/rendition-x");
+        predicateParams.put("3_exists", "jcr:content/renditions/rendition-y");
+        predicateParams.put("notexists", "jcr:content/renditions/rendition-1");
+        predicateParams.put("1_notexists", "jcr:content/renditions/rendition-2");
+
+        assertFalse(predicateEvaluator.includes(predicate, row, evaluationContext));
+    }
+
+    @Test
+    public void includes_OrEmpty() throws Exception {
+        when(predicate.getBool(NodeExistsPredicateEvaluator.OR)).thenReturn(true);
+
+        assertTrue(predicateEvaluator.includes(predicate, row, evaluationContext));
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/search/impl/NodeExistsPredicateEvaluatorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/search/impl/NodeExistsPredicateEvaluatorTest.java
@@ -112,7 +112,7 @@ public class NodeExistsPredicateEvaluatorTest {
     public void includes_AndEmpty() throws Exception {
         when(predicate.getBool(NodeExistsPredicateEvaluator.OR)).thenReturn(false);
 
-        assertTrue(predicateEvaluator.includes(predicate, row, evaluationContext));
+        assertFalse(predicateEvaluator.canFilter(predicate, evaluationContext));
     }
 
     @Test
@@ -144,6 +144,6 @@ public class NodeExistsPredicateEvaluatorTest {
     public void includes_OrEmpty() throws Exception {
         when(predicate.getBool(NodeExistsPredicateEvaluator.OR)).thenReturn(true);
 
-        assertTrue(predicateEvaluator.includes(predicate, row, evaluationContext));
+        assertFalse(predicateEvaluator.canFilter(predicate, evaluationContext));
     }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/search/impl/NodeExistsPredicateEvaluatorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/search/impl/NodeExistsPredicateEvaluatorTest.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.search.impl;
 
 import com.day.cq.search.Predicate;


### PR DESCRIPTION
Resolves #904 .. 

```
/**
 * This AEM QueryBuilder predicate checks if a JCR node exists, or doesn't exist, off the provided relative path.
 *
 * There are 3 configurations:
 *
 * nodeExists.or = true | false (defaults to false)
 * -- When nodeExists.or = false (the default), all .exists and .notexists conditions for this predicate are AND'd together to determine if the result node is included.
 *
 * nodeExists.#_exists = relative path (relative from the result node) to another node. This relative path mush exist for this expression to return true
 * -- Multiple exists conditions can be present and need to be prefixed via the usual `#_exists` syntax.
 *
 * nodeExists.#_notexists = relative path (relative from the result node) to another node. This relative path mush NOT exist for this expression to return true
 * -- Multiple exists conditions can be present and need to be prefixed via the usual `#_notexists` syntax.
 *
 * nodeExists.or=true
 * nodeExists.exists=jcr:content/renditions/original
 * nodeExists.2_exists=jcr:content/renditions/cq5dam.thumbnail.48.48.png
 * nodeExists.1_notexists=jcr:content/renditions/cq5dam.web.1280.1280.png
 * nodeExists.2_notexists=jcr:content/renditions/cq5dam.web.600.400.png
 */
```