### PR TITLE
sling filter to avoid upstream caching of incorrect md5 values

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactory.java
@@ -21,16 +21,27 @@ package com.adobe.acs.commons.rewriter.impl;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.Dictionary;
+import java.util.Hashtable;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.management.DynamicMBean;
 import javax.management.NotCompliantMBeanException;
 import javax.management.openmbean.CompositeType;
 import javax.management.openmbean.OpenDataException;
 import javax.management.openmbean.OpenType;
 import javax.management.openmbean.SimpleType;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang.StringUtils;
@@ -42,11 +53,15 @@ import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.api.SlingConstants;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.commons.osgi.PropertiesUtil;
 import org.apache.sling.rewriter.ProcessingComponentConfiguration;
 import org.apache.sling.rewriter.ProcessingContext;
 import org.apache.sling.rewriter.Transformer;
 import org.apache.sling.rewriter.TransformerFactory;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.ComponentContext;
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventConstants;
 import org.osgi.service.event.EventHandler;
@@ -70,7 +85,7 @@ import com.google.common.cache.CacheBuilder;
  * Re-writes paths to CSS and JS clientlibs to include the md5 checksum as a "
  * selector; in the form: /path/to/clientlib.123456789.css
  */
-@Component(metatype = true, label = "Versioned Clientlibs Transformer Factory",
+@Component(metatype = true, label = "ACS AEM Commons - Versioned Clientlibs Transformer Factory",
     description = "Sling Rewriter Transformer Factory to add auto-generated checksums to client library references")
 @Properties({
     @Property(name = "pipeline.type",
@@ -89,11 +104,17 @@ public final class VersionedClientlibsTransformerFactory extends AbstractGuavaCa
 
     private static final boolean DEFAULT_DISABLE_VERSIONING = false;
 
+    private static final boolean DEFAULT_ENFORCE_MD5 = false;
+
     @Property(label="MD5 Cache Size", description="Maximum size of the md5 cache.", intValue = DEFAULT_MD5_CACHE_SIZE)
     private static final String PROP_MD5_CACHE_SIZE = "md5cache.size";
 
     @Property(label="Disable Versioning", description="Should versioning of clientlibs be disabled", boolValue = DEFAULT_DISABLE_VERSIONING)
     private static final String PROP_DISABLE_VERSIONING = "disable.versioning";
+
+    @Property(label="Enforce MD5", description="Enables a filter which returns a 404 error if the MD5 in the request does not match the expected value",
+        boolValue = DEFAULT_ENFORCE_MD5)
+    private static final String PROP_ENFORCE_MD5 = "enforce.md5";
 
     private static final String ATTR_JS_PATH = "src";
     private static final String ATTR_CSS_PATH = "href";
@@ -111,20 +132,36 @@ public final class VersionedClientlibsTransformerFactory extends AbstractGuavaCa
     @Reference
     private HtmlLibraryManager htmlLibraryManager;
 
+    private ServiceRegistration filterReg;
+
     public VersionedClientlibsTransformerFactory() throws NotCompliantMBeanException {
         super(GenericCacheMBean.class);
     }
 
     @Activate
-    protected void activate(Map<String, Object> props) {
+    protected void activate(ComponentContext componentContext) {
+        Dictionary<?, ?> props = componentContext.getProperties();
         final int size = PropertiesUtil.toInteger(props.get(PROP_MD5_CACHE_SIZE), DEFAULT_MD5_CACHE_SIZE);
         this.md5Cache = CacheBuilder.newBuilder().recordStats().maximumSize(size).build();
         this.disableVersioning = PropertiesUtil.toBoolean(props.get(PROP_DISABLE_VERSIONING), DEFAULT_DISABLE_VERSIONING);
+        boolean enforceMd5 = PropertiesUtil.toBoolean(props.get(PROP_ENFORCE_MD5), DEFAULT_ENFORCE_MD5);
+        if (enforceMd5) {
+            Dictionary<Object, Object> filterProps = new Hashtable<Object, Object>();
+            filterProps.put("sling.filter.scope", "REQUEST");
+            filterProps.put("service.ranking", Integer.valueOf(0));
+
+            filterReg = componentContext.getBundleContext().registerService(Filter.class.getName(),
+                    new BadMd5VersionedClientLibsFilter(), filterProps);
+        }
     }
 
     @Deactivate
     protected void deactivate() {
         this.md5Cache = null;
+        if (filterReg != null) {
+            filterReg.unregister();;
+            filterReg = null;
+        }
     }
 
     public Transformer createTransformer() {
@@ -232,14 +269,28 @@ public final class VersionedClientlibsTransformerFactory extends AbstractGuavaCa
         }
     }
 
-    private String getMd5(final HtmlLibrary htmlLibrary) throws IOException, ExecutionException {
+    @Nonnull private String getMd5(@Nonnull final HtmlLibrary htmlLibrary) throws IOException, ExecutionException {
         return md5Cache.get(new VersionedClientLibraryMd5CacheKey(htmlLibrary), new Callable<String>() {
 
             @Override
             public String call() throws Exception {
-                return DigestUtils.md5Hex(htmlLibrary.getInputStream());
+                return calculateMd5(htmlLibrary);
             }
         });
+    }
+
+    @Nonnull private String calculateMd5(@Nonnull final HtmlLibrary htmlLibrary) throws IOException {
+        return DigestUtils.md5Hex(htmlLibrary.getInputStream());
+    }
+
+    @Nullable private String calculateMd5(SlingHttpServletRequest slingRequest) throws IOException {
+        HtmlLibrary library = htmlLibraryManager.getLibrary(slingRequest);
+        if (library == null) {
+            log.debug("No Client Library found for {}", slingRequest.getRequestURI());
+            return null;
+        } else {
+            return calculateMd5(library);
+        }
     }
 
     private class VersionableClientlibsTransformer extends AbstractTransformer {
@@ -298,5 +349,92 @@ public final class VersionedClientlibsTransformerFactory extends AbstractGuavaCa
                 new String[] { "Cache Key", "Value" },
                 new String[] { "Cache Key", "Value" },
                 new OpenType[] { SimpleType.STRING, SimpleType.STRING });
+    }
+
+    @Nonnull
+    static UriInfo getUriInfo(@Nullable final String uri) {
+        if (uri != null) {
+            String[] parts = uri.split("\\.");
+            if (parts.length > 2) {
+                StringBuilder result = new StringBuilder();
+                result.append(parts[0]);
+                result.append('.');
+                result.append(parts[parts.length - 1]);
+
+                String md5 = parts[parts.length - 2];
+                if (MIN_SELECTOR.equals(md5)) {
+                    md5 = "";
+                }
+                return new UriInfo(result.toString(), md5);
+            } else {
+                // too little parts, just return what came in
+                return new UriInfo(uri, "");
+            }
+        }
+        return new UriInfo("", "");
+    }
+
+    class BadMd5VersionedClientLibsFilter implements Filter {
+
+        @Override
+        public void doFilter(final ServletRequest request,
+                             final ServletResponse response,
+                             final FilterChain filterChain) throws IOException, ServletException {
+            if (request instanceof SlingHttpServletRequest && response instanceof SlingHttpServletResponse) {
+                final SlingHttpServletRequest slingRequest = (SlingHttpServletRequest) request;
+                final SlingHttpServletResponse slingResponse = (SlingHttpServletResponse) response;
+                String uri = slingRequest.getRequestURI();
+                if (uri.endsWith(".js") || uri.endsWith(".css")) {
+                    UriInfo uriInfo = getUriInfo(uri);
+                    String md5FromCache = null;
+                    try {
+                        md5FromCache = getCacheEntry(uriInfo.cleanedUri);
+                    } catch (Exception e) {
+                        md5FromCache = null;
+                    }
+
+                    // this static value "Invalid cache key parameter." happens when the cache key can't be
+                    // found in the cache
+                    if ("Invalid cache key parameter.".equals(md5FromCache)) {
+                        md5FromCache = calculateMd5(slingRequest);
+                    }
+
+                    if (md5FromCache == null) {
+                        // something went bad during the cache access
+                        log.warn("Failed to fetch data from Versioned ClientLibs cache, allowing {} to pass", uri);
+                        filterChain.doFilter(request, response);
+                    } else {
+                        // the file is in the cache, compare the md5 from cache with the one in the request
+                        if (md5FromCache.equals(uriInfo.md5)) {
+                            log.debug("MD5 equals for '{}' in Versioned ClientLibs cache, allowing {} to pass", uriInfo.cleanedUri, uri);
+                            filterChain.doFilter(request, response);
+                        } else {
+                            log.info("MD5 differs for '{}' in Versioned ClientLibs cache. Sending 404 for '{}'", uriInfo.cleanedUri, uri);
+                            slingResponse.sendError(HttpServletResponse.SC_NOT_FOUND);
+                        }
+                    }
+                } else {
+                    filterChain.doFilter(request, response);
+                }
+            } else {
+                filterChain.doFilter(request, response);
+            }
+        }
+
+        @Override
+        public void init(final FilterConfig filterConfig) throws ServletException {}
+
+        @Override
+        public void destroy() {}
+    }
+
+    static class UriInfo {
+        private final String cleanedUri;
+        private final String md5;
+
+        UriInfo(String cleanedUri, String md5) {
+            this.cleanedUri = cleanedUri;
+            this.md5 = md5;
+        }
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactory.java
@@ -386,6 +386,12 @@ public final class VersionedClientlibsTransformerFactory extends AbstractGuavaCa
                 String uri = slingRequest.getRequestURI();
                 if (uri.endsWith(".js") || uri.endsWith(".css")) {
                     UriInfo uriInfo = getUriInfo(uri);
+                    if ("".equals(uriInfo.md5)) {
+                        log.debug("MD5 is blank for '{}' in Versioned ClientLibs cache, allowing {} to pass", uriInfo.cleanedUri, uri);
+                        filterChain.doFilter(request, response);
+                        return;
+                    }
+
                     String md5FromCache = null;
                     try {
                         md5FromCache = getCacheEntry(uriInfo.cleanedUri);
@@ -409,7 +415,8 @@ public final class VersionedClientlibsTransformerFactory extends AbstractGuavaCa
                             log.debug("MD5 equals for '{}' in Versioned ClientLibs cache, allowing {} to pass", uriInfo.cleanedUri, uri);
                             filterChain.doFilter(request, response);
                         } else {
-                            log.info("MD5 differs for '{}' in Versioned ClientLibs cache. Sending 404 for '{}'", uriInfo.cleanedUri, uri);
+                            log.info("MD5 differs for '{}' in Versioned ClientLibs cache. Expected {}. Sending 404 for '{}'",
+                                    new Object[] { uriInfo.cleanedUri, uriInfo.md5, uri });
                             slingResponse.sendError(HttpServletResponse.SC_NOT_FOUND);
                         }
                     }

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactoryTest.java
@@ -497,6 +497,14 @@ public class VersionedClientlibsTransformerFactoryTest {
         verify404();
     }
 
+    @Test
+    public void doFilter_noMd5() throws Exception {
+        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.min.js");
+        filter.doFilter(slingRequest, slingResponse, filterChain);
+
+        verifyNo404();
+    }
+
     private void verifyNothingHappened() throws IOException, ServletException {
         verifyZeroInteractions(htmlLibraryManager);
         verifyNo404();

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactoryTest.java
@@ -26,29 +26,36 @@ import com.day.cq.widget.LibraryType;
 
 import junitx.util.PrivateAccessor;
 
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.rewriter.Transformer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.internal.configuration.InjectingAnnotationEngine;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.helpers.AttributesImpl;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
-import static org.mockito.Mockito.only;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
 
-import java.util.Collections;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Dictionary;
+import java.util.Hashtable;
 
 @RunWith(MockitoJUnitRunner.class)
 public class VersionedClientlibsTransformerFactoryTest {
@@ -61,18 +68,47 @@ public class VersionedClientlibsTransformerFactoryTest {
     @Mock
     private ContentHandler handler;
 
+    @Mock
+    private SlingHttpServletRequest slingRequest;
+
+    @Mock
+    private SlingHttpServletResponse slingResponse;
+
+    @Mock
+    private FilterChain filterChain;
+
     private VersionedClientlibsTransformerFactory factory;
+
+    private Filter filter;
 
     private Transformer transformer;
 
+    @Mock
+    private ComponentContext componentContext;
+
+    @Mock
+    private BundleContext bundleContext;
+
     private final String PATH = "/etc/clientlibs/test";
     private final String FAKE_STREAM_CHECKSUM="fcadcfb01c1367e9e5b7f2e6d455ba8f";
+    private final byte[] BYTES;
+    private final java.io.InputStream INPUTSTREAM;
+    private final String INPUTSTREAM_MD5;
+
+    public VersionedClientlibsTransformerFactoryTest() throws Exception {
+        BYTES = "test".getBytes("UTF-8");
+        INPUTSTREAM = new ByteArrayInputStream(BYTES);
+        INPUTSTREAM_MD5 = DigestUtils.md5Hex(BYTES);
+    }
 
     @Before
     public void setUp() throws Exception {
+        when(componentContext.getBundleContext()).thenReturn(bundleContext);
+        when(componentContext.getProperties()).thenReturn(new Hashtable<Object, Object>());
         factory = new VersionedClientlibsTransformerFactory();
+        filter = factory.new BadMd5VersionedClientLibsFilter();
         PrivateAccessor.setField(factory, "htmlLibraryManager", htmlLibraryManager);
-        factory.activate(Collections.<String, Object>emptyMap());
+        factory.activate(componentContext);
 
         when(htmlLibrary.getLibraryPath()).thenReturn(PATH);
         when(htmlLibrary.getInputStream()).thenReturn(new java.io.ByteArrayInputStream("I love strings".getBytes()));
@@ -80,12 +116,23 @@ public class VersionedClientlibsTransformerFactoryTest {
 
         transformer = factory.createTransformer();
         transformer.setContentHandler(handler);
+
+        verifyNoMoreInteractions(bundleContext);
     }
 
     @After
     public void tearDown() throws Exception {
         reset(htmlLibraryManager, htmlLibrary, handler);
         transformer = null;
+    }
+
+    @Test
+    public void testRegisterFilter() throws Exception {
+        Hashtable<Object, Object> props = new Hashtable<Object, Object>();
+        props.put("enforce.md5", Boolean.TRUE);
+        when(componentContext.getProperties()).thenReturn(props);
+        factory.activate(componentContext);
+        verify(bundleContext).registerService(eq(Filter.class.getName()), any(Object.class), any(Dictionary.class));
     }
 
     @Test
@@ -382,5 +429,86 @@ public class VersionedClientlibsTransformerFactoryTest {
                 attributesCaptor.capture());
 
         assertEquals("https://example.com/same/scheme/styles.css", attributesCaptor.getValue().getValue(0));
+    }
+
+    @Test
+    public void doFilter_nonJSCSS() throws Exception {
+        when(slingRequest.getRequestURI()).thenReturn("/some_other/uri.html");
+        filter.doFilter(slingRequest, slingResponse, filterChain);
+        verifyNothingHappened();
+    }
+
+    @Test
+    public void doFilter_notFoundInCache_md5Match() throws Exception {
+        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.min." + INPUTSTREAM_MD5 + ".js");
+
+        HtmlLibrary library = mock(HtmlLibrary.class);
+        when(library.getInputStream()).thenReturn(INPUTSTREAM);
+        when(library.getLibraryPath()).thenReturn("/etc/clientlibs/some.js");
+        when(htmlLibraryManager.getLibrary(slingRequest)).thenReturn(library);
+
+        filter.doFilter(slingRequest, slingResponse, filterChain);
+
+        verifyNo404();
+    }
+
+    @Test
+    public void doFilter_notFoundInCache_md5MisMatch() throws Exception {
+        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.min.foobar.js");
+
+        HtmlLibrary library = mock(HtmlLibrary.class);
+        when(library.getInputStream()).thenReturn(INPUTSTREAM );
+        when(library.getLibraryPath()).thenReturn("/etc/clientlibs/some.js");
+        when(htmlLibraryManager.getLibrary(slingRequest)).thenReturn(library);
+
+        filter.doFilter(slingRequest, slingResponse, filterChain);
+
+        verify404();
+    }
+
+    @Test
+    public void doFilter_notFoundInCache_NoClientLib() throws Exception {
+        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.min.foobar.js");
+        when(htmlLibraryManager.getLibrary(slingRequest)).thenReturn(null);
+
+        filter.doFilter(slingRequest, slingResponse, filterChain);
+
+        verifyNo404();
+    }
+
+    @Test
+    public void doFilter_foundInCache_md5Match() throws Exception {
+        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.min." + INPUTSTREAM_MD5 + ".js");
+        factory.getCache().put(new VersionedClientLibraryMd5CacheKey("/etc/clientlibs/some", LibraryType.JS), INPUTSTREAM_MD5);
+
+        filter.doFilter(slingRequest, slingResponse, filterChain);
+
+        verifyZeroInteractions(htmlLibraryManager);
+        verifyNo404();
+    }
+
+    @Test
+    public void doFilter_foundInCache_md5MisMatch() throws Exception {
+        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.min.foobar.js");
+        factory.getCache().put(new VersionedClientLibraryMd5CacheKey("/etc/clientlibs/some", LibraryType.JS), INPUTSTREAM_MD5);
+
+        filter.doFilter(slingRequest, slingResponse, filterChain);
+
+        verify404();
+    }
+
+    private void verifyNothingHappened() throws IOException, ServletException {
+        verifyZeroInteractions(htmlLibraryManager);
+        verifyNo404();
+    }
+
+    private void verifyNo404() throws IOException, ServletException {
+        verify(filterChain).doFilter(slingRequest, slingResponse);
+        verify(slingResponse, never()).sendError(anyInt());
+    }
+
+    private void verify404() throws IOException, ServletException {
+        verify(filterChain, never()).doFilter(slingRequest, slingResponse);
+        verify(slingResponse).sendError(HttpServletResponse.SC_NOT_FOUND);
     }
 }


### PR DESCRIPTION
based on patch from @wimsymons, but modified to be tightly coupled to the transformer

fixes #911