### PR TITLE
The ContentModificationFramework allows you to perform custom changes…

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/cmf/ContentModificationProcessor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/cmf/ContentModificationProcessor.java
@@ -1,0 +1,25 @@
+package com.adobe.acs.commons.cmf;
+
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.ResourceResolver;
+
+public interface ContentModificationProcessor {
+	
+	
+	/**
+	 * Identify the resources, which would be affected by a certain ContentModificationStep.
+	 * 
+	 * @param contentModificationStep  the name of the ContentModificationStep which should be used
+	 * @param path determines the subtree which should be validated
+	 * @param resolver the resourceresolver to use	
+	 * @return null if the ContentModificationStep is not available, or a list of resources as defined by the
+	 *   respective ContentModificationProcessor. Returns an empty list of no resources can be identified
+	 * @throws NoSuchContentModificationStepException 
+	 */
+	public IdentifiedResources identifyAffectedResources (String contentModificationStep, String path, ResourceResolver resolver) throws NoSuchContentModificationStepException;
+	
+	
+	
+	public void modifyResources (IdentifiedResources resources, ResourceResolver resolver) throws NoSuchContentModificationStepException, PersistenceException;
+	
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/cmf/ContentModificationStep.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/cmf/ContentModificationStep.java
@@ -1,0 +1,38 @@
+package com.adobe.acs.commons.cmf;
+
+import java.util.List;
+
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+
+
+/**
+ * 
+ *
+ */
+
+
+public interface ContentModificationStep {
+	
+	public static final String STEP_NAME = "contentModification.name";
+
+	
+	/**
+	 * Identify the resources which should be considered for modification
+	 * @param path the root resource of the subtree which should be considered
+	 * @return the resources which are going to be modified
+	 */
+	public List<Resource> identifyResources (Resource resource);
+	
+	
+	/**
+	 * Modify the resource.
+	 * 
+	 * Performs all relevant operations on the resource. An implementation should not persist
+	 * the changes, that means it should not call <code>resource.getResourceResolver().commit();</code>
+	 * @param resource the resource which should be modified
+	 */
+	public void performModification (Resource resource);
+	
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/cmf/IdentifiedResources.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/cmf/IdentifiedResources.java
@@ -1,0 +1,37 @@
+package com.adobe.acs.commons.cmf;
+
+import java.util.List;
+
+/**
+ * IdentifiedResources is used to hold the information about the
+ * resources which have been identified by a ContentModificationStep.
+ *
+ */
+
+public class IdentifiedResources {
+	
+	List <String> paths; // the paths only
+	String contentModificationStep;
+	
+	public IdentifiedResources (List<String> paths, String name) {
+		this.paths = paths;
+		this.contentModificationStep = name;
+	}
+	
+	
+	public List <String> getPaths () {
+		return paths;
+	}
+	
+	
+	/**
+	 * identifies the step which created this IdentifiedResource
+	 * @return the label of the ContentModification Step
+	 */
+	public String getContentModificationStep () {
+		return contentModificationStep;
+	}
+	
+	
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/cmf/NoSuchContentModificationStepException.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/cmf/NoSuchContentModificationStepException.java
@@ -1,0 +1,12 @@
+package com.adobe.acs.commons.cmf;
+
+public class NoSuchContentModificationStepException extends Exception {
+
+
+	private static final long serialVersionUID = 2040296153469265596L;
+
+	public NoSuchContentModificationStepException (String msg) {
+		super (msg);
+	}
+	
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/cmf/TraversingContentModificationStep.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/cmf/TraversingContentModificationStep.java
@@ -1,0 +1,74 @@
+package com.adobe.acs.commons.cmf;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+
+
+/**
+ * This class implements the Visitor pattern for the identifyResources() method.
+ *
+ */
+public abstract class TraversingContentModificationStep implements ContentModificationStep {
+
+	@Override
+	public List<Resource> identifyResources(Resource rootResource) {
+		
+		List<Resource> result = new LinkedList<Resource>();
+		return visit (result, rootResource);
+	}
+	
+	/**
+	 * Visits the resource r and its sub-resources. 
+	 * @param r
+	 * @return
+	 */
+	private List<Resource> visit (List<Resource> list, Resource r) {
+		
+		/**
+		 * This implementation tries to avoid the list.addAll method
+		 */
+		
+		Resource foundResource = visitResource (r);
+		if (foundResource != null) {
+			list.add(foundResource);
+		}
+		Iterator<Resource> iter =  r.listChildren();
+		while (iter.hasNext()) {
+			Resource innerResource = iter.next();
+			if (accept(innerResource)) {
+				list = (visit (list, innerResource));
+			}
+			
+		}
+		return list;
+		
+	}
+
+	
+	/**
+	 * <code>visitResource</code> implements the visitor pattern and is called for every resource.
+	 * @param res the resource to inspect
+	 * @return the resource if the resource should considered be for the inclusion in the result 
+	 *   delivered by identifyResources; null otherwise
+	 */
+	public abstract Resource visitResource (Resource res);
+	
+	
+	
+	/**
+	 * Decides if a certain resource (and sub-resources) will be traversed. This allows to cut off subtrees, where not 
+	 * change is expected to happen
+	 * @param res the resource
+	 * @return true if the resources and it's sub-resources should be visited.
+	 */
+	
+	public boolean accept (Resource res) {
+		return true;
+	}
+	
+	
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/cmf/impl/ContentModificationProcessorImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/cmf/impl/ContentModificationProcessorImpl.java
@@ -1,0 +1,143 @@
+package com.adobe.acs.commons.cmf.impl;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Properties;
+import org.apache.felix.scr.annotations.Property;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.ReferenceCardinality;
+import org.apache.felix.scr.annotations.ReferencePolicy;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.acs.commons.cmf.ContentModificationProcessor;
+import com.adobe.acs.commons.cmf.ContentModificationStep;
+import com.adobe.acs.commons.cmf.IdentifiedResources;
+import com.adobe.acs.commons.cmf.NoSuchContentModificationStepException;
+
+@Component
+@Service
+@Properties({
+    @Property(name="felix.webconsole.label", value="cmf"),
+    @Property(name="felix.webconsole.title", value="Content Modification Framework"),
+})
+public class ContentModificationProcessorImpl extends HttpServlet implements ContentModificationProcessor {
+
+	
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	@Reference(cardinality=ReferenceCardinality.OPTIONAL_MULTIPLE,
+			policy=ReferencePolicy.DYNAMIC, 
+			referenceInterface=com.adobe.acs.commons.cmf.ContentModificationStep.class)
+	HashMap<String, ContentModificationStep> registeredSteps = new HashMap<String,ContentModificationStep>();
+	
+	private static final Logger log = LoggerFactory.getLogger(ContentModificationProcessorImpl.class);
+	
+	
+
+	
+	protected void bindContentModificationStep (ContentModificationStep step, Map properties) {
+		synchronized (registeredSteps) {
+			String name = (String) properties.get(ContentModificationStep.STEP_NAME);
+			if (StringUtils.isEmpty(name)) {
+				name = step.getClass().getName();
+			}
+			registeredSteps.put (name, step);
+			log.info("registered content modification step '{}'", name);
+		}
+	}
+	
+	protected void unbindContentModificationStep (ContentModificationStep step, Map properties) {
+		synchronized (registeredSteps) {
+			String name = (String) properties.get(ContentModificationStep.STEP_NAME);
+			if (StringUtils.isEmpty(name)) {
+				name = step.getClass().getName();
+			}
+			registeredSteps.remove(name);
+			log.info("unregistered content modification step '{}'", name);
+		}
+	}
+	
+	/** Webconsole **/
+	protected void doGet(final HttpServletRequest req, final HttpServletResponse res) throws IOException {
+		PrintWriter pw = res.getWriter();
+		pw.println("<div class='statline'>Registered Content Modification Steps:</div>");
+		pw.println("<ul>");
+		for (String step: registeredSteps.keySet()) {
+			pw.println("<li>" + step + "</li>");
+		}
+		pw.println("</ul>");
+	}
+
+
+
+	@Override
+	public IdentifiedResources identifyAffectedResources(String name, String path,
+			ResourceResolver resolver) throws NoSuchContentModificationStepException {
+		
+		ContentModificationStep cms = registeredSteps.get(name);
+		if (cms == null) {
+			String msg = String.format("ContentModificationStep %s not found", name);
+			throw new NoSuchContentModificationStepException(msg);
+		}
+		
+		Resource rootResource = resolver.getResource(path);
+		
+		List <Resource> r=  cms.identifyResources(rootResource);
+		
+		List <String> result = new ArrayList<String> (r.size());
+		Iterator<Resource> iter = r.iterator();
+		while (iter.hasNext()) {
+			Resource res = iter.next();
+			result.add(res.getPath());
+		}
+		
+		log.info("ContentModificationStep {} identified {} resources below {} for modification", new Object[]{name,result.size(), path});
+		
+		return new IdentifiedResources (result, name);
+		
+		
+	}
+
+	@Override
+	public void modifyResources(IdentifiedResources resources,
+			ResourceResolver resolver)
+			throws NoSuchContentModificationStepException, PersistenceException {
+		
+		ContentModificationStep cms = registeredSteps.get(resources.getContentModificationStep());
+		if (cms == null) {
+			String msg = String.format("ContentModificationStep %s not found", resources.getContentModificationStep());
+			throw new NoSuchContentModificationStepException(msg);
+		}
+		
+		Iterator<String> iter = resources.getPaths().iterator();
+		while (iter.hasNext()) {
+			String path = iter.next();
+			Resource toModify = resolver.getResource(path);
+			cms.performModification(toModify);
+			toModify.getResourceResolver().commit();
+		}
+		
+		
+	}
+	
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/cmf/impl/ContentModificationServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/cmf/impl/ContentModificationServlet.java
@@ -1,0 +1,128 @@
+package com.adobe.acs.commons.cmf.impl;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Set;
+
+import javax.servlet.ServletOutputStream;
+
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.sling.SlingServlet;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.acs.commons.cmf.ContentModificationProcessor;
+import com.adobe.acs.commons.cmf.IdentifiedResources;
+import com.adobe.acs.commons.cmf.NoSuchContentModificationStepException;
+
+
+/**
+ * The ContentModificationServlet should be set on a resource with these 2 properties for configuration
+ * <ul>
+ *   <li><code>path</code> describes the repository path on which to work</li>
+ *   <li><code>modificationStep</code> is the name of the ContentModificationtep which is going to be used</li>
+ * </ul>
+ *
+ * When invoked on a GET request, the servlet will display only the resources which are going to be changed.
+ * If invoked via POST the change is performed as well.
+ * 
+ */
+
+
+@SlingServlet(
+        methods = { "GET", "POST" },
+        resourceTypes = { "acs-commons/components/cmf" },
+        extensions = { "html" }
+)
+public class ContentModificationServlet extends SlingAllMethodsServlet {
+	
+	private static Logger log = LoggerFactory.getLogger(ContentModificationServlet.class);
+	
+	private static final String PATH = "path";
+	private static final String MODIFICATION_STEP = "modificationStep";
+
+
+	@Reference
+	ContentModificationProcessor cmp;
+	
+	
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	protected void doGet (SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException {
+		
+		ServletOutputStream out = response.getOutputStream();
+
+		Resource resource = request.adaptTo(Resource.class);
+		if (resource == null) {
+			response.sendError(500, "No resource");
+			log.error ("not invoked on a resource");
+			return;
+		}
+		ValueMap props = resource.adaptTo(ValueMap.class);
+		String usedModificationStep = props.get(MODIFICATION_STEP).toString();
+		String path = props.get(PATH).toString();
+		
+		out.print(String.format("<p>Starting %s on path %s</p>", new Object[]{usedModificationStep,path}));
+		
+		try {
+			IdentifiedResources id = cmp.identifyAffectedResources(usedModificationStep, path, request.getResourceResolver());
+			Iterator<String> resources = id.getPaths().iterator();
+			out.print("Found resources:<ul>");
+			while (resources.hasNext()) {
+				out.print (String.format("<li>%s</li>", resources.next()));
+			}
+			out.print("</ul>");			
+			
+		} catch (NoSuchContentModificationStepException e) {
+			out.print ("<p>Did not find modification step called " + usedModificationStep + "</p>");
+		}
+	}
+
+	
+	protected void doPost (SlingHttpServletRequest request, SlingHttpServletResponse response) throws IOException {
+		
+		ServletOutputStream out = response.getOutputStream();
+
+		Resource resource = request.adaptTo(Resource.class);
+		if (resource == null) {
+			response.sendError(500, "No resource");
+			log.error ("not invoked on a resource");
+			return;
+		}
+		ValueMap props = resource.adaptTo(ValueMap.class);
+		String usedModificationStep = props.get(MODIFICATION_STEP).toString();
+		String path = props.get(PATH).toString();
+		
+		out.print(String.format("<p>Starting %s on path %s</p>", new Object[]{usedModificationStep,path}));
+		
+		try {
+			IdentifiedResources id = cmp.identifyAffectedResources(usedModificationStep, path, request.getResourceResolver());
+			Iterator<String> resources = id.getPaths().iterator();
+			out.print("Found resources:<ul>");
+			while (resources.hasNext()) {
+				out.print (String.format("<li>%s</li>", resources.next()));
+			}
+			out.print("</ul>");
+			
+			out.print("<p>Start modification</p>");
+			
+			cmp.modifyResources(id, request.getResourceResolver());
+			
+			out.print("<p>Modification completed</p>");
+			
+			
+		} catch (NoSuchContentModificationStepException e) {
+			out.print ("<p>Did not find modification step called " + usedModificationStep + "</p>");
+		}
+	}
+	
+	
+}


### PR DESCRIPTION
This PR is based on #924 where I got lot of good feedback. I incorporated it all (I hope) and also tuned a bit here and there. The biggest change and the reason why I do a 2nd PR is the renaming to ContentModificationFramework.


In projects you often encounter the situation, that over time the structure of individual components and pages change or need to be modified. Typically this is done by writing a custom servlet, which does that job.
But this is unflexible and often lacks some features like

- partial migration
- dry run
- reasonable logging

This Content MOdification Framework tries to provide these features, and requires you to implement these 2 aspects (by implementing the ContentModificationStep interface)

    identifying the resources which need to be changed
    transform a resource from the existing structure to the new structure

The execution of one of the registered ContentModificationSteps can be triggered using the ContentModificationProcessor service. A sample use of the ContentModificationProcessor can be seen in the ContentMigrationServlet.

