### PR TITLE
Fixes #921 - Corrects Quickly clientlib category name

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/quickly/clientlibs/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/quickly/clientlibs/.content.xml
@@ -24,4 +24,4 @@
           jcr:primaryType="cq:ClientLibraryFolder"
           categories="[acs-commons.quickly]"
           dependencies="[acs-commons.angularjs.v1.3.all]"
-          embed="[acs-commons.lodash,acs-commons.json2,acs-commons.angularjs.v1.3.modules.ng-storage]"/>
+          embed="[acs-commons.lodash,acs-commons.json,acs-commons.angularjs.v1.3.modules.ng-storage]"/>


### PR DESCRIPTION
Fixes Quickly clientlib categories dependency on acs-commons.json