### PR TITLE
#918 - Updated queryHelper param delimiter to be /n (from ,;\s\n\t)

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/util/impl/QueryHelperImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/impl/QueryHelperImpl.java
@@ -69,7 +69,7 @@ public class QueryHelperImpl implements QueryHelper {
         final List<Resource> resources = new ArrayList<Resource>();
 
         if (QUERY_BUILDER.equalsIgnoreCase(language)) {
-            final String[] lines = statement.split("[,;\\s\\n\\t]+");
+            final String[] lines = statement.split("[\\n]+");
             final Map<String, String> params = ParameterUtil.toMap(lines, "=", false, null, true);
 
             // ensure all results are returned
@@ -84,7 +84,7 @@ public class QueryHelperImpl implements QueryHelper {
             }
         } else if (LIST.equalsIgnoreCase(language)) {
             if (StringUtils.isNotBlank(statement)) {
-                final String[] lines = statement.split("[,;\\s\\n\\t]+");
+                final String[] lines = statement.split("[\\n]+");
 
                 for (String line : lines) {
                     if (StringUtils.isNotBlank(line)) {

--- a/bundle/src/main/java/com/adobe/acs/commons/util/impl/QueryHelperImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/impl/QueryHelperImpl.java
@@ -67,9 +67,9 @@ public class QueryHelperImpl implements QueryHelper {
                                         final String relPath) throws RepositoryException {
 
         final List<Resource> resources = new ArrayList<Resource>();
+        final String[] lines = StringUtils.split(statement, '\n');
 
         if (QUERY_BUILDER.equalsIgnoreCase(language)) {
-            final String[] lines = statement.split("[\\n]+");
             final Map<String, String> params = ParameterUtil.toMap(lines, "=", false, null, true);
 
             // ensure all results are returned
@@ -84,8 +84,6 @@ public class QueryHelperImpl implements QueryHelper {
             }
         } else if (LIST.equalsIgnoreCase(language)) {
             if (StringUtils.isNotBlank(statement)) {
-                final String[] lines = statement.split("[\\n]+");
-
                 for (String line : lines) {
                     if (StringUtils.isNotBlank(line)) {
                         final Resource resource = resourceResolver.getResource(line);


### PR DESCRIPTION
@nateyolles how does this look?

The delimiters are just \n ... Everything else is a valid character (,;\s) in a node name, and \t seems just strange as a list delimiter.