### PR TITLE
Feature/1005 - Assets Folder Properties Support

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/dam/impl/AssetsFolderPropertiesSupport.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/dam/impl/AssetsFolderPropertiesSupport.java
@@ -87,6 +87,12 @@ public class AssetsFolderPropertiesSupport extends SlingSafeMethodsServlet imple
     private static final String GRANITE_UI_FORM_VALUES = "granite.ui.form.values";
 
     /**
+     * The is a reference to the OOTB AEM PostOperation that handles updates for Folder Properties; This is used below in process(..) to ensure that all OOTB behaviors are executed.
+     */
+    @Reference(target="&(sling.post.operation=dam.share.folder)(sling.servlet.methods=POST)")
+    private PostOperation folderShareHandler;
+
+    /**
      * This method is responsible for post processing POSTs to the FolderShareHandler PostOperation (:operation = dam.share.folder).
      * This method will store a whitelisted set of request parameters to their relative location off of the [sling:*Folder] node.
      *
@@ -123,22 +129,15 @@ public class AssetsFolderPropertiesSupport extends SlingSafeMethodsServlet imple
         // Do Nothing
     }
 
-    @Reference(target="&(sling.post.operation=dam.share.folder)(sling.servlet.methods=POST)")
-    private PostOperation folderShareHandler;
-
     public void process(SlingHttpServletRequest request, List<Modification> changes) throws Exception {
         if (AssetsFolderPropertiesSupportRequest.isMarked(request)) {
-            if (folderShareHandler != null) {
-                log.trace("Sending the the wrapped dam.folder.share request to the AEM Assets dam.folder.share PostOperation for final processing");
+            log.trace("Sending the the wrapped dam.folder.share request to the AEM Assets dam.folder.share PostOperation for final processing");
 
-                final AssetsFolderPropertiesSupportRequest wrappedRequest = new AssetsFolderPropertiesSupportRequest(request, DAM_FOLDER_SHARE_OPERATION);
+            final AssetsFolderPropertiesSupportRequest wrappedRequest = new AssetsFolderPropertiesSupportRequest(request, DAM_FOLDER_SHARE_OPERATION);
 
-                folderShareHandler.run(wrappedRequest, new DummyPostResponse(), new SlingPostProcessor[]{});
+            folderShareHandler.run(wrappedRequest, new DummyPostResponse(), new SlingPostProcessor[]{});
 
-                log.trace("Processed the the wrapped dam.folder.share request with the AEM Assets dam.folder.share PostOperation");
-            } else {
-                log.error("Folder Share Handler PostOperation is NOT active.");
-            }
+            log.trace("Processed the the wrapped dam.folder.share request with the AEM Assets dam.folder.share PostOperation");
         }
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/dam/impl/AssetsFolderPropertiesSupport.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/dam/impl/AssetsFolderPropertiesSupport.java
@@ -1,0 +1,248 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.dam.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.felix.scr.annotations.*;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.apache.sling.api.wrappers.CompositeValueMap;
+import org.apache.sling.api.wrappers.SlingHttpServletRequestWrapper;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.apache.sling.jcr.resource.JcrResourceConstants;
+import org.apache.sling.servlets.post.AbstractPostResponse;
+import org.apache.sling.servlets.post.Modification;
+import org.apache.sling.servlets.post.PostOperation;
+import org.apache.sling.servlets.post.SlingPostProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+
+@Component(
+        label = "ACS AEM Commons - Assets Folder Properties Support",
+        metatype = true,
+        policy = ConfigurationPolicy.REQUIRE,
+        immediate = true
+)
+@Properties({
+        @Property(
+                name = "service.ranking",
+                intValue = -2000,
+                propertyPrivate = true
+        ),
+        @Property(
+                name = "sling.filter.scope",
+                value = "REQUEST",
+                propertyPrivate = true
+        ),
+        @Property(
+                name = "sling.filter.pattern",
+                value = "/content/dam/.*",
+                propertyPrivate = true
+        ),
+        @Property(
+                name = "sling.servlet.methods",
+                value = "GET",
+                propertyPrivate = true
+        ),
+        @Property(
+                name = "sling.servlet.resourceTypes",
+                value = "acs-commons/touchui-widgets/asset-folder-properties-support",
+                propertyPrivate = true
+        )
+})
+@Service
+public class AssetsFolderPropertiesSupport extends SlingSafeMethodsServlet implements Filter, SlingPostProcessor {
+    private static final Logger log = LoggerFactory.getLogger(AssetsFolderPropertiesSupport.class);
+
+    private static final String DAM_PATH_PREFIX = "/content/dam";
+    private static final String POST_METHOD = "post";
+    private static final String OPERATION = ":operation";
+    private static final String DAM_FOLDER_SHARE_OPERATION = "dam.share.folder";
+    private static final String GRANITE_UI_FORM_VALUES = "granite.ui.form.values";
+
+    /**
+     * This method is responsible for post processing POSTs to the FolderShareHandler PostOperation (:operation = dam.share.folder).
+     * This method will store a whitelisted set of request parameters to their relative location off of the [sling:*Folder] node.
+     *
+     * Note, this is executed AFTER the OOTB FolderShareHandler PostOperation.
+     *
+     * At this time this method only supports single-value Strings and ignores all @typeHints.
+     *
+     * This method must fail fast via the accepts(...) method.
+     *
+     * @param servletRequest the request object
+     * @param servletResponse the response object
+     * @param chain the filter chain
+     * @throws IOException
+     * @throws ServletException
+     */
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain chain) throws IOException, ServletException {
+        final SlingHttpServletRequest request = (SlingHttpServletRequest) servletRequest;
+        final SlingHttpServletResponse response = (SlingHttpServletResponse) servletResponse;
+
+        if (!accepts(request)) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        log.trace("ACS AEM Commons Assets Folder Properties Support applied to POST Request");
+        chain.doFilter(new AssetsFolderPropertiesSupportRequest(request, null), response);
+    }
+
+    public void init(FilterConfig filterConfig) throws ServletException {
+        // Do Nothing
+    }
+
+    public void destroy() {
+        // Do Nothing
+    }
+
+    @Reference(target="&(sling.post.operation=dam.share.folder)(sling.servlet.methods=POST)")
+    private PostOperation folderShareHandler;
+
+    public void process(SlingHttpServletRequest request, List<Modification> changes) throws Exception {
+        if (AssetsFolderPropertiesSupportRequest.isMarked(request)) {
+            if (folderShareHandler != null) {
+                log.trace("Sending the the wrapped dam.folder.share request to the AEM Assets dam.folder.share PostOperation for final processing");
+
+                final AssetsFolderPropertiesSupportRequest wrappedRequest = new AssetsFolderPropertiesSupportRequest(request, DAM_FOLDER_SHARE_OPERATION);
+
+                folderShareHandler.run(wrappedRequest, new DummyPostResponse(), new SlingPostProcessor[]{});
+
+                log.trace("Processed the the wrapped dam.folder.share request with the AEM Assets dam.folder.share PostOperation");
+            } else {
+                log.error("Folder Share Handler PostOperation is NOT active.");
+            }
+        }
+    }
+
+    /**
+     * Gateway method the Filter uses to determine if the request is a candidate for processing by Assets Folder Properties Support.
+     * These checks should be fast and fail broadest and fastest first.
+     *
+     * @param request the request
+     * @return true if Assets Folder Properties Support should process this request.
+     */
+    protected boolean accepts(SlingHttpServletRequest request) {
+        if (!StringUtils.equalsIgnoreCase(POST_METHOD, request.getMethod())) {
+            // Only POST methods are processed
+            return false;
+        } else if (!DAM_FOLDER_SHARE_OPERATION.equals(request.getParameter(OPERATION))) {
+            // Only requests with :operation=dam.share.folder are processed
+            return false;
+        } else if (!StringUtils.startsWith(request.getResource().getPath(), DAM_PATH_PREFIX)) {
+            // Only requests under /content/dam are processed
+            return false;
+        } else if (!request.getResource().isResourceType(JcrResourceConstants.NT_SLING_FOLDER)
+                && !request.getResource().isResourceType(JcrResourceConstants.NT_SLING_ORDERED_FOLDER)) {
+            // Only requests to sling:Folders or sling:Ordered folders are processed
+            return false;
+        }
+
+        // If the above checks do not fail, treat as a valid request
+        return true;
+    }
+
+    /**
+     * This method handles the READING of the properties so that granite UI widgets can display stored data in the form.
+     * This needs to be included AFTER 	/apps/dam/gui/content/assets/foldersharewizard/jcr:content/body/items/form/items/wizard/items/settingStep/items/fixedColumns/items/fixedColumn2/items/tabs/items/tab1/items/folderproperties
+     * such that it can augment the Property map constructed by that OOTB script.
+     *
+     * Note that this exposes a value map for the [sling:*Folder] node, and NOT the [sling:*Folder]/jcr:content, so properties must be prefixed with jcr:content/...
+     *
+     * This can be achieved by creating a resource merge:
+     * /apps/dam/gui/content/assets/foldersharewizard/jcr:content/body/items/form/items/wizard/items/settingStep/items/fixedColumns/items/fixedColumn2/items/tabs/items/tab1/items/folderproperties/assets-folder-properties-support@sling:resourceType = acs-commons/touchui-widgets/asset-folder-properties-support
+     * /apps/dam/gui/content/assets/foldersharewizard/jcr:content/body/items/form/items/wizard/items/settingStep/items/fixedColumns/items/fixedColumn2/items/tabs/items/tab1/items/folderproperties/assets-folder-properties-support@sling:orderBefore = titlefield
+     *
+     * @param request the request object
+     * @param response the response object
+     * @throws ServletException
+     * @throws IOException
+     */
+    @Override
+    protected final void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response) throws ServletException, IOException {
+        final Resource suffixResource = request.getResourceResolver().resolve(request.getRequestPathInfo().getSuffix());
+        if (suffixResource == null) { return; }
+
+        log.trace("AssetsFolderPropertiesSupport GET method for folder resource [ {} ]", suffixResource.getPath());
+
+        ValueMap formProperties = (ValueMap) request.getAttribute(GRANITE_UI_FORM_VALUES);
+
+        if (formProperties == null) {
+            formProperties = new ValueMapDecorator(new HashMap<String, Object>());
+        }
+
+        request.setAttribute(GRANITE_UI_FORM_VALUES, new CompositeValueMap(formProperties, suffixResource.getValueMap(), true));
+    }
+
+    /** Synthetic Objects to allow this request to traverse the request processing stack **/
+
+    protected class DummyPostResponse extends AbstractPostResponse {
+        protected void doSend(HttpServletResponse response) throws IOException {
+            // Do nothing
+        }
+
+        public void onChange(String type, String... arguments) {
+            // Do nothing
+        }
+    }
+
+
+    /**
+     * Sling HTTP Request wrapper that masks the :operation so the default Sling POST Servlet can be invoked.
+     */
+    protected static class AssetsFolderPropertiesSupportRequest extends SlingHttpServletRequestWrapper {
+        private static  String REQUEST_ATTR_KEY = AssetsFolderPropertiesSupportRequest.class.getName();
+
+        private String operationValue;
+
+        public AssetsFolderPropertiesSupportRequest(SlingHttpServletRequest request, String operationValue) {
+            super(request);
+            markRequest(request);
+            this.operationValue = operationValue;
+        }
+
+        public static void markRequest(SlingHttpServletRequest request) {
+            request.setAttribute(REQUEST_ATTR_KEY, true);
+        }
+
+        protected static boolean isMarked(SlingHttpServletRequest request) {
+            return request.getAttribute(REQUEST_ATTR_KEY) != null;
+        }
+
+        public String getParameter(String key) {
+            if (isMarked(this) && OPERATION.equals(key)) {
+                return operationValue;
+            } else {
+                return super.getParameter(key);
+            }
+        }
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/dam/impl/AssetsFolderPropertiesSupport.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/dam/impl/AssetsFolderPropertiesSupport.java
@@ -46,7 +46,6 @@ import java.util.List;
 
 @Component(
         label = "ACS AEM Commons - Assets Folder Properties Support",
-        metatype = true,
         policy = ConfigurationPolicy.REQUIRE,
         immediate = true
 )

--- a/bundle/src/test/java/com/adobe/acs/commons/dam/impl/AssetsFolderPropertiesSupportTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/dam/impl/AssetsFolderPropertiesSupportTest.java
@@ -1,0 +1,185 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.dam.impl;
+
+import com.adobe.cq.commerce.common.ValueMapDecorator;
+import com.google.common.collect.ImmutableMap;
+import org.apache.jackrabbit.JcrConstants;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.jcr.resource.JcrResourceConstants;
+import org.apache.sling.servlets.post.PostOperation;
+import org.apache.sling.servlets.post.PostResponse;
+import org.apache.sling.servlets.post.SlingPostProcessor;
+import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.apache.sling.testing.mock.sling.servlet.MockRequestPathInfo;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AssetsFolderPropertiesSupportTest {
+
+    @Rule
+    public final SlingContext slingContext = new SlingContext(ResourceResolverType.RESOURCERESOLVER_MOCK);
+
+    @Rule
+    public final OsgiContext osgiContext = new OsgiContext();
+
+    MockSlingHttpServletRequest request;
+
+    MockSlingHttpServletResponse response;
+
+    Resource slingFolderResource;
+
+    Resource slingOrderedFolderResource;
+
+    Resource invalidResourceTypeResource;
+
+    Resource invalidPathResource;
+
+    @Mock
+    PostOperation postOperation;
+
+    @InjectMocks
+    AssetsFolderPropertiesSupport assetsFolderPropertiesSupport = new AssetsFolderPropertiesSupport();
+
+    @Before
+    public void setUp() throws Exception {
+
+        request = new MockSlingHttpServletRequest(slingContext.resourceResolver(), osgiContext.bundleContext());
+        response = new MockSlingHttpServletResponse();
+
+        slingFolderResource = slingContext.create().resource("/content/dam/folder", ImmutableMap.<String, Object>builder()
+                .put(JcrConstants.JCR_PRIMARYTYPE, JcrResourceConstants.NT_SLING_FOLDER)
+                .build());
+
+        slingOrderedFolderResource = slingContext.create().resource("/content/dam/folder/ordered", ImmutableMap.<String, Object>builder()
+                .put(JcrConstants.JCR_PRIMARYTYPE, JcrResourceConstants.NT_SLING_ORDERED_FOLDER)
+                .build());
+
+        invalidResourceTypeResource = slingContext.create().resource("/content/dam/folder/asset.png", ImmutableMap.<String, Object>builder()
+                .put(JcrConstants.JCR_PRIMARYTYPE, "dam:Asset")
+                .build());
+
+        invalidPathResource
+                = slingContext.create().resource("/content/site/pages", ImmutableMap.<String, Object>builder()
+                .put(JcrConstants.JCR_PRIMARYTYPE, JcrResourceConstants.NT_SLING_FOLDER)
+                .build());
+
+        request.setResource(slingFolderResource);
+        request.setParameterMap(ImmutableMap.<String, Object>builder().put(":operation", "dam.share.folder").build());
+        request.setMethod("post");
+    }
+
+    @Test
+    public void accepts_slingFolder() throws Exception {
+        request.setResource(slingFolderResource);
+
+        assertTrue(assetsFolderPropertiesSupport.accepts(request));
+    }
+
+    @Test
+    public void accepts_slingOrderedFolder() throws Exception {
+        request.setResource(slingOrderedFolderResource);
+
+        assertTrue(assetsFolderPropertiesSupport.accepts(request));
+    }
+
+    @Test
+    public void accepts_rejects_method() throws Exception {
+        request.setMethod("get");
+
+        assertFalse(assetsFolderPropertiesSupport.accepts(request));
+    }
+
+    @Test
+    public void accepts_rejects_path() throws Exception {
+        request.setResource(invalidPathResource);
+
+        assertFalse(assetsFolderPropertiesSupport.accepts(request));
+    }
+
+    @Test
+    public void accepts_rejects_resourceType() throws Exception {
+        request.setResource(invalidResourceTypeResource);
+
+        assertFalse(assetsFolderPropertiesSupport.accepts(request));
+    }
+
+    @Test
+    public void accepts_rejects_operation() throws Exception {
+        request.setParameterMap(ImmutableMap.<String, Object>builder().put(":operation", "not.dam.folder.share").build());
+
+        assertFalse(assetsFolderPropertiesSupport.accepts(request));
+    }
+
+    @Test
+    public void process() throws Exception {
+        assetsFolderPropertiesSupport.process(new AssetsFolderPropertiesSupport.AssetsFolderPropertiesSupportRequest(request, null), new ArrayList<>());
+
+        verify(postOperation, times(1)).run(any(AssetsFolderPropertiesSupport.AssetsFolderPropertiesSupportRequest.class), any(PostResponse.class), any(SlingPostProcessor[].class));
+    }
+
+    @Test
+    public void process_skips() throws Exception {
+        assetsFolderPropertiesSupport.process(request, new ArrayList<>());
+
+        verify(postOperation, never()).run(eq(request), any(PostResponse.class), any(SlingPostProcessor[].class));
+    }
+
+    @Test
+    public void doGet() throws Exception {
+        final ValueMap graniteUiFormValues = new ValueMapDecorator(new HashMap<>());
+        graniteUiFormValues.put("ootb", "ootb value");
+
+        slingContext.create().resource("/content/dam/do-get/folder", ImmutableMap.<String, Object>builder().put("resource", "resource value").build());
+
+        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(slingContext.resourceResolver(), osgiContext.bundleContext());
+        MockRequestPathInfo requestPathInfo = (MockRequestPathInfo)request.getRequestPathInfo();
+        requestPathInfo.setResourcePath("wizard.html");
+        requestPathInfo.setSuffix("/content/dam/do-get/folder");
+        request.setAttribute("granite.ui.form.values", graniteUiFormValues);
+
+        assetsFolderPropertiesSupport.doGet(request, response);
+
+        ValueMap actual = (ValueMap) request.getAttribute("granite.ui.form.values");
+
+        assertEquals("ootb value", actual.get("ootb", String.class));
+        assertEquals("resource value", actual.get("resource", String.class));
+    }
+}


### PR DESCRIPTION
Resolves #1005 

Re-factored to leverage the default Sling POST Servlet, and invokes the OOTB FolderShareHandler via a PostProcessor.

* Config policy required
* Granite UI names are off the sling:Folder and NOT the [sling:*Folder]/jcr:content

Example property for setting Brand Portal mcConfig property

![image](https://cloud.githubusercontent.com/assets/1451868/26408287/5aaa18ee-406b-11e7-96d0-4fe66f9d24b6.png)

[acs-aem-commons-assets-folder-properties-support-1.0.0.zip](https://github.com/Adobe-Consulting-Services/acs-aem-commons/files/1025865/acs-aem-commons-assets-folder-properties-support-1.0.0.zip)
