### PR TITLE
httpcache enhancement: allow caching of non 200 responses

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/CacheContent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/CacheContent.java
@@ -62,11 +62,7 @@ public class CacheContent {
     public CacheContent(String charEncoding, String contentType, Map<String, List<String>> headers, InputStream
             dataInputStream) {
 
-        this.status = HttpServletResponse.SC_OK;
-        this.charEncoding = charEncoding;
-        this.contentType = contentType;
-        this.headers = headers;
-        this.dataInputStream = dataInputStream;
+        this(HttpServletResponse.SC_OK, charEncoding, contentType, headers, dataInputStream);
     }
 
     /**

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/CacheContent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/CacheContent.java
@@ -24,6 +24,7 @@ import com.adobe.acs.commons.httpcache.store.TempSink;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.servlet.http.HttpServletResponse;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -36,6 +37,8 @@ import java.util.Map;
 public class CacheContent {
     private static final Logger log = LoggerFactory.getLogger(CacheContent.class);
 
+    /** Response status **/
+    private int status;
     /** Response character encoding */
     private String charEncoding;
     /** Response content type */
@@ -59,6 +62,27 @@ public class CacheContent {
     public CacheContent(String charEncoding, String contentType, Map<String, List<String>> headers, InputStream
             dataInputStream) {
 
+        this.status = HttpServletResponse.SC_OK;
+        this.charEncoding = charEncoding;
+        this.contentType = contentType;
+        this.headers = headers;
+        this.dataInputStream = dataInputStream;
+    }
+
+    /**
+     * Construct <code>CacheContent</code> using parameters. Prefer constructing an instance using <code>build</code>
+     * method.
+     *
+     * @param status
+     * @param charEncoding
+     * @param contentType
+     * @param headers
+     * @param dataInputStream
+     */
+    public CacheContent(int status, String charEncoding, String contentType, Map<String, List<String>> headers, InputStream
+            dataInputStream) {
+
+        this.status = status;
         this.charEncoding = charEncoding;
         this.contentType = contentType;
         this.headers = headers;
@@ -78,6 +102,8 @@ public class CacheContent {
      * @return
      */
     public CacheContent build(HttpCacheServletResponseWrapper responseWrapper) throws HttpCacheDataStreamException {
+        this.status = responseWrapper.getStatus();
+
         // Extract information from response and populate state of the instance.
         this.charEncoding = responseWrapper.getCharacterEncoding();
         this.contentType = responseWrapper.getContentType();
@@ -98,6 +124,13 @@ public class CacheContent {
         this.dataInputStream = responseWrapper.getTempSink().createInputStream();
 
         return this;
+    }
+
+    /**
+     * Get status code.
+     */
+    public int getStatus() {
+        return status;
     }
 
     /**
@@ -143,4 +176,5 @@ public class CacheContent {
     public TempSink getTempSink(){
         return this.tempSink;
     }
+
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImpl.java
@@ -383,6 +383,7 @@ public class HttpCacheEngineImpl extends AnnotatedStandardMBean implements HttpC
             }
         }
 
+        response.setStatus(cacheContent.getStatus());
         // Spool header info into the servlet response.
         for (String headerName : cacheContent.getHeaders().keySet()) {
             for (String headerValue : cacheContent.getHeaders().get(headerName)) {

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/package-info.java
@@ -18,6 +18,6 @@
  * #L%
  */
 
-@aQute.bnd.annotation.Version("3.0.0")
+@aQute.bnd.annotation.Version("3.1.0")
 package com.adobe.acs.commons.httpcache.engine;
 

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/mem/impl/MemCachePersistenceObject.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/mem/impl/MemCachePersistenceObject.java
@@ -38,6 +38,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Value for cache item in mem store.
  */
 class MemCachePersistenceObject {
+    /** Response status **/
+    private int status;
     /** Response character encoding */
     private String charEncoding;
     /** Response content type */
@@ -64,9 +66,10 @@ class MemCachePersistenceObject {
      * @param dataInputStream
      * @throws HttpCacheDataStreamException
      */
-    public MemCachePersistenceObject buildForCaching(String charEncoding, String contentType, Map<String,
+    public MemCachePersistenceObject buildForCaching(int status, String charEncoding, String contentType, Map<String,
             List<String>> headers, InputStream dataInputStream) throws HttpCacheDataStreamException {
 
+        this.status = status;
         this.charEncoding = charEncoding;
         this.contentType = contentType;
 
@@ -88,6 +91,13 @@ class MemCachePersistenceObject {
         return this;
     }
 
+    /**
+     * Get response status
+     * @return the status code
+     */
+    public int getStatus() {
+        return status;
+    }
     /**
      * Get char encoding.
      *

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/mem/impl/MemHttpCacheStoreImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/mem/impl/MemHttpCacheStoreImpl.java
@@ -167,8 +167,8 @@ public class MemHttpCacheStoreImpl extends AbstractGuavaCacheMBean<CacheKey, Mem
     //-------------------------<CacheStore interface specific implementation>
     @Override
     public void put(CacheKey key, CacheContent content) throws HttpCacheDataStreamException {
-        cache.put(key, new MemCachePersistenceObject().buildForCaching(content.getCharEncoding(), content
-                .getContentType(), content.getHeaders(), content.getInputDataStream()));
+        cache.put(key, new MemCachePersistenceObject().buildForCaching(content.getStatus(), content.getCharEncoding(),
+                content.getContentType(), content.getHeaders(), content.getInputDataStream()));
 
     }
 
@@ -190,7 +190,7 @@ public class MemHttpCacheStoreImpl extends AbstractGuavaCacheMBean<CacheKey, Mem
         // Increment hit count
         value.incrementHitCount();
 
-        return new CacheContent(value.getCharEncoding(), value.getContentType(), value.getHeaders(), new
+        return new CacheContent(value.getStatus(), value.getCharEncoding(), value.getContentType(), value.getHeaders(), new
                 ByteArrayInputStream(value.getBytes()));
     }
 
@@ -257,6 +257,7 @@ public class MemHttpCacheStoreImpl extends AbstractGuavaCacheMBean<CacheKey, Mem
     protected void addCacheData(Map<String, Object> data, MemCachePersistenceObject cacheObj) {
         int hitCount = cacheObj.getHitCount();
         long size = cacheObj.getBytes().length;
+        data.put("Status", cacheObj.getStatus());
         data.put("Size", FileUtils.byteCountToDisplaySize(size));
         data.put("Content Type", cacheObj.getContentType());
         data.put("Character Encoding", cacheObj.getCharEncoding());
@@ -275,9 +276,9 @@ public class MemHttpCacheStoreImpl extends AbstractGuavaCacheMBean<CacheKey, Mem
     @Override
     protected CompositeType getCacheEntryType() throws OpenDataException {
        return new CompositeType("Cache Entry", "Cache Entry",
-                new String[] { "Cache Key", "Size", "Content Type", "Character Encoding", "Hits", "Total Size Served from Cache" },
-                new String[] { "Cache Key", "Size", "Content Type", "Character Encoding", "Hits", "Total Size Served from Cache" },
-                new OpenType[] { SimpleType.STRING, SimpleType.STRING, SimpleType.STRING, SimpleType.STRING, SimpleType.INTEGER, SimpleType.STRING });
+                new String[] { "Cache Key", "Status", "Size", "Content Type", "Character Encoding", "Hits", "Total Size Served from Cache" },
+                new String[] { "Cache Key", "Status", "Size", "Content Type", "Character Encoding", "Hits", "Total Size Served from Cache" },
+                new OpenType[] { SimpleType.STRING, SimpleType.INTEGER, SimpleType.STRING, SimpleType.STRING, SimpleType.STRING, SimpleType.INTEGER, SimpleType.STRING });
 
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/mem/impl/MemTempSinkImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/mem/impl/MemTempSinkImpl.java
@@ -53,7 +53,7 @@ public class MemTempSinkImpl implements TempSink {
         if (null != sink) {
             return new ByteArrayInputStream(sink);
         } else {
-            throw new HttpCacheDataStreamException("Nothing available in sink.");
+            return new ByteArrayInputStream(new byte[0]);
         }
     }
 


### PR DESCRIPTION
an obvious use case for caching on AEM (as opposed to Dispatcher or above) would be non-200 Responses, which Dispatcher will not cache, so that e.g. redirects can make up a high part of the requests that actually hit the publishers.

this PR brings cachability of responses that are not 200 OK to the engine and the in-memory cache storage. some steps remain to be done on the project side (in particular reconfiguring the engine to not include `CacheOnlyResponse200` and creating rules that make sure that the repsonse code is duely considered). I tried to keep the PR to the minimum that is required to make non-200-caching possible at all.