### PR TITLE
Feature/946 system notifications breaking

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/xss/XSSFunctions.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/xss/XSSFunctions.java
@@ -20,7 +20,7 @@
 package com.adobe.acs.commons.xss;
 
 import aQute.bnd.annotation.ProviderType;
-import org.apache.sling.xss.XSSAPI;
+import com.adobe.granite.xss.XSSAPI;
 import tldgen.Function;
 
 import java.util.regex.Pattern;

--- a/bundle/src/main/java/com/adobe/acs/commons/xss/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/xss/package-info.java
@@ -20,6 +20,6 @@
 /**
  * XSS JSP Functions.
  */
-@aQute.bnd.annotation.Version("2.0.0")
+@aQute.bnd.annotation.Version("3.0.0")
 @tldgen.TagLibrary(value = "http://www.adobe.com/consulting/acs-aem-commons/xss", descriptorFile = "xss.tld")
 package com.adobe.acs.commons.xss;

--- a/bundle/src/test/java/com/adobe/acs/commons/xss/XSSFunctionsTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/xss/XSSFunctionsTest.java
@@ -19,8 +19,8 @@
  */
 package com.adobe.acs.commons.xss;
 
+import com.adobe.granite.xss.XSSAPI;
 import org.apache.commons.lang.RandomStringUtils;
-import org.apache.sling.xss.XSSAPI;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;


### PR DESCRIPTION
Fixes #946 

Rolls back use of deprecated XSS functions which are still used in AEM.