### PR TITLE
Feature/1008 - Email subject mangled for non-latin chars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .settings/
 target/
 .DS_Store
+lib/
 
 #Intellij
 .idea/
@@ -22,3 +23,4 @@ content/src/main/content/jcr_root/etc/designs/.content.xml
 content/src/main/content/jcr_root/etc/clientlibs/.content.xml
 .pmd
 .metadata
+

--- a/bundle/src/main/java/com/adobe/acs/commons/email/EmailServiceConstants.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/email/EmailServiceConstants.java
@@ -28,6 +28,7 @@ import aQute.bnd.annotation.ProviderType;
 @ProviderType
 public final class EmailServiceConstants {
 
+
     private EmailServiceConstants() {
 
     }
@@ -43,4 +44,11 @@ public final class EmailServiceConstants {
      * map to the sendEmail() function.
      */
     public static final String SENDER_NAME = "senderName";
+
+
+    /**
+     * Subject line variable used to specify the subject in the input parameter map.
+     */
+    public static final String SUBJECT = "subject";
+
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/email/impl/EmailServiceImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/email/impl/EmailServiceImpl.java
@@ -221,6 +221,11 @@ public final class EmailServiceImpl implements EmailService {
             email.setFrom(params.get(EmailServiceConstants.SENDER_EMAIL_ADDRESS));
         }
 
+        // #1008 setting the subject via the setSubject(..) parameter.
+        if (params.containsKey(EmailServiceConstants.SUBJECT)) {
+            email.setSubject(params.get(EmailServiceConstants.SUBJECT));
+        }
+
         return email;
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/email/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/email/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Email Service.
  */
-@aQute.bnd.annotation.Version("1.1.0")
+@aQute.bnd.annotation.Version("1.2.0")
 package com.adobe.acs.commons.email;

--- a/bundle/src/test/java/com/adobe/acs/commons/email/EmailServiceImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/email/EmailServiceImplTest.java
@@ -67,7 +67,7 @@ public class EmailServiceImplTest {
     private ResourceResolver resourceResolver;
 
     @Mock
-    private MessageGateway<SimpleEmail> messageGateway;
+    private MessageGateway<SimpleEmail> messageGatewaySimpleEmail;
 
     @Mock
     private MessageGateway<HtmlEmail> messageGatewayHtmlEmail;
@@ -90,7 +90,7 @@ public class EmailServiceImplTest {
 
         MockitoAnnotations.initMocks(this);
 
-        when(messageGatewayService.getGateway(SimpleEmail.class)).thenReturn(messageGateway);
+        when(messageGatewayService.getGateway(SimpleEmail.class)).thenReturn(messageGatewaySimpleEmail);
         when(messageGatewayService.getGateway(HtmlEmail.class)).thenReturn(messageGatewayHtmlEmail);
         when(resourceResolverFactory.getServiceResourceResolver(Matchers.anyMap())).thenReturn(resourceResolver);
         when(resourceResolver.adaptTo(Session.class)).thenReturn(session);
@@ -132,7 +132,7 @@ public class EmailServiceImplTest {
 
         List<String> failureList = emailService.sendEmail(emailTemplatePath, params, recipients);
 
-        verify(messageGateway, times(recipients.length)).send(captor.capture());
+        verify(messageGatewaySimpleEmail, times(recipients.length)).send(captor.capture());
 
         assertEquals(expectedSenderEmailAddress, captor.getValue().getFromAddress().getAddress());
         assertEquals(expectedSenderName, captor.getValue().getFromAddress().getPersonal());
@@ -166,7 +166,7 @@ public class EmailServiceImplTest {
 
         List<String> failureList = emailService.sendEmail(emailTemplatePath, params, recipient);
 
-        verify(messageGateway, times(1)).send(captor.capture());
+        verify(messageGatewaySimpleEmail, times(1)).send(captor.capture());
 
         assertEquals(expectedSenderEmailAddress, captor.getValue().getFromAddress().getAddress());
         assertEquals(expectedSenderName, captor.getValue().getFromAddress().getPersonal());
@@ -252,6 +252,22 @@ public class EmailServiceImplTest {
         emailService.sendEmail(templatePath, params, recipient);
      }
 
+    @Test
+    public final void testSubjectSetting() throws Exception {
+        final String expectedSubject = "问候";
+
+        final Map<String, String> params = new HashMap<String, String>();
+        params.put("subject", expectedSubject);
+
+        final String recipient =  "upasanac@acs.com";
+
+        ArgumentCaptor<SimpleEmail> captor = ArgumentCaptor.forClass(SimpleEmail.class);
+
+        emailService.sendEmail(emailTemplatePath, params, recipient);
+        verify(messageGatewaySimpleEmail, times(1)).send(captor.capture());
+
+        assertEquals(expectedSubject, captor.getValue().getSubject());
+    }
 
     @After
     public final void tearDown() {


### PR DESCRIPTION
Resolves issue w Subject mangling for non latin characters.. fixed provided by  @shivakumarc9_twitter on Gitter.

Example population of the subject...

```
emailParams.put(ContactUsUtils.SUBJECT, contactUsModel.getButtonTitle()+ " - "+ contactUsModel.getQuestionCategory());
```