### PR TITLE
#975 - remove use of the deprecated Felix whiteboard properties

### DIFF
--- a/bundle-twitter/pom.xml
+++ b/bundle-twitter/pom.xml
@@ -85,11 +85,11 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.compendium</artifactId>
+            <artifactId>osgi.cmpn</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -115,11 +115,11 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.compendium</artifactId>
+            <artifactId>osgi.cmpn</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>org.osgi.core</artifactId>
+            <artifactId>osgi.core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/bundle/src/main/java/com/adobe/acs/commons/http/headers/impl/AbstractDispatcherCacheHeaderFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/http/headers/impl/AbstractDispatcherCacheHeaderFilter.java
@@ -26,6 +26,7 @@ import org.apache.jackrabbit.oak.commons.PropertiesUtil;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -146,7 +147,8 @@ public abstract class AbstractDispatcherCacheHeaderFilter implements Filter {
             Dictionary<String, String> filterProps = new Hashtable<String, String>();
 
             log.debug("Adding filter ({}) to pattern: {}", this.toString(), pattern);
-            filterProps.put("pattern", pattern);
+            filterProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_REGEX, pattern);
+            filterProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT, "(" + HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME + "=*)");
             ServiceRegistration filterReg = context.getBundleContext().registerService(Filter.class.getName(), this, filterProps);
             filterRegistrations.add(filterReg);
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/http/headers/impl/DailyExpiresHeaderFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/http/headers/impl/DailyExpiresHeaderFilter.java
@@ -32,11 +32,9 @@ import java.util.Calendar;
 @Component(
     label = "ACS AEM Commons - Dispatcher Expires Header - Daily",
     description = "Adds an Expires header to content to enable Dispatcher TTL support.",
-    immediate = false,
     metatype = true,
     configurationFactory = true,
     policy = ConfigurationPolicy.REQUIRE)
-@Service
 @Properties({
   @Property(label = "Filter Patterns",
       description = "Patterns on which to apply this Expires rule.",

--- a/bundle/src/main/java/com/adobe/acs/commons/http/headers/impl/DispatcherMaxAgeHeaderFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/http/headers/impl/DispatcherMaxAgeHeaderFilter.java
@@ -36,11 +36,9 @@ import java.util.Enumeration;
 @Component(
       label = "ACS AEM Commons - Dispacher Cache Control Header - Max Age",
       description = "Adds a Cache-Control max-age header to content to enable Dispatcher TTL support.",
-      immediate = false,
       metatype = true,
       configurationFactory = true,
       policy = ConfigurationPolicy.REQUIRE)
-@Service
 @Properties({
     @Property(label = "Filter Patterns",
         description = "Patterns on which to apply this Max Age cache-control rule.",

--- a/bundle/src/main/java/com/adobe/acs/commons/http/headers/impl/MonthlyExpiresHeaderFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/http/headers/impl/MonthlyExpiresHeaderFilter.java
@@ -36,11 +36,9 @@ import java.util.Dictionary;
 @Component(
     label = "ACS AEM Commons - Dispatcher Expires Header - Monthly",
     description = "Adds an Expires header to content to enable Dispatcher TTL support.",
-    immediate = false,
     metatype = true,
     configurationFactory = true,
     policy = ConfigurationPolicy.REQUIRE)
-@Service
 @Properties({
   @Property(label = "Filter Patterns",
       description = "Patterns on which to apply this Expires rule.",

--- a/bundle/src/main/java/com/adobe/acs/commons/http/headers/impl/WeeklyExpiresHeaderFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/http/headers/impl/WeeklyExpiresHeaderFilter.java
@@ -36,11 +36,9 @@ import java.util.Dictionary;
 @Component(
     label = "ACS AEM Commons - Dispatcher Expires Header - Weekly",
     description = "Adds an Expires header to content to enable Dispatcher TTL support.",
-    immediate = false,
     metatype = true,
     configurationFactory = true,
     policy = ConfigurationPolicy.REQUIRE)
-@Service
 @Properties({
   @Property(label = "Filter Patterns",
       description = "Patterns on which to apply this Expires rule.",

--- a/bundle/src/main/java/com/adobe/acs/commons/http/injectors/AbstractHtmlRequestInjector.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/http/injectors/AbstractHtmlRequestInjector.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.felix.scr.annotations.Deactivate;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -146,7 +147,8 @@ public abstract class AbstractHtmlRequestInjector implements Filter {
         Dictionary<String, String> filterProps = new Hashtable<String, String>();
 
         filterProps.put("service.ranking", String.valueOf(ranking));
-        filterProps.put("pattern", StringUtils.defaultIfEmpty(pattern, ".*"));
+        filterProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_REGEX, StringUtils.defaultIfEmpty(pattern, ".*"));
+        filterProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT, "(" + HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME + "=*)");
         filterRegistration = ctx.getBundleContext().registerService(Filter.class.getName(), this, filterProps);
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactory.java
@@ -161,7 +161,7 @@ public final class VersionedClientlibsTransformerFactory extends AbstractGuavaCa
         this.disableVersioning = PropertiesUtil.toBoolean(props.get(PROP_DISABLE_VERSIONING), DEFAULT_DISABLE_VERSIONING);
         this.enforceMd5 = PropertiesUtil.toBoolean(props.get(PROP_ENFORCE_MD5), DEFAULT_ENFORCE_MD5);
         if (enforceMd5) {
-            Dictionary<Object, Object> filterProps = new Hashtable<Object, Object>();
+            Dictionary<String, Object> filterProps = new Hashtable<String, Object>();
             filterProps.put("sling.filter.scope", "REQUEST");
             filterProps.put("service.ranking", Integer.valueOf(0));
 

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/AemEnvironmentIndicatorFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/AemEnvironmentIndicatorFilter.java
@@ -15,6 +15,7 @@ import org.apache.sling.commons.osgi.PropertiesUtil;
 import org.apache.sling.xss.XSSAPI;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -250,7 +251,8 @@ public class AemEnvironmentIndicatorFilter implements Filter {
 
         if (StringUtils.isNotBlank(css) || StringUtils.isNotBlank(titlePrefix)) {
             Dictionary<String, String> filterProps = new Hashtable<String, String>();
-            filterProps.put("pattern", ".*");
+            filterProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_PATTERN, "/");
+            filterProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT, "(" + HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME + "=*)");
             filterRegistration = ctx.getBundleContext().registerService(Filter.class.getName(), this, filterProps);
         }
 

--- a/bundle/src/test/java/com/adobe/acs/commons/http/headers/impl/AbstractDispatcherCacheHeaderFilterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/http/headers/impl/AbstractDispatcherCacheHeaderFilterTest.java
@@ -52,6 +52,7 @@ import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.component.ComponentContext;
 
 import com.adobe.acs.commons.http.headers.impl.AbstractDispatcherCacheHeaderFilter;
+import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractDispatcherCacheHeaderFilterTest {
@@ -144,7 +145,7 @@ public class AbstractDispatcherCacheHeaderFilterTest {
             @Override
             @SuppressWarnings("unchecked")
             public boolean matches(Object item) {
-                return StringUtils.equals(pattern, ((Dictionary<String, Object>) item).get("pattern").toString());
+                return StringUtils.equals(pattern, ((Dictionary<String, Object>) item).get(HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_REGEX).toString());
             };
         };
 
@@ -175,7 +176,7 @@ public class AbstractDispatcherCacheHeaderFilterTest {
             @Override
             @SuppressWarnings("unchecked")
             public boolean matches(Object item) {
-                return StringUtils.equals(pattern, ((Dictionary<String, Object>) item).get("pattern").toString());
+                return StringUtils.equals(pattern, ((Dictionary<String, Object>) item).get(HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_REGEX).toString());
             };
         };
 
@@ -188,7 +189,7 @@ public class AbstractDispatcherCacheHeaderFilterTest {
             @Override
             @SuppressWarnings("unchecked")
             public boolean matches(Object item) {
-                return StringUtils.equals(secondPattern, ((Dictionary<String, Object>) item).get("pattern").toString());
+                return StringUtils.equals(secondPattern, ((Dictionary<String, Object>) item).get(HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_REGEX).toString());
             };
         };
 

--- a/bundle/src/test/java/com/adobe/acs/commons/logging/impl/JsonEventLoggerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/logging/impl/JsonEventLoggerTest.java
@@ -33,7 +33,7 @@ public class JsonEventLoggerTest {
     @Test
     public void testConstructMessage() throws JSONException {
         Map<String, Object> emptyProps = new LinkedHashMap<String, Object>();
-        Event empty = new Event("my/empty/topic", mapToDictionary(emptyProps));
+        Event empty = new Event("my/empty/topic", emptyProps);
 
         JSONObject jEmptyProps = new JSONObject(JsonEventLogger.constructMessage(empty));
         assertEquals("basic event, empty props", "my/empty/topic", jEmptyProps.getString("event.topics"));
@@ -41,28 +41,28 @@ public class JsonEventLoggerTest {
         Map<String, Object> stringProps = new LinkedHashMap<String, Object>();
         stringProps.put("slingevent:application", "376e48ac-b010-4905-8a35-f5413cf6a930");
 
-        Event stringEvent = new Event("my/simple/topic", mapToDictionary(stringProps));
+        Event stringEvent = new Event("my/simple/topic", stringProps);
         JSONObject jStringProps = new JSONObject(JsonEventLogger.constructMessage(stringEvent));
 
         assertEquals("simple event, string props", "376e48ac-b010-4905-8a35-f5413cf6a930", jStringProps.getString("slingevent:application"));
 
         Map<String, Object> intProps = new LinkedHashMap<String, Object>();
         intProps.put("event.job.retries", -1);
-        Event intEvent = new Event("my/simple/topic", mapToDictionary(intProps));
+        Event intEvent = new Event("my/simple/topic", intProps);
         JSONObject jIntProps = new JSONObject(JsonEventLogger.constructMessage(intEvent));
 
         assertEquals("simple event, int props", -1, jIntProps.getInt("event.job.retries"));
 
         Map<String, Object> boolProps = new LinkedHashMap<String, Object>();
         boolProps.put("event.isSimple", true);
-        Event boolEvent = new Event("my/simple/topic", mapToDictionary(boolProps));
+        Event boolEvent = new Event("my/simple/topic", boolProps);
         JSONObject jBoolProps = new JSONObject(JsonEventLogger.constructMessage(boolEvent));
 
         assertTrue("simple event, bool props", jBoolProps.getBoolean("event.isSimple"));
 
         Map<String, Object> stringArrayProps = new LinkedHashMap<String, Object>();
         stringArrayProps.put("resourceChangedAttributes", new String[]{"first", "second"});
-        Event stringArrayEvent = new Event("my/simple/topic", mapToDictionary(stringArrayProps));
+        Event stringArrayEvent = new Event("my/simple/topic", stringArrayProps);
         JSONObject jStringArray = new JSONObject(JsonEventLogger.constructMessage(stringArrayEvent));
 
         assertNotNull("complex event, string array not null", jStringArray.optJSONArray("resourceChangedAttributes"));
@@ -71,7 +71,7 @@ public class JsonEventLoggerTest {
 
         Map<String, Object> intArrayProps = new LinkedHashMap<String, Object>();
         intArrayProps.put("numbers", new Integer[]{0, 1, 2});
-        Event intArrayEvent = new Event("my/simple/topic", mapToDictionary(intArrayProps));
+        Event intArrayEvent = new Event("my/simple/topic", intArrayProps);
         JSONObject jIntArray = new JSONObject(JsonEventLogger.constructMessage(intArrayEvent));
 
         assertNotNull("complex event, int array not null", jIntArray.optJSONArray("numbers"));
@@ -83,7 +83,7 @@ public class JsonEventLoggerTest {
         Map<String, Object> headers = new LinkedHashMap<String, Object>();
         headers.put("user-agent", "curl/7.25.0");
         mapProps.put("headers", headers);
-        Event mapEvent = new Event("my/simple/topic", mapToDictionary(mapProps));
+        Event mapEvent = new Event("my/simple/topic", mapProps);
         JSONObject jMapProps = new JSONObject(JsonEventLogger.constructMessage(mapEvent));
 
         assertNotNull("complex event, map not null", jMapProps.optJSONObject("headers"));
@@ -91,16 +91,12 @@ public class JsonEventLoggerTest {
 
         Map<String, Object> stringSetProps = new LinkedHashMap<String, Object>();
         stringSetProps.put("resourceChangedAttributes", new LinkedHashSet<String>(Arrays.asList("first", "second")));
-        Event stringSetEvent = new Event("my/simple/topic", mapToDictionary(stringSetProps));
+        Event stringSetEvent = new Event("my/simple/topic", stringSetProps);
         JSONObject jStringSet = new JSONObject(JsonEventLogger.constructMessage(stringSetEvent));
 
         assertNotNull("complex event, string set not null", jStringSet.optJSONArray("resourceChangedAttributes"));
         assertEquals("complex event, string set props", "first", jStringSet.getJSONArray("resourceChangedAttributes").getString(0));
         assertEquals("complex event, string set props", "second", jStringSet.getJSONArray("resourceChangedAttributes").getString(1));
 
-    }
-
-    private static Dictionary<?, ?> mapToDictionary(Map<String, Object> props) {
-        return new Hashtable<String, Object>(props);
     }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactoryTest.java
@@ -120,7 +120,7 @@ public class VersionedClientlibsTransformerFactoryTest {
     @Before
     public void setUp() throws Exception {
         when(componentContext.getBundleContext()).thenReturn(bundleContext);
-        when(componentContext.getProperties()).thenReturn(new Hashtable<Object, Object>());
+        when(componentContext.getProperties()).thenReturn(new Hashtable<String, Object>());
         factory = new VersionedClientlibsTransformerFactory();
         filter = factory.new BadMd5VersionedClientLibsFilter();
         PrivateAccessor.setField(factory, "htmlLibraryManager", htmlLibraryManager);
@@ -152,7 +152,7 @@ public class VersionedClientlibsTransformerFactoryTest {
 
     @Test
     public void testRegisterFilter() throws Exception {
-        Hashtable<Object, Object> props = new Hashtable<Object, Object>();
+        Hashtable<String, Object> props = new Hashtable<String, Object>();
         props.put("enforce.md5", Boolean.TRUE);
         when(componentContext.getProperties()).thenReturn(props);
         factory.activate(componentContext);

--- a/pom.xml
+++ b/pom.xml
@@ -218,14 +218,14 @@
         <dependencies>
             <dependency>
                 <groupId>org.osgi</groupId>
-                <artifactId>org.osgi.core</artifactId>
-                <version>4.2.0</version>
+                <artifactId>osgi.core</artifactId>
+                <version>6.0.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>
-                <artifactId>org.osgi.compendium</artifactId>
-                <version>4.2.0</version>
+                <artifactId>osgi.cmpn</artifactId>
+                <version>6.0.0</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
This change impacts the Environment filter and the dispatcher Expires/Cache-Control filters.

Testing looks good on 6.2 and 6.3 for the Environment filter and the Cache-Control filter, but can't get the Expires header to work. I see the filter being registered and called, but the expires header always shows up at `Expires: Thu, 01 Jan 1970 00:00:00 GMT`

Hoping @bstopp has a better test setup.