### PR TITLE
Feature/1043 1044 - Package Replication improvements

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/PackageHelperImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/PackageHelperImpl.java
@@ -37,10 +37,7 @@ import org.apache.jackrabbit.vault.packaging.PackageException;
 import org.apache.jackrabbit.vault.packaging.PackageId;
 import org.apache.jackrabbit.vault.packaging.Packaging;
 import org.apache.jackrabbit.vault.packaging.Version;
-import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.json.JSONArray;
 import org.apache.sling.commons.json.JSONException;
 import org.apache.sling.commons.json.JSONObject;
@@ -105,7 +102,7 @@ public final class PackageHelperImpl implements PackageHelper {
                 dstParentNode.getSession().save();
             }
         } catch (RepositoryException e) {
-            log.error("Could not add package thumbnail: {}", e.getMessage());
+            log.error("Could not add package thumbnail: {}", e);
         }
     }
 
@@ -399,7 +396,7 @@ public final class PackageHelperImpl implements PackageHelper {
             json.put("msg", msg);
             return json.toString();
         } catch (JSONException e) {
-            log.error("Error creating JSON Error response message: {}", e.getMessage());
+            log.error("Error creating JSON Error response message: {}", e);
             return JSON_EXCEPTION_MSG;
         }
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/replication/status/impl/JcrPackageReplicationStatusEventHandler.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/replication/status/impl/JcrPackageReplicationStatusEventHandler.java
@@ -344,7 +344,7 @@ public class JcrPackageReplicationStatusEventHandler implements JobConsumer, Eve
      * @param paths the list of paths to resolve to Jcr Packages
      * @return a list of Jcr Packages that correspond to the provided paths
      */
-    List<JcrPackage> getJcrPackages(final ResourceResolver resourceResolver, final String[] paths) {
+    private List<JcrPackage> getJcrPackages(final ResourceResolver resourceResolver, final String[] paths) {
         final List<JcrPackage> packages = new ArrayList<JcrPackage>();
 
         for (final String path : paths) {

--- a/bundle/src/main/java/com/adobe/acs/commons/replication/status/impl/JcrPackageReplicationStatusEventHandler.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/replication/status/impl/JcrPackageReplicationStatusEventHandler.java
@@ -246,16 +246,12 @@ public class JcrPackageReplicationStatusEventHandler implements JobConsumer, Eve
                                 jcrPackage.getDefinition().getId());
                     }
                 } catch (RepositoryException e) {
-                    log.error("RepositoryException occurred updating replication status for contents of package");
-                    log.error(e.getMessage());
-
+                    log.error("RepositoryException occurred updating replication status for contents of package", e);
                 } catch (IOException e) {
-                    log.error("IOException occurred updating replication status for contents of package");
-                    log.error(e.getMessage());
+                    log.error("IOException occurred updating replication status for contents of package", e);
 
                 } catch (PackageException e) {
-                    log.error("Could not retrieve the Packages contents.");
-                    log.error(e.getMessage());
+                    log.error("Could not retrieve the Packages contents.", e);
                 }
             }
         } catch (LoginException e) {
@@ -304,7 +300,7 @@ public class JcrPackageReplicationStatusEventHandler implements JobConsumer, Eve
         for (final String path : paths) {
             final Resource eventResource = resourceResolver.getResource(path);
 
-            JcrPackage jcrPackage;
+            JcrPackage jcrPackage = null;
 
             try {
                 jcrPackage = packaging.open(eventResource.adaptTo(Node.class), false);
@@ -313,6 +309,10 @@ public class JcrPackageReplicationStatusEventHandler implements JobConsumer, Eve
                 }
             } catch (RepositoryException e) {
                 log.warn("Error checking if the path [ {} ] is a JCR Package.", path);
+            } finally {
+                if (jcrPackage != null) {
+                    jcrPackage.close();
+                }
             }
 
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/replication/status/impl/JcrPackageReplicationStatusEventHandler.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/replication/status/impl/JcrPackageReplicationStatusEventHandler.java
@@ -37,7 +37,6 @@ import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.PropertyOption;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.Service;
-import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.vault.packaging.JcrPackage;
 import org.apache.jackrabbit.vault.packaging.PackageException;
 import org.apache.jackrabbit.vault.packaging.Packaging;
@@ -46,7 +45,6 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.api.resource.ResourceUtil;
-import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.commons.osgi.PropertiesUtil;
 import org.apache.sling.event.jobs.Job;
 import org.apache.sling.event.jobs.JobManager;
@@ -416,15 +414,11 @@ public class JcrPackageReplicationStatusEventHandler implements JobConsumer, Eve
      * @throws RepositoryException
      */
     private Calendar getJcrPackageLastModified(final ResourceResolver resourceResolver,
-                                               final JcrPackage jcrPackage) throws RepositoryException {
+                                               final JcrPackage jcrPackage) throws RepositoryException, IOException {
         if (ReplicatedAt.CURRENT_TIME.equals(this.replicatedAt)) {
             return Calendar.getInstance();
         } else {
-            final String path = jcrPackage.getNode().getPath();
-            final Resource resource = resourceResolver.getResource(path).getChild(JcrConstants.JCR_CONTENT);
-            final ValueMap properties = resource.adaptTo(ValueMap.class);
-
-            return properties.get(JcrConstants.JCR_LASTMODIFIED, Calendar.class);
+            return jcrPackage.getPackage().getCreated();
         }
     }
 

--- a/bundle/src/test/java/com/adobe/acs/commons/replication/status/impl/JcrPackageReplicationStatusEventHandlerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/replication/status/impl/JcrPackageReplicationStatusEventHandlerTest.java
@@ -17,7 +17,6 @@ import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.event.jobs.Job;
 import org.apache.sling.event.jobs.JobManager;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -145,13 +144,12 @@ public class JcrPackageReplicationStatusEventHandlerTest {
         when(contentNode3parent.isNodeType("sling:OrderedFolder")).thenReturn(true);
     }
 
-    @After
-    public void tearDown() throws Exception {
-
-    }
-
     @Test
     public void testProcess() throws Exception {
+        Map<String, String> config = new HashMap<>();
+        config.put("replicated-by.override", "Package Replication");
+        eventHandler.activate(config);
+
         eventHandler.process(job);
 
         verify(replicationStatusManager, times(1)).setReplicationStatus(
@@ -161,7 +159,6 @@ public class JcrPackageReplicationStatusEventHandlerTest {
                 eq(ReplicationStatusManager.Status.ACTIVATED),
                 eq(contentResource1), eq(contentResource2), eq(contentResource3));
     }
-
 
     @Test
     public void testHandleEvent() throws LoginException {

--- a/bundle/src/test/java/com/adobe/acs/commons/replication/status/impl/JcrPackageReplicationStatusEventHandlerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/replication/status/impl/JcrPackageReplicationStatusEventHandlerTest.java
@@ -10,6 +10,7 @@ import org.apache.jackrabbit.vault.packaging.JcrPackage;
 import org.apache.jackrabbit.vault.packaging.JcrPackageDefinition;
 import org.apache.jackrabbit.vault.packaging.PackageId;
 import org.apache.jackrabbit.vault.packaging.Packaging;
+import org.apache.jackrabbit.vault.packaging.VaultPackage;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -93,6 +94,7 @@ public class JcrPackageReplicationStatusEventHandlerTest {
         final Resource packageResource = mock(Resource.class);
         final Node packageNode = mock(Node.class);
         final JcrPackage jcrPackage = mock(JcrPackage.class);
+        final VaultPackage vaultPackage = mock(VaultPackage.class);
         final Node jcrPackageNode = mock(Node.class);
         final JcrPackageDefinition jcrPackageDefinition = mock(JcrPackageDefinition.class);
         final Resource jcrPackageJcrContent = mock(Resource.class);
@@ -120,6 +122,9 @@ public class JcrPackageReplicationStatusEventHandlerTest {
         when(jcrPackage.getNode()).thenReturn(jcrPackageNode);
         when(jcrPackageNode.getPath()).thenReturn(PACKAGE_PATH);
         when(packageResource.getChild("jcr:content")).thenReturn(jcrPackageJcrContent);
+
+        when(jcrPackage.getPackage()).thenReturn(vaultPackage);
+        when(vaultPackage.getCreated()).thenReturn(calendar);
 
         Map<String, Object> properties = new HashMap<String, Object>();
         properties.put(JcrConstants.JCR_LASTMODIFIED, calendar);


### PR DESCRIPTION
Combines updated to JCR Package Replication #1043 and #1043

* Closes package after opening to prevent resource leakage
* Improves "replicated by" to default to the actual user that performs the replication. Legacy OSGi configuration available to allow a named user to be assigned for all package replication (leave this value blank to use the real user)