### PR TITLE
#1094 - QR Code bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 [Unreleased]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-3.10.0...HEAD
 
+### Fixed
+
+- #1094: Fixed issue with QR Code where its on by default. This requires toggling QR Code on and off to reset the client lib category.  
 
 ## [3.10.0] - 2017-08-20
 

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/QrCodeServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/QrCodeServlet.java
@@ -59,7 +59,7 @@ public class QrCodeServlet extends SlingSafeMethodsServlet {
         response.setCharacterEncoding("UTF-8");
 
         if (externalizer == null) {
-            log.error("Externalizer is not configured. This is required for QR Code servlet to work.");
+            log.warn("Externalizer is not configured. This is required for QR Code servlet to work.");
             response.setStatus(SlingHttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 
         } else if (request.getResource().getValueMap().get(PN_ENABLED, false)) {
@@ -82,11 +82,11 @@ public class QrCodeServlet extends SlingSafeMethodsServlet {
                 response.getWriter().write(json.toString());
                 response.getWriter().flush();
             } else {
-                log.error("Externalizer configuration for AEM Publish did not yield a valid URL");
+                log.warn("Externalizer configuration for AEM Publish did not yield a valid URL");
                 response.setStatus(SlingHttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             }
         } else {
-            log.error("Externalizer configuration for AEM Publish did not yield a valid URL");
+            log.warn("Externalizer configuration for AEM Publish did not yield a valid URL");
             response.setStatus(SlingHttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         }
     }

--- a/content/src/main/content/jcr_root/etc/acs-commons/qr-code/_jcr_content/clientlib-authoring/.content.xml
+++ b/content/src/main/content/jcr_root/etc/acs-commons/qr-code/_jcr_content/clientlib-authoring/.content.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
-    categories="[cq.authoring.editor.hook]"
+    categories="[]"
     dependencies="[cq.authoring.editor,acs-commons.vendor.qr-code]"/>


### PR DESCRIPTION
* Defaulted QR Code to be off (cq.author.editor.hook clientlib category was incorrectly set by default)
* May require toggling QR Code button to clear existing category
* Dropped some log levels to WARN