### PR TITLE
ErrorPageHandlerImpl: Fix default value for not-found behavior

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/errorpagehandler/impl/ErrorPageHandlerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/errorpagehandler/impl/ErrorPageHandlerImpl.java
@@ -139,7 +139,8 @@ public final class ErrorPageHandlerImpl implements ErrorPageHandlerService {
             options = {
                     @PropertyOption(value = "Redirect to Login", name = REDIRECT_TO_LOGIN),
                     @PropertyOption(value = "Respond with 404", name = RESPOND_WITH_404)
-            })
+            },
+            value = DEFAULT_NOT_FOUND_DEFAULT_BEHAVIOR)
     private static final String PROP_NOT_FOUND_DEFAULT_BEHAVIOR = "not-found.behavior";
 
 


### PR DESCRIPTION
Make sure the default not-found behavior is also displayed correctly in OSGi config dialog.
Otherwise the default behavior is set correctly if no value is set in the osgi config, but is displayed wrong in the dialog of felix console.