### PR TITLE
Add source attachments for jar files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,11 @@
                     <version>2.5</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.0.1</version>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.sling</groupId>
                     <artifactId>maven-sling-plugin</artifactId>
                     <version>2.1.0</version>
@@ -212,6 +217,24 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-source-plugin</artifactId>
+              <executions>
+                  <execution>
+                      <id>attach-sources</id>
+                      <phase>verify</phase>
+                      <goals>
+                          <goal>jar-no-fork</goal>
+                      </goals>
+                      <configuration>
+                          <excludeResources>true</excludeResources>
+                      </configuration>
+                  </execution>
+              </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <scm>


### PR DESCRIPTION
Having source attachments is useful when browsing class files in the Java IDE.