### PR TITLE
Feature/957

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/errorpagehandler/impl/ErrorPageHandlerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/errorpagehandler/impl/ErrorPageHandlerImpl.java
@@ -306,12 +306,18 @@ public final class ErrorPageHandlerImpl implements ErrorPageHandlerService {
      */
 	private String findErrorsPath(SlingHttpServletRequest request, Resource errorResource) {
 		final String errorResourcePath = errorResource.getPath();
-		final Resource page = findFirstRealParentOrSelf(request, errorResource);
+		Resource real = findFirstRealParentOrSelf(request, errorResource);
 
         String errorsPath = null;
-        if(page != null) {
-            log.trace("Found page is [ {} ]", page.getPath());
-	        final InheritanceValueMap pageProperties = new HierarchyNodeInheritanceValueMap(page);
+        if (real != null) {
+            log.trace("Found real resource at [ {} ]", real.getPath());
+            if (!JcrConstants.JCR_CONTENT.equals(real.getName())) {
+                Resource tmp = real.getChild(JcrConstants.JCR_CONTENT);
+                if (tmp != null) {
+                    real = tmp;
+                }
+            }
+	        final InheritanceValueMap pageProperties = new HierarchyNodeInheritanceValueMap(real);
 	        errorsPath = pageProperties.getInherited(ERROR_PAGE_PROPERTY, String.class);
         } else {
         	log.trace("No page found for [ {} ]", errorResource);

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/runners/AEMTransientWorkflowRunnerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/runners/AEMTransientWorkflowRunnerImpl.java
@@ -32,6 +32,7 @@ import com.day.cq.workflow.model.WorkflowModel;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
@@ -212,8 +213,13 @@ public class AEMTransientWorkflowRunnerImpl extends AbstractAEMWorkflowRunner im
                     workspace.commit();
                 }
             } catch (Exception e) {
-                log.error("Error processing periodic execution: {}", e);
+                log.error("Error processing periodic execution for job [ {} ] for workspace [ {} ]", new String[]{ jobName, workspace.getPath() }, e);
                 unscheduleJob(scheduler, jobName, configResource, workspace);
+                try {
+                    stop(workspace);
+                } catch (PersistenceException e1) {
+                    log.error("Unable to mark this workspace [ {} ] as stopped.", workspace.getPath(), e1);
+                }
             } finally {
                 if (adminResourceResolver != null) {
                     adminResourceResolver.close();

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/runners/AEMWorkflowRunnerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/runners/AEMWorkflowRunnerImpl.java
@@ -22,17 +22,15 @@ package com.adobe.acs.commons.workflow.bulk.execution.impl.runners;
 
 import com.adobe.acs.commons.fam.ThrottledTaskRunner;
 import com.adobe.acs.commons.workflow.bulk.execution.BulkWorkflowRunner;
-import com.adobe.acs.commons.workflow.bulk.execution.model.Status;
 import com.adobe.acs.commons.workflow.bulk.execution.model.Config;
 import com.adobe.acs.commons.workflow.bulk.execution.model.Payload;
-import com.adobe.acs.commons.workflow.bulk.execution.model.PayloadGroup;
+import com.adobe.acs.commons.workflow.bulk.execution.model.Status;
 import com.adobe.acs.commons.workflow.bulk.execution.model.Workspace;
 import com.day.cq.workflow.WorkflowException;
 import com.day.cq.workflow.WorkflowService;
 import com.day.cq.workflow.WorkflowSession;
 import com.day.cq.workflow.exec.Workflow;
 import com.day.cq.workflow.model.WorkflowModel;
-import org.apache.commons.lang.StringUtils;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.Service;
@@ -301,8 +299,13 @@ public class AEMWorkflowRunnerImpl extends AbstractAEMWorkflowRunner implements 
                     workspace.commit();
                 }
             } catch (Exception e) {
-                log.error("Error processing periodic execution: {}", e);
+                log.error("Error processing periodic execution for job [ {} ] for workspace [ {} ]", new String[]{ jobName, workspace.getPath() }, e);
                 unscheduleJob(scheduler, jobName, configResource, workspace);
+                try {
+                    stop(workspace);
+                } catch (PersistenceException e1) {
+                    log.error("Unable to mark this workspace [ {} ] as stopped.", workspace.getPath(), e1);
+                }
             } finally {
                 if (adminResourceResolver != null) {
                     adminResourceResolver.close();

--- a/bundle/src/test/java/com/adobe/acs/commons/errorpagehandler/impl/ErrorPageHandlerImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/errorpagehandler/impl/ErrorPageHandlerImplTest.java
@@ -19,8 +19,6 @@
  */
 package com.adobe.acs.commons.errorpagehandler.impl;
 
-import static org.junit.Assert.assertEquals;
-
 import org.apache.sling.api.resource.NonExistingResource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.testing.mock.sling.junit.SlingContext;
@@ -29,7 +27,12 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
 public class ErrorPageHandlerImplTest {
 
     @Rule
@@ -79,4 +82,15 @@ public class ErrorPageHandlerImplTest {
         assertEquals("/content/project/test/error-pages.html", new ErrorPageHandlerImpl().findErrorPage(request, new NonExistingResource(resourceResolver, "/content/project/test/non-existing-page/jcr:content/test1/test2")));
     }
 
+    @Test
+    public void testFindErrorPage_nonExistingPageWithoutExtension() {
+        assertEquals("/content/project/test/error-pages.html", new ErrorPageHandlerImpl().findErrorPage(request, new NonExistingResource(resourceResolver, "/content/project/non-existing-page")));
+    }
+
+    @Test
+    public void testFindErrorPage_JcrContent0() {
+        assertEquals("/content/project/test/error-pages.html",
+                new ErrorPageHandlerImpl().findErrorPage(request,
+                        new NonExistingResource(resourceResolver, "/content/project/jcr:content/non-existing")));
+    }
 }


### PR DESCRIPTION
Fixes issue with error page handler errorPaths property lookup.

In the previous update to this feature, InheritanceValueMaps were introduced that look at the incorrect path ([cq:Page] vs [cq:Page]/jcr:contnet) 

@nc-andreashaller  can you take a quick look?
