### PR TITLE
New framework: JcrPersist - non-instrusive ORM for JCR

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/JcrPersist.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/JcrPersist.java
@@ -51,8 +51,6 @@ import com.day.cq.wcm.api.Page;
  * using the JCR without any intrusion. This also allows the system
  * to be more extensible.
  * 
- * @author sangupta
- *
  */
 public class JcrPersist {
 	

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/JcrPersist.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/JcrPersist.java
@@ -1,0 +1,264 @@
+package com.adobe.acs.commons.jcrpersist;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.jcr.RepositoryException;
+
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.acs.commons.jcrpersist.annotation.AEMProperty;
+import com.adobe.acs.commons.jcrpersist.annotation.AEMPropertyExclude;
+import com.adobe.acs.commons.jcrpersist.extension.ValueMapReader;
+import com.adobe.acs.commons.jcrpersist.util.ReflectionUtils;
+import com.day.cq.commons.jcr.JcrConstants;
+import com.day.cq.wcm.api.Page;
+
+/**
+ * Main class that does the magic of reading/writing POJO directly
+ * using the JCR without any intrusion. This also allows the system
+ * to be more extensible.
+ * 
+ * @author sangupta
+ *
+ */
+public class JcrPersist {
+	
+	/**
+	 * My private logger
+	 */
+	private static final Logger LOGGER = LoggerFactory.getLogger(JcrPersist.class);
+	
+	/**
+	 * Classes that correspond to basic parameter types, which are handled directly in code
+	 */
+	static Set<Class<?>> BASIC_PARAMS = new HashSet<>();
+	
+	/**
+	 * List of all registered custom value-map readers
+	 */
+	static Map<String, ValueMapReader> CUSTOM_VALUE_MAP_READERS = new HashMap<>();
+	
+	static Map<Class<?>, ResourceType> NODE_TYPE_FOR_CLASS = new HashMap<>();
+	
+	static final ResourceType NT_UNSTRUCTURED_RESOURCE_TYPE = new ResourceType(JcrConstants.NT_UNSTRUCTURED, null);
+	
+	/**
+	 * Add default values
+	 */
+	static {
+		// primitives
+		BASIC_PARAMS.add(byte.class);
+		BASIC_PARAMS.add(char.class);
+		BASIC_PARAMS.add(short.class);
+		BASIC_PARAMS.add(int.class);
+		BASIC_PARAMS.add(long.class);
+		BASIC_PARAMS.add(float.class);
+		BASIC_PARAMS.add(double.class);
+		BASIC_PARAMS.add(boolean.class);
+		
+		// primitive boxed
+		BASIC_PARAMS.add(Byte.class);
+		BASIC_PARAMS.add(Character.class);
+		BASIC_PARAMS.add(Short.class);
+		BASIC_PARAMS.add(Integer.class);
+		BASIC_PARAMS.add(Long.class);
+		BASIC_PARAMS.add(Float.class);
+		BASIC_PARAMS.add(Double.class);
+		BASIC_PARAMS.add(Boolean.class);
+		
+		// other basic types
+		BASIC_PARAMS.add(String.class);
+		BASIC_PARAMS.add(Calendar.class);
+		BASIC_PARAMS.add(Date.class);
+		BASIC_PARAMS.add(URI.class);
+		BASIC_PARAMS.add(BigDecimal.class);
+		
+		// primitives array
+		BASIC_PARAMS.add(byte[].class);
+		BASIC_PARAMS.add(char[].class);
+		BASIC_PARAMS.add(short[].class);
+		BASIC_PARAMS.add(int[].class);
+		BASIC_PARAMS.add(long[].class);
+		BASIC_PARAMS.add(float[].class);
+		BASIC_PARAMS.add(double[].class);
+		BASIC_PARAMS.add(boolean[].class);
+		
+		// primitive boxed arrays
+		BASIC_PARAMS.add(Byte[].class);
+		BASIC_PARAMS.add(Character[].class);
+		BASIC_PARAMS.add(Short[].class);
+		BASIC_PARAMS.add(Integer[].class);
+		BASIC_PARAMS.add(Long[].class);
+		BASIC_PARAMS.add(Float[].class);
+		BASIC_PARAMS.add(Double[].class);
+		BASIC_PARAMS.add(Boolean[].class);
+		
+		// add custom readers
+		CUSTOM_VALUE_MAP_READERS.put("cq:Page", new ValueMapReader() {
+			
+			@Override
+			public ValueMap readValueMap(Resource resource) {
+				Page page = resource.adaptTo(Page.class);
+				return page.getProperties();
+			}
+			
+		});
+	}
+	
+	/**
+	 * Register a custom value map reader that allows to read properties from a given
+	 * node type for setting values in object attributes.
+	 * 
+	 * @param resourceType
+	 * @param reader
+	 * @return
+	 */
+	public static boolean addCustomValueMapReader(String resourceType, ValueMapReader reader) {
+		if(CUSTOM_VALUE_MAP_READERS.containsKey(resourceType)) {
+			return false;
+		}
+		
+		CUSTOM_VALUE_MAP_READERS.put(resourceType, reader);
+		return true;
+	}
+	
+	// facade functions for reading/writing start here
+	
+	public static <T> T read(String nodePath, Class<T> classOfT, ResourceResolver resourceResolver) throws InstantiationException, IllegalAccessException {
+		return JcrReader.read(nodePath, classOfT, resourceResolver);
+	}
+	
+	public static <T> T read(Resource resource, Class<T> classOfT) throws InstantiationException, IllegalAccessException {
+		return JcrReader.read(resource, classOfT);
+	}
+	
+	public static void readToInstance(Resource resource, Object instance) throws IllegalArgumentException, IllegalAccessException, InstantiationException {
+		JcrReader.readToInstance(resource, instance);
+	}
+	
+	public static void persist(String nodePath, Object object, ResourceResolver resourceResolver) throws RepositoryException, PersistenceException, IllegalArgumentException, IllegalAccessException {
+		JcrWriter.persist(nodePath, object, resourceResolver, true);
+	}
+	
+	public static void persist(String nodePath, Object object, ResourceResolver resourceResolver, boolean deepPersist) throws RepositoryException, PersistenceException, IllegalArgumentException, IllegalAccessException {
+		JcrWriter.persist(nodePath, object, resourceResolver, deepPersist);
+	}
+	
+	public static void persist(String nodePath, Object object, ResourceResolver resourceResolver, String[] propertiesToSave) throws RepositoryException, PersistenceException, IllegalArgumentException, IllegalAccessException {
+		
+	}
+	
+	public static boolean includeField(Class<?> clazz, String fieldName) {
+		return false;
+	}
+	
+	public static boolean excludeField(Class<?> clazz, String fieldName) {
+		return false;
+	}
+	
+	public static boolean setFieldName(Class<?> clazz, String fieldName, String propertyName) {
+		return false;
+	}
+	
+	public static boolean setType(Class<?> clazz, String primaryType) {
+		return false;
+	}
+	
+	public static boolean setImplicitCollection(Class<?> clazz, String fieldName) {
+		return false;
+	}
+	
+	public static boolean addPropertyConverter(Class<?> sourceClass, Class<?> destinationClass, Object converter) {
+		return false;
+	}
+	
+	public static boolean refresh(Object instance, ResourceResolver resourceResolver) {
+		return false;
+	}
+	
+	public static boolean save(Object instance, ResourceResolver resourceResolver) {
+		return false;
+	}
+	
+	// Utility function common to reading/writing start here
+
+	/**
+	 * Check if a given field is transient. A field is considered transient if
+	 * and only if the field is marked with `transient` keyword and no
+	 * annotation of type {@link AEMProperty} exists over the field; or if the
+	 * field is marked with {@link AEMPropertyExclude} annotation.
+	 * 
+	 * @param field
+	 *            the non-<code>null</code> field to check.
+	 * 
+	 * @return <code>true</code> if field is to be considered transient,
+	 *         <code>false</code> otherwise
+	 */
+	static boolean isTransient(Field field) {
+		boolean nativeTransient = ReflectionUtils.isTransient(field);
+		
+		if(nativeTransient) {
+			// if property is covered using @AEMProperty annotation it shall not be excluded
+			AEMProperty aemProperty = field.getAnnotation(AEMProperty.class);
+			if(aemProperty == null) {
+				return true;
+			}
+			
+			return false;
+		}
+		
+		// is the property annotated with @AEMExclude ?
+		AEMPropertyExclude exclude = field.getAnnotation(AEMPropertyExclude.class);
+		if(exclude != null) {
+			return true;
+		}
+		
+		return false;
+	}
+
+	/**
+	 * Returns the name of the field to look for in JCR.
+	 * 
+	 * @param field
+	 * @return
+	 */
+	static String getFieldName(Field field) {
+		AEMProperty annotation = field.getAnnotation(AEMProperty.class);
+		if(annotation == null) {
+			return field.getName();
+		}
+		
+		return annotation.value();
+	}
+
+	public static boolean isPrimitiveFieldType(Class<?> fieldType) {
+		return JcrPersist.BASIC_PARAMS.contains(fieldType);
+	}
+
+	static class ResourceType {
+		
+		final String primaryType;
+		
+		final String childType;
+		
+		public ResourceType(String primaryType, String childType) {
+			this.primaryType = primaryType;
+			this.childType = childType;
+		}
+		
+	}
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/JcrPersist.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/JcrPersist.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.jcrpersist;
 
 import java.lang.reflect.Field;

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/JcrReader.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/JcrReader.java
@@ -1,0 +1,395 @@
+package com.adobe.acs.commons.jcrpersist;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceUtil;
+import org.apache.sling.api.resource.ValueMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.acs.commons.jcrpersist.annotation.AEMImplicitCollection;
+import com.adobe.acs.commons.jcrpersist.annotation.AEMPathProperty;
+import com.adobe.acs.commons.jcrpersist.extension.ValueMapReader;
+import com.adobe.acs.commons.jcrpersist.util.ReflectionUtils;
+import com.adobe.acs.commons.jcrpersist.util.StringUtils;
+import com.day.cq.commons.jcr.JcrConstants;
+
+/**
+ * Code to read a given object from a JCR node.
+ * 
+ * @author sangupta
+ *
+ */
+class JcrReader {
+	
+	/**
+	 * My private logger
+	 */
+	private static final Logger LOGGER = LoggerFactory.getLogger(JcrReader.class);
+
+	/**
+	 * Read from the given node path and populate a new instance of the given type
+	 * using the provided resource resolver.
+	 * 
+	 * @param nodePath
+	 *            the path of the node to read data from
+	 * 
+	 * @param classOfT
+	 *            the type which needs to be instantiated for populating fields
+	 * 
+	 * @param resourceResolver
+	 *            the {@link ResourceResolver} to use
+	 * 
+	 * @return a new {@link Object} of type represented by <code>classOfT</code>
+	 * 
+	 * @throws InstantiationException
+	 *             if we cannot create a new instance
+	 * 
+	 * @throws IllegalAccessException
+	 * 
+	 * @throws {@link
+	 *             IllegalArgumentException} if node path is <code>null</code> or
+	 *             empty, of <code>classOfT</code> is <code>null</code>, or
+	 *             <code>resourceResolver</code> is <code>null</code>
+	 */
+	static <T> T read(String nodePath, Class<T> classOfT, ResourceResolver resourceResolver) throws InstantiationException, IllegalAccessException {
+		if(nodePath == null || nodePath.trim().isEmpty()) {
+			throw new IllegalArgumentException("Node path cannot be null/empty");
+		}
+		
+		if(classOfT == null) {
+			throw new IllegalArgumentException("Object to save cannot be null");
+		}
+		
+		if(resourceResolver == null) {
+			throw new IllegalArgumentException("ResourceResolver cannot be null");
+		}
+		
+		Resource resource = resourceResolver.getResource(nodePath);
+		if(resource == null || ResourceUtil.isNonExistingResource(resource)) {
+			return null;
+		}
+		
+		return read(resource, classOfT);
+	}
+	
+	/**
+	 * Populate the properties of the given {@link Resource} to a new {@link Object}
+	 * of given type.
+	 * 
+	 * @param resource
+	 *            the {@link Resource} to read from
+	 * 
+	 * @param classOfT
+	 *            the type to instantiate
+	 * 
+	 * @return a new instantiated type with properties from {@link Resource}
+	 * 
+	 * @throws InstantiationException
+	 * 
+	 * @throws IllegalAccessException
+	 */
+	static <T> T read(Resource resource, Class<T> classOfT) throws InstantiationException, IllegalAccessException {
+		if(classOfT == null) {
+			throw new IllegalArgumentException("Object type to bind resource to cannot be null");
+		}
+		
+		if(resource == null) {
+			return null;
+		}
+		
+		// create a new instance
+		T instance = instantiate(classOfT);
+		
+		// read values from resource
+		readToInstance(resource, instance);
+		
+		// return
+		return instance;
+	}
+	
+	/**
+	 * Populate the given object instance properties by reading the given resource.
+	 * The existing properties are not cleaned before population starts. If the
+	 * resource is <code>null</code> the values remain unmodified on the instance.
+	 * 
+	 * @param resource
+	 *            the {@link Resource} to be read.
+	 * 
+	 * @param instance
+	 *            the object instance whose properties are to be populated
+	 * 
+	 * @throws IllegalArgumentException
+	 *             if instance is <code>null</code>
+	 * 
+	 * @throws IllegalAccessException
+	 * @throws InstantiationException
+	 */
+	static void readToInstance(Resource resource, Object instance) throws IllegalArgumentException, IllegalAccessException, InstantiationException {
+		if(instance == null) {
+			throw new IllegalArgumentException("Object to be populated cannot be null");
+		}
+		
+		if(resource == null) {
+			return;
+		}
+		
+		// get type of instance we need to create
+		final Class<?> classOfT = instance.getClass();
+		
+		// find all fields
+		List<Field> fields = ReflectionUtils.getAllFields(classOfT);
+		if(fields == null || fields.isEmpty()) {
+			return;
+		}
+		
+		// read values
+		ValueMap values;
+
+		// get the custom value-map reader
+		String resourceType = resource.getResourceType();
+		ValueMapReader customReader = JcrPersist.CUSTOM_VALUE_MAP_READERS.get(resourceType);
+		if(customReader != null) {
+			values = customReader.readValueMap(resource);
+		} else {
+			values = resource.getValueMap();
+		}
+		
+		// start reading each field
+		for(final Field field : fields) {
+			if(JcrPersist.isTransient(field)) {
+				// skip transient fields
+				continue;
+			}
+			
+			// find the type of field
+			final Class<?> fieldType = field.getType();
+			final String fieldName = JcrPersist.getFieldName(field);
+			
+			// set accessible
+			field.setAccessible(true);
+			
+			// handle AEMPathProperty annotation
+			AEMPathProperty pathProperty = field.getAnnotation(AEMPathProperty.class);
+			if(pathProperty != null) {
+				field.set(instance, resource.getPath());
+				continue;
+			}
+
+			// handle the value as primitive first
+			if(JcrPersist.isPrimitiveFieldType(fieldType)) {
+				boolean handled = populateField(field, instance, values);
+				if(!handled) {
+					LOGGER.warn("Unable to bind value for primitive attribute: {}", field.getName());
+				}
+				
+				// let's move back
+				continue;
+			}
+			
+			// the value could not be handled - may its 
+			final boolean isCollection = Collection.class.isAssignableFrom(fieldType);
+
+			// check if this is a collection of child objects - or a single object
+			if(isCollection) {
+				Type type = field.getGenericType();
+				if(!(type instanceof ParameterizedType)) {
+					// TODO: don't know how to create a list of non-parameterized type
+					continue;
+				}
+				
+				// find collection type
+				ParameterizedType pt = (ParameterizedType) type;
+				Class<?> collectionType = (Class<?>) pt.getActualTypeArguments()[0];
+				
+				// check if this is an implicit collection or an explicit collection
+				Resource subResource;
+
+				AEMImplicitCollection implicitCollection = field.getAnnotation(AEMImplicitCollection.class);
+				if(implicitCollection == null) {
+					// check if we have a property node with the same name
+					subResource = getChildResource(resource, fieldName);
+					if(subResource == null || ResourceUtil.isNonExistingResource(subResource)) {
+						field.set(instance, null);
+						continue;
+					}
+				} else {
+					// we are an implicit collection
+					// read direct descendants
+					subResource = resource;
+				}
+				
+				// check if there are children available for the subResource
+				Iterator<Resource> iterator = subResource.listChildren();
+				if(iterator == null) {
+					field.set(instance, getCollectionOfType(fieldType));
+					continue;
+				}
+				
+				Collection<Object> collection = getCollectionOfType(fieldType);
+				while(iterator.hasNext()) {
+					Resource child = iterator.next();
+					
+					LOGGER.debug("Child name: {}", child.getName());
+					if(child.getPath().endsWith("/jcr:content")) {
+						// skip the jcr:content node
+						continue;
+					}
+					
+					Object childObject = read(child, collectionType);
+					if(childObject != null) {
+						collection.add(childObject);
+					}
+				}
+				
+				field.set(instance, collection);
+				continue;
+			}
+
+			// this is a composed object directly as a child node
+			Resource subResource = getChildResource(resource, fieldName);
+			if(subResource == null || ResourceUtil.isNonExistingResource(subResource)) {
+				field.set(instance, null);
+				continue;
+			}
+			
+			Object subInstance = read(subResource, fieldType);
+			field.set(instance, subInstance);
+		}
+	}
+	
+	/**
+	 * Return the child resource with the given child name from the given
+	 * {@link Resource}
+	 * 
+	 * @param resource
+	 *            the {@link Resource} to read child from
+	 * 
+	 * @param childName
+	 *            the name of the child
+	 * 
+	 * @return the child {@link Resource} instance if available, or
+	 *         <code>null</code>
+	 */
+	private static Resource getChildResource(Resource resource, String childName) {
+		Resource subResource = resource.getChild(childName);
+		if(subResource != null && !ResourceUtil.isNonExistingResource(subResource)) {
+			return subResource;
+		}
+		
+		subResource = resource.getChild(JcrConstants.JCR_CONTENT);
+		if(subResource == null || ResourceUtil.isNonExistingResource(subResource)) {
+			return null;
+		}
+		
+		return subResource.getChild(childName);
+	}
+
+	/**
+	 * Return a new collection of the provided type where the type is either an
+	 * abstract class or an interface. For example, we instantiate an
+	 * {@link ArrayList} for a {@link List}, and a {@link HashSet} for a {@link Set}
+	 * implementation.
+	 * 
+	 * @param type
+	 *            the type to instantiate
+	 * 
+	 * @return <code>null</code> if the provided type is <code>null</code> or
+	 *         un-handled, else the instantiated type is returned
+	 */
+	private static Collection<Object> getCollectionOfType(Class<?> type) {
+		if(type == null) {
+			return null;
+		}
+		
+		if(type.equals(List.class)) {
+			return new ArrayList<>();
+		}
+		
+		if(type.equals(Set.class)) {
+			return new HashSet<>();
+		}
+		
+		return null;
+	}
+	
+	/**
+	 * Populate the provided field in the given instance
+	 * @param field
+	 * @param instance
+	 * @param values
+	 * @return
+	 * @throws IllegalArgumentException
+	 * @throws IllegalAccessException
+	 */
+	private static <T> boolean populateField(Field field, T instance, ValueMap values) throws IllegalArgumentException, IllegalAccessException {
+		String name = JcrPersist.getFieldName(field);
+		Object value = values.get(name);
+		
+		if(value == null) {
+			return ReflectionUtils.bindValue(field, instance, null);
+		}
+		
+		Class<?> fieldType = field.getType();
+
+		if(value instanceof Calendar) {
+			Calendar calendar = (Calendar) value;
+
+			// check field type
+			if(fieldType.equals(Date.class)) {
+				value = new Date(calendar.getTimeInMillis());
+			}
+			
+			if(fieldType.equals(long.class)) {
+				value = calendar.getTimeInMillis();
+			}
+			
+			if(fieldType.equals(String.class)) {
+				value = new Date(calendar.getTimeInMillis()).toString();
+			}
+		}
+		
+		if(value instanceof String) {
+			String str = (String) value;
+			
+			if(fieldType.equals(Date.class)) {
+				value = new Date(StringUtils.getLongValue(str, 0l));
+			}
+			
+			if(fieldType.equals(Calendar.class)) {
+				Calendar calendar = Calendar.getInstance();
+				calendar.setTimeInMillis(StringUtils.getLongValue(str, 0l));
+				value = calendar;
+			}
+		}
+		
+		return ReflectionUtils.bindValue(field, instance, value);
+	}
+	
+	/**
+	 * Create a new instance for the given class. This method is used to make sure
+	 * that we can use custom extension points for using factories tomorrow.
+	 * 
+	 * @param classOfT
+	 * @return
+	 * @throws InstantiationException
+	 * @throws IllegalAccessException
+	 */
+	private static <T> T instantiate(Class<T> classOfT) throws InstantiationException, IllegalAccessException {
+		// TODO: allow extension point for using custom factories and argument-constructors
+		return classOfT.newInstance();
+	}
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/JcrReader.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/JcrReader.java
@@ -49,8 +49,6 @@ import com.day.cq.commons.jcr.JcrConstants;
 /**
  * Code to read a given object from a JCR node.
  * 
- * @author sangupta
- *
  */
 class JcrReader {
 	

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/JcrReader.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/JcrReader.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.jcrpersist;
 
 import java.lang.reflect.Field;

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/JcrWriter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/JcrWriter.java
@@ -48,8 +48,6 @@ import com.day.cq.commons.jcr.JcrConstants;
 /**
  * Code to persist a given object instance to a JCR node.
  * 
- * @author sangupta
- *
  */
 class JcrWriter {
 

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/JcrWriter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/JcrWriter.java
@@ -1,0 +1,238 @@
+package com.adobe.acs.commons.jcrpersist;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.jcr.RepositoryException;
+
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.acs.commons.jcrpersist.JcrPersist.ResourceType;
+import com.adobe.acs.commons.jcrpersist.annotation.AEMImplicitCollection;
+import com.adobe.acs.commons.jcrpersist.annotation.AEMPathProperty;
+import com.adobe.acs.commons.jcrpersist.annotation.AEMType;
+import com.adobe.acs.commons.jcrpersist.util.AssertUtils;
+import com.adobe.acs.commons.jcrpersist.util.ReflectionUtils;
+import com.day.cq.commons.jcr.JcrConstants;
+
+/**
+ * Code to persist a given object instance to a JCR node.
+ * 
+ * @author sangupta
+ *
+ */
+class JcrWriter {
+
+	/**
+	 * My private logger
+	 */
+	private static final Logger LOGGER = LoggerFactory.getLogger(JcrWriter.class);
+	
+	static final Map<String, Object> RESOURCE_TYPE_NT_UNSTRUCTURED = new HashMap<>();
+	
+	static {
+		RESOURCE_TYPE_NT_UNSTRUCTURED.put(JcrConstants.JCR_PRIMARYTYPE, JcrConstants.NT_UNSTRUCTURED);
+	}
+	
+	static void persist(final String nodePath, final Object instance, ResourceResolver resourceResolver, boolean deepPersist) throws RepositoryException, PersistenceException, IllegalArgumentException, IllegalAccessException {
+		if(nodePath == null || nodePath.trim().isEmpty()) {
+			throw new IllegalArgumentException("Node path cannot be null/empty");
+		}
+		
+		if(instance == null) {
+			throw new IllegalArgumentException("Object to save cannot be null");
+		}
+		
+		if(resourceResolver == null) {
+			throw new IllegalArgumentException("ResourceResolver cannot be null");
+		}
+		
+		// get the resource
+		Resource resource = resourceResolver.getResource(nodePath);
+		
+		final boolean exists = (resource != null) && !ResourceUtil.isNonExistingResource(resource);
+		
+		final ResourceType resourceType = getResourceType(instance.getClass());
+		
+		// let's create the resource first
+		LOGGER.debug("Creating node at: {} of type: {}", nodePath, resourceType.primaryType);
+		resource = ResourceUtil.getOrCreateResource(resourceResolver, nodePath, asMap(resourceType.primaryType), JcrConstants.NT_UNSTRUCTURED, true);
+		
+		if(AssertUtils.isNotEmpty(resourceType.childType)) {
+			LOGGER.debug("Needs a child node, creating node at: {} of type: {}", nodePath, resourceType.childType);
+			resource = ResourceUtil.getOrCreateResource(resourceResolver, nodePath + "/" + JcrConstants.JCR_CONTENT, resourceType.childType, JcrConstants.NT_UNSTRUCTURED, true);
+		}
+		
+		// read the existing resource map
+		ModifiableValueMap values = resource.adaptTo(ModifiableValueMap.class);
+		
+		// find properties to be saved
+		List<Field> fields = ReflectionUtils.getAllFields(instance.getClass());
+		if(fields == null || fields.isEmpty()) {
+			// TODO: remove all properties
+		} else {
+			for(final Field field : fields) {
+				if(JcrPersist.isTransient(field)) {
+					// skip transient fields
+					continue;
+				}
+				
+				// find the type of field
+				final Class<?> fieldType = field.getType();
+				final String fieldName = JcrPersist.getFieldName(field);
+				
+				// set accessible
+				field.setAccessible(true);
+
+				// handle the value as primitive first
+				if(JcrPersist.isPrimitiveFieldType(fieldType)) {
+					Object value = field.get(instance);
+					
+					if(value == null) {
+						// remove the attribute that is null
+						values.remove(fieldName);
+						continue;
+					}
+					
+					values.put(fieldName, value);
+					continue;
+				}
+				
+				// do not persist compound objects if they are not needed
+				if(!deepPersist) {
+					continue;
+				}
+				
+				// the value could not be handled - may its 
+				final boolean isCollection = Collection.class.isAssignableFrom(fieldType);
+				if(isCollection) {
+					String collectionRoot = nodePath;
+					
+					// check if this is an implicit collection
+					AEMImplicitCollection implicitCollection = field.getAnnotation(AEMImplicitCollection.class);
+					if(implicitCollection == null) {
+						// create a child collection of required type
+						// and persist all instances
+						
+						// create the first child node first
+						persist(nodePath + "/" + fieldName, new Object(), resourceResolver, false);
+						
+						// update collection root
+						collectionRoot = nodePath + "/" + fieldName;
+					}
+					
+					// now for each child in the collection - create a new node
+					Collection<Object> collection = (Collection<Object>) field.get(instance);
+					if(collection == null) {
+						// TODO: remove the object if it exists on this resource
+						continue;
+					}
+					
+					Field pathField = null;
+					for(Object childObject : collection) {
+						if(pathField == null) {
+							pathField = findAEMPathField(childObject.getClass());
+						}
+						
+						String childName = null;
+						if(pathField != null) {
+							pathField.setAccessible(true);
+							childName = extractNodeNameFromPath(pathField, childObject);
+						}
+						
+						if(childName == null) {
+							childName = UUID.randomUUID().toString();
+						}
+						
+						persist(collectionRoot + "/" + childName, childObject, resourceResolver, true);
+					}
+				} else {
+					// this is a single compound object
+					// create a child node and persist all its values
+					Object value = field.get(instance);
+					if(value == null) {
+						continue;
+					}
+					
+					persist(nodePath + "/" + fieldName, value, resourceResolver, true);
+				}
+			}
+		}
+		
+		// save back
+		resourceResolver.commit();
+	}
+
+	private static String extractNodeNameFromPath(Field pathField, Object childObject) throws IllegalArgumentException, IllegalAccessException {
+		Object pathObject = pathField.get(childObject);
+		if(pathObject == null) {
+			return null;
+		}
+		
+		String pathValue = pathObject.toString();
+		if(AssertUtils.isEmpty(pathValue)) {
+			return null;
+		}
+		
+		int lastIndex = pathValue.lastIndexOf('/');
+		if(lastIndex >= 0) {
+			pathValue = pathValue.substring(lastIndex + 1);
+		}
+
+		return pathValue;
+	}
+
+	private static Field findAEMPathField(Class<? extends Object> clazz) {
+		// TODO: implement caching
+		List<Field> fields = ReflectionUtils.getAllFields(clazz);
+		if(fields == null || fields.isEmpty()) {
+			LOGGER.warn("Object of type {} does NOT contain a AEMPathProperty attribute - multiple instances may conflict", clazz);
+			return null;
+		}
+		
+		for(Field field : fields) {
+			if(field.isAnnotationPresent(AEMPathProperty.class)) {
+				return field;
+			}
+		}
+		
+		LOGGER.warn("Object of type {} does NOT contain a AEMPathProperty attribute - multiple instances may conflict", clazz);
+		return null;
+	}
+
+	private static ResourceType getResourceType(Class<?> clazz) {
+		if(clazz == null) {
+			return JcrPersist.NT_UNSTRUCTURED_RESOURCE_TYPE;
+		}
+		
+		ResourceType type = JcrPersist.NODE_TYPE_FOR_CLASS.get(clazz);
+		if(type != null) {
+			return type;
+		}
+		
+		AEMType aemType = clazz.getAnnotation(AEMType.class);
+		if(aemType != null) {
+			return new ResourceType(aemType.primaryType(), aemType.childType());
+		}
+		
+		return JcrPersist.NT_UNSTRUCTURED_RESOURCE_TYPE;
+	}
+
+	private static Map<String, Object> asMap(String value) {
+		Map<String, Object> map = new HashMap<>();
+		map.put(JcrConstants.JCR_PRIMARYTYPE, value);
+		
+		return map;
+	}
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/JcrWriter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/JcrWriter.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.jcrpersist;
 
 import java.lang.reflect.Field;

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMImplicitCollection.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMImplicitCollection.java
@@ -30,8 +30,6 @@ import java.lang.annotation.Target;
  * are direct descendants of this node and do not have an extra
  * wrapper child node around.
  * 
- * @author sangupta
- *
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD, ElementType.METHOD })

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMImplicitCollection.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMImplicitCollection.java
@@ -1,0 +1,20 @@
+package com.adobe.acs.commons.jcrpersist.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation to indicate that collection elements
+ * are direct descendants of this node and do not have an extra
+ * wrapper child node around.
+ * 
+ * @author sangupta
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.METHOD })
+public @interface AEMImplicitCollection {
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMImplicitCollection.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMImplicitCollection.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.jcrpersist.annotation;
 
 import java.lang.annotation.ElementType;

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMPathProperty.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMPathProperty.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.jcrpersist.annotation;
 
 import java.lang.annotation.ElementType;

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMPathProperty.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMPathProperty.java
@@ -28,8 +28,6 @@ import java.lang.annotation.Target;
 /**
  * Marker annotation to populate the node path in a given object.
  * 
- * @author sangupta
- *
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD, ElementType.METHOD })

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMPathProperty.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMPathProperty.java
@@ -1,0 +1,18 @@
+package com.adobe.acs.commons.jcrpersist.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation to populate the node path in a given object.
+ * 
+ * @author sangupta
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.METHOD })
+public @interface AEMPathProperty {
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMProperty.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMProperty.java
@@ -28,8 +28,6 @@ import java.lang.annotation.Target;
 /**
  * Annotation to provide a custom name to a property.
  * 
- * @author sangupta
- *
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD, ElementType.METHOD })

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMProperty.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMProperty.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.jcrpersist.annotation;
 
 import java.lang.annotation.ElementType;

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMProperty.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMProperty.java
@@ -1,0 +1,25 @@
+package com.adobe.acs.commons.jcrpersist.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to provide a custom name to a property.
+ * 
+ * @author sangupta
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.METHOD })
+public @interface AEMProperty {
+
+	/**
+	 * @return the desired name of the field when it is serialized or
+	 *         deserialized from JCR
+	 * 
+	 */
+	String value();
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMPropertyExclude.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMPropertyExclude.java
@@ -29,8 +29,6 @@ import java.lang.annotation.Target;
  * Marker annotation to signify that the attribute be excluded
  * from all serialization/deserialization workflows.
  * 
- * @author sangupta
- *
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD, ElementType.METHOD })

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMPropertyExclude.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMPropertyExclude.java
@@ -1,0 +1,19 @@
+package com.adobe.acs.commons.jcrpersist.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation to signify that the attribute be excluded
+ * from all serialization/deserialization workflows.
+ * 
+ * @author sangupta
+ *
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.METHOD })
+public @interface AEMPropertyExclude {
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMPropertyExclude.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMPropertyExclude.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.jcrpersist.annotation;
 
 import java.lang.annotation.ElementType;

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMType.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMType.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.jcrpersist.annotation;
 
 import java.lang.annotation.ElementType;

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMType.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/annotation/AEMType.java
@@ -1,0 +1,21 @@
+package com.adobe.acs.commons.jcrpersist.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface AEMType {
+
+	/**
+	 * @return the desired name of the field when it is serialized or
+	 *         deserialized from JCR
+	 * 
+	 */
+	String primaryType();
+	
+	String childType();
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/extension/TypeInstantiator.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/extension/TypeInstantiator.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.jcrpersist.extension;
 
 /**

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/extension/TypeInstantiator.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/extension/TypeInstantiator.java
@@ -25,8 +25,6 @@ package com.adobe.acs.commons.jcrpersist.extension;
  * to extend functionality for classes that cannot be instantiated
  * using a default no-argument constructor.
  * 
- * @author sangupta
- *
  * @param <T>
  */
 public interface TypeInstantiator<T> {

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/extension/TypeInstantiator.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/extension/TypeInstantiator.java
@@ -1,0 +1,16 @@
+package com.adobe.acs.commons.jcrpersist.extension;
+
+/**
+ * Instantiate a new instance for a given type. This may be used
+ * to extend functionality for classes that cannot be instantiated
+ * using a default no-argument constructor.
+ * 
+ * @author sangupta
+ *
+ * @param <T>
+ */
+public interface TypeInstantiator<T> {
+	
+	public T getNewInstance();
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/extension/ValueMapReader.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/extension/ValueMapReader.java
@@ -1,0 +1,18 @@
+package com.adobe.acs.commons.jcrpersist.extension;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+
+/**
+ * An extension point that can be used to provide reading
+ * via {@link ValueMap} for JCR objects that do not directly
+ * provide that functionality.
+ * 
+ * @author sangupta
+ *
+ */
+public interface ValueMapReader {
+	
+	public ValueMap readValueMap(Resource resource);
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/extension/ValueMapReader.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/extension/ValueMapReader.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.jcrpersist.extension;
 
 import org.apache.sling.api.resource.Resource;

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/extension/ValueMapReader.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/extension/ValueMapReader.java
@@ -28,8 +28,6 @@ import org.apache.sling.api.resource.ValueMap;
  * via {@link ValueMap} for JCR objects that do not directly
  * provide that functionality.
  * 
- * @author sangupta
- *
  */
 public interface ValueMapReader {
 	

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/AssertUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/AssertUtils.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.jcrpersist.util;
 
 /**

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/AssertUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/AssertUtils.java
@@ -26,8 +26,6 @@ package com.adobe.acs.commons.jcrpersist.util;
  * Part of the code of this class has been borrowed from the open-source project
  * <code>jerry-core</code> from https://github.com/sangupta/jerry-core.
  * 
- * @author sangupta
- *
  */
 public class AssertUtils {
 

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/AssertUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/AssertUtils.java
@@ -1,0 +1,34 @@
+package com.adobe.acs.commons.jcrpersist.util;
+
+/**
+ * Simple assertion functions.
+ * 
+ * Part of the code of this class has been borrowed from the open-source project
+ * <code>jerry-core</code> from https://github.com/sangupta/jerry-core.
+ * 
+ * @author sangupta
+ *
+ */
+public class AssertUtils {
+
+	public static boolean isEmpty(String str) {
+		if(str == null || str.isEmpty()) {
+			return true;
+		}
+		
+		return false;
+	}
+	
+	public static boolean isEmpty(Object[] array) {
+		if(array == null || array.length == 0) {
+			return true;
+		}
+		
+		return false;
+	}
+
+	public static boolean isNotEmpty(String str) {
+		return !isEmpty(str);
+	}
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/ReflectionBindUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/ReflectionBindUtils.java
@@ -1,0 +1,549 @@
+package com.adobe.acs.commons.jcrpersist.util;
+
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility methods around object reflection.
+ * 
+ * Part of the code of this class has been borrowed from the open-source project
+ * <code>jerry-core</code> from https://github.com/sangupta/jerry-core.
+ *
+ * @author sangupta
+ *
+ */
+public abstract class ReflectionBindUtils {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ReflectionBindUtils.class);
+
+    public static void bindURI(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+
+    	if(value == null) {
+    		field.set(instance, null);
+    		return;
+    	}
+    	
+    	if(value instanceof URI) {
+    		field.set(instance, (URI) value);
+    		return;
+    	}
+    	
+    	if(value instanceof String) {
+    		try {
+				URI uri = new URI((String) value);
+				field.set(instance, uri);
+			} catch (URISyntaxException e) {
+				LOGGER.debug("Unable to convert value to URI: {}", value);
+			}
+    		
+    		return;
+    	}
+    }
+
+    public static void bindBoolean(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+
+    	if(value instanceof Boolean) {
+			field.setBoolean(instance, (Boolean) value);
+		} else {
+			field.setBoolean(instance, StringUtils.getBoolean(value.toString(), field.getBoolean(instance)));
+		}
+    }
+    
+    public static void bindBooleanObject(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+    	
+    	if(value == null) {
+    		field.set(instance, null);
+    		return;
+    	}
+
+    	if(value instanceof Boolean) {
+			field.set(instance, (Boolean) value);
+		} else {
+			Boolean boolValue = Boolean.parseBoolean(value.toString());
+			field.set(instance, boolValue);
+		}
+    }
+
+    public static void bindByte(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+
+    	if(value instanceof Byte) {
+			field.setByte(instance, (Byte) value);
+		} else {
+			field.setByte(instance, StringUtils.getByteValue(value.toString(), field.getByte(instance)));
+		}
+    }
+    
+    public static void bindByteObject(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+    	
+    	if(value == null) {
+    		field.set(instance, null);
+    		return;
+    	}
+
+    	if(value instanceof Byte) {
+			field.set(instance, (Byte) value);
+		} else {
+			Byte byteValue = Byte.parseByte(value.toString());
+			field.set(instance, byteValue);
+		}
+    }
+
+    public static void bindShort(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+
+    	if(value instanceof Short) {
+			field.setShort(instance, (Short) value);
+		} else {
+			field.setShort(instance, StringUtils.getShortValue(value.toString(), field.getShort(instance)));
+		}
+    }
+    
+    public static void bindShortObject(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+    	
+    	if(value == null) {
+    		field.set(instance, null);
+    		return;
+    	}
+
+    	if(value instanceof Short) {
+			field.set(instance, (Short) value);
+		} else {
+			Short shortValue = Short.parseShort(value.toString());
+			field.set(instance, shortValue);
+		}
+    }
+
+    public static void bindInteger(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+    	
+    	if(value == null) {
+    		return;
+    	}
+    	
+    	if(value instanceof Integer) {
+			field.setInt(instance, (Integer) value);
+		} else {
+			field.setInt(instance, StringUtils.getIntValue(value.toString(), field.getInt(instance)));
+		}
+    }
+    
+    public static void bindIntegerObject(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+    	
+    	if(value == null) {
+    		field.set(instance, null);
+    		return;
+    	}
+
+    	if(value instanceof Integer) {
+			field.set(instance, (Integer) value);
+		} else {
+			Integer intValue = Integer.parseInt(value.toString());
+			field.set(instance, intValue);
+		}
+    }
+
+    public static void bindLong(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+
+    	if(value instanceof Long) {
+			field.setLong(instance, (Long) value);
+		} else {
+			field.setLong(instance, StringUtils.getLongValue(value.toString(), field.getLong(instance)));
+		}
+    }
+    
+    public static void bindLongObject(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+    	
+    	if(value == null) {
+    		field.set(instance, null);
+    		return;
+    	}
+
+    	if(value instanceof Long) {
+			field.set(instance, (Long) value);
+		} else {
+			Long longValue = Long.parseLong(value.toString());
+			field.set(instance, longValue);
+		}
+    }
+
+    public static void bindChar(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+
+    	if(value instanceof Character) {
+			field.setChar(instance, (Character) value);
+		} else {
+			field.setChar(instance, StringUtils.getCharValue(value.toString(), field.getChar(instance)));
+		}
+    }
+    
+    public static void bindCharacterObject(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+    	
+    	if(value == null) {
+    		field.set(instance, null);
+    		return;
+    	}
+
+    	if(value instanceof Character) {
+			field.set(instance, (Character) value);
+		} else {
+			Character charValue = value.toString().toCharArray()[0];
+			field.set(instance, charValue);
+		}
+    }
+
+    public static void bindFloat(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+
+    	if(value instanceof Float) {
+			field.setFloat(instance, (Float) value);
+		} else {
+			field.setFloat(instance, StringUtils.getFloatValue(value.toString(), field.getFloat(instance)));
+		}
+    }
+    
+    public static void bindFloatObject(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+    	
+    	if(value == null) {
+    		field.set(instance, null);
+    		return;
+    	}
+
+    	if(value instanceof Float) {
+			field.set(instance, (Float) value);
+		} else {
+			Float floatValue = Float.parseFloat(value.toString());
+			field.set(instance, floatValue);
+		}
+    }
+
+    public static void bindDouble(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+
+    	if(value instanceof Double) {
+			field.setDouble(instance, (Double) value);
+		} else {
+			field.setDouble(instance, StringUtils.getDoubleValue(value.toString(), field.getDouble(instance)));
+		}
+    }
+    
+    public static void bindDoubleObject(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+    	
+    	if(value == null) {
+    		field.set(instance, null);
+    		return;
+    	}
+
+    	if(value instanceof Double) {
+			field.set(instance, (Double) value);
+		} else {
+			Double doubleValue = Double.parseDouble(value.toString());
+			field.set(instance, doubleValue);
+		}
+    }
+
+    public static void bindByteArray(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+
+		if(value instanceof byte[]) {
+			field.set(instance, (byte[]) value);
+		} else {
+			if(value instanceof String) {
+				byte[] array = StringUtils.deStringifyByteArray((String) value);
+				field.set(instance, array);
+			}
+		}
+	}
+
+    public static void bindCharArray(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+
+		if(value instanceof char[]) {
+			field.set(instance, (char[]) value);
+		} else {
+			if(value instanceof String) {
+				char[] array = StringUtils.deStringifyCharArray((String) value);
+				field.set(instance, array);
+			}
+		}
+	}
+
+    public static void bindShortArray(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+
+		if(value instanceof short[]) {
+			field.set(instance, (short[]) value);
+		} else {
+			if(value instanceof String) {
+				short[] array = StringUtils.deStringifyShortArray((String) value);
+				field.set(instance, array);
+			}
+		}
+	}
+
+    public static void bindIntArray(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+
+		if(value instanceof int[]) {
+			field.set(instance, (int[]) value);
+		} else if(value instanceof Integer[]) {
+			Integer[] array = (Integer[]) value;
+			int[] newArray = new int[array.length];
+			
+			for(int index = 0; index < array.length; index++) {
+				newArray[index] = array[index];
+			}
+			
+			field.set(instance, newArray);
+		} else if(value instanceof String) {
+			int[] array = StringUtils.deStringifyIntArray((String) value);
+			field.set(instance, array);
+		}
+	}
+
+    public static void bindLongArray(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+
+		if(value instanceof long[]) {
+			field.set(instance, (long[]) value);
+		} else if(value instanceof Long[]) {
+			Long[] array = (Long[]) value;
+			long[] newArray = new long[array.length];
+			
+			for(int index = 0; index < array.length; index++) {
+				newArray[index] = array[index];
+			}
+			
+			field.set(instance, newArray);
+		} else if(value instanceof String) {
+			long[] array = StringUtils.deStringifyLongArray((String) value);
+			field.set(instance, array);
+		}
+	}
+
+	public static void bindFloatArray(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+
+		if(value instanceof float[]) {
+			field.set(instance, (float[]) value);
+		} else if(value instanceof Float[]) {
+			Float[] array = (Float[]) value;
+			float[] newArray = new float[array.length];
+			
+			for(int index = 0; index < array.length; index++) {
+				newArray[index] = array[index];
+			}
+			
+			field.set(instance, newArray);
+		} else if(value instanceof String) {
+			float[] array = StringUtils.deStringifyFloatArray((String) value);
+			field.set(instance, array);
+		}
+	}
+
+	public static void bindDoubleArray(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+
+		if(value instanceof double[]) {
+			field.set(instance, (double[]) value);
+		} else if(value instanceof Double[]) {
+			Double[] array = (Double[]) value;
+			double[] newArray = new double[array.length];
+			
+			for(int index = 0; index < array.length; index++) {
+				newArray[index] = array[index];
+			}
+			
+			field.set(instance, newArray);
+		} else if(value instanceof String) {
+			double[] array = StringUtils.deStringifyDoubleArray((String) value);
+			field.set(instance, array);
+		}
+	}
+
+	public static void bindBooleanArray(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return;
+    	}
+
+    	if(instance == null) {
+    		return;
+    	}
+
+		if(value instanceof boolean[]) {
+			field.set(instance, (boolean[]) value);
+		} else if(value instanceof Boolean[]) {
+			Boolean[] array = (Boolean[]) value;
+			boolean[] newArray = new boolean[array.length];
+			
+			for(int index = 0; index < array.length; index++) {
+				newArray[index] = array[index];
+			}
+			
+			field.set(instance, newArray);
+		} else if(value instanceof String) {
+			boolean[] array = StringUtils.deStringifyBooleanArray((String) value);
+			field.set(instance, array);
+		}
+	}
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/ReflectionBindUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/ReflectionBindUtils.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.jcrpersist.util;
 
 import java.lang.reflect.Field;

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/ReflectionBindUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/ReflectionBindUtils.java
@@ -33,8 +33,6 @@ import org.slf4j.LoggerFactory;
  * Part of the code of this class has been borrowed from the open-source project
  * <code>jerry-core</code> from https://github.com/sangupta/jerry-core.
  *
- * @author sangupta
- *
  */
 public abstract class ReflectionBindUtils {
 

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/ReflectionUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/ReflectionUtils.java
@@ -33,8 +33,6 @@ import java.util.List;
  * Part of the code of this class has been borrowed from the open-source project
  * <code>jerry-core</code> from https://github.com/sangupta/jerry-core.
  *
- * @author sangupta
- *
  */
 public abstract class ReflectionUtils {
 

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/ReflectionUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/ReflectionUtils.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.jcrpersist.util;
 
 import java.lang.reflect.Field;

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/ReflectionUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/ReflectionUtils.java
@@ -1,0 +1,235 @@
+package com.adobe.acs.commons.jcrpersist.util;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Utility methods around object reflection.
+ * 
+ * Part of the code of this class has been borrowed from the open-source project
+ * <code>jerry-core</code> from https://github.com/sangupta/jerry-core.
+ *
+ * @author sangupta
+ *
+ */
+public abstract class ReflectionUtils {
+
+    public static boolean isTransient(Field field) {
+    	if(field == null) {
+    		return false;
+    	}
+
+    	return Modifier.isTransient(field.getModifiers());
+    }
+    
+    public static boolean bindValue(Field field, Object instance, Object value) throws IllegalArgumentException, IllegalAccessException {
+    	if(field == null) {
+    		return false;
+    	}
+
+    	if(instance == null) {
+    		return false;
+    	}
+
+    	Class<?> type = field.getType();
+
+		// set accessible so that we can work with private fields
+		field.setAccessible(true);
+		
+		if(value != null && type.equals(value.getClass())) {
+			field.set(instance, value);
+			return true;
+		}
+
+		if(type.equals(URI.class)) {
+			ReflectionBindUtils.bindURI(field, instance, value);
+			return true;
+		}
+		
+		if(type.equals(boolean.class)) {
+			ReflectionBindUtils.bindBoolean(field, instance, value);
+			return true;
+		}
+		if(type.equals(Boolean.class)) {
+			ReflectionBindUtils.bindBooleanObject(field, instance, value);
+			return true;
+		}
+
+		if(type.equals(byte.class)) {
+			ReflectionBindUtils.bindByte(field, instance, value);
+			return true;
+		}
+		if(type.equals(Byte.class)) {
+			ReflectionBindUtils.bindByteObject(field, instance, value);
+			return true;
+		}
+
+		if(type.equals(short.class)) {
+			ReflectionBindUtils.bindShort(field, instance, value);
+			return true;
+		}
+		if(type.equals(Short.class)) {
+			ReflectionBindUtils.bindShortObject(field, instance, value);
+			return true;
+		}
+
+		if(type.equals(char.class)) {
+			ReflectionBindUtils.bindChar(field, instance, value);
+			return true;
+		}
+		if(type.equals(Character.class)) {
+			ReflectionBindUtils.bindCharacterObject(field, instance, value);
+			return true;
+		}
+
+		if(type.equals(int.class)) {
+			ReflectionBindUtils.bindInteger(field, instance, value);
+			return true;
+		}
+		if(type.equals(Integer.class)) {
+			ReflectionBindUtils.bindIntegerObject(field, instance, value);
+			return true;
+		}
+
+		if(type.equals(long.class)) {
+			ReflectionBindUtils.bindLong(field, instance, value);
+			return true;
+		}
+		if(type.equals(Long.class)) {
+			ReflectionBindUtils.bindLongObject(field, instance, value);
+			return true;
+		}
+
+		if(type.equals(float.class)) {
+			ReflectionBindUtils.bindFloat(field, instance, value);
+			return true;
+		}
+		if(type.equals(Float.class)) {
+			ReflectionBindUtils.bindFloatObject(field, instance, value);
+			return true;
+		}
+
+		if(type.equals(double.class)) {
+			ReflectionBindUtils.bindDouble(field, instance, value);
+			return true;
+		}
+		if(type.equals(Double.class)) {
+			ReflectionBindUtils.bindDoubleObject(field, instance, value);
+			return true;
+		}
+
+		// check if this is an array and the value is of type String
+		if(type.equals(byte[].class)) {
+			ReflectionBindUtils.bindByteArray(field, instance, value);
+			return true;
+		}
+		if(type.equals(char[].class)) {
+			ReflectionBindUtils.bindCharArray(field, instance, value);
+			return true;
+		}
+		if(type.equals(short[].class)) {
+			ReflectionBindUtils.bindShortArray(field, instance, value);
+			return true;
+		}
+		if(type.equals(int[].class)) {
+			ReflectionBindUtils.bindIntArray(field, instance, value);
+			return true;
+		}
+		if(type.equals(long[].class)) {
+			ReflectionBindUtils.bindLongArray(field, instance, value);
+			return true;
+		}
+		if(type.equals(float[].class)) {
+			ReflectionBindUtils.bindFloatArray(field, instance, value);
+			return true;
+		}
+		if(type.equals(double[].class)) {
+			ReflectionBindUtils.bindDoubleArray(field, instance, value);
+			return true;
+		}
+		if(type.equals(boolean[].class)) {
+			ReflectionBindUtils.bindBooleanArray(field, instance, value);
+			return true;
+		}
+		
+		// we have not handled the value
+		return false;
+    }
+
+	public static <T> T getFieldForName(Object instance, String name, Class<T> castTo) {
+		if(instance == null) {
+			return null;
+		}
+		
+		if(AssertUtils.isEmpty(name)) {
+			return null;
+		}
+		
+		Class<?> clazz = instance.getClass();
+		List<Field> fields = getAllFields(clazz);
+		if(fields.isEmpty()) {
+			return null;
+		}
+		
+		for(Field field : fields) {
+			if(field.getName().equals(name)) {
+				try {
+					field.setAccessible(true);
+					Object object = field.get(instance);
+					if(object == null) {
+						return null;
+					}
+					
+					return castTo.cast(object);
+				} catch (IllegalArgumentException | IllegalAccessException e) {
+					throw new RuntimeException(e);
+				}
+			}
+		}
+		
+		return null;
+	}
+
+	/**
+	 * Return all fields including all-private and all-inherited fields for the
+	 * given class.
+	 * 
+	 * @param clazz
+	 *            the class for which fields are needed
+	 * 
+	 * @return the {@link List} of {@link Field} objects in no certain order
+	 * 
+	 * @throws IllegalArgumentException if given class is <code>null</code>
+	 */
+	public static List<Field> getAllFields(Class<?> clazz) {
+		if(clazz == null) {
+			throw new IllegalArgumentException("Class to read fields from cannot be null");
+		}
+		
+		// TODO: implement caching for faster retrievals
+        List<Field> fields = new ArrayList<>();
+        populateAllFields(clazz, fields);
+        return fields;
+    }
+    
+    public static void populateAllFields(Class<?> clazz, List<Field> fields) {
+        if(clazz == null) {
+            return;
+        }
+        
+        Field[] array = clazz.getDeclaredFields();
+        if(array != null && array.length > 0) {
+            fields.addAll(Arrays.asList(array));
+        }
+        
+        if(clazz.getSuperclass() == null) {
+            return;
+        }
+        
+        populateAllFields(clazz.getSuperclass(), fields);
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/StringUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/StringUtils.java
@@ -1,0 +1,231 @@
+package com.adobe.acs.commons.jcrpersist.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simple functions to work around {@link String} objects.
+ * 
+ * Part of the code of this class has been borrowed from the open-source project
+ * <code>jerry-core</code> from https://github.com/sangupta/jerry-core.
+ * 
+ * @author sangupta
+ *
+ */
+public class StringUtils {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(StringUtils.class);
+	
+	public static final String COMMA_SEPARATOR_CHAR = ",";
+
+	public static boolean getBoolean(String boolString) {
+	    return getBoolean(boolString, false);
+ 	}
+	
+	public static boolean getBoolean(String boolString, boolean defaultValue) {
+		if (AssertUtils.isNotEmpty(boolString)) {
+			boolString = boolString.toLowerCase();
+			if ("yes".equals(boolString) || "true".equals(boolString) || "on".equals(boolString)) {
+				return true;
+			}
+
+			if ("no".equals(boolString) || "false".equals(boolString) || "off".equals(boolString)) {
+				return false;
+			}
+		}
+
+		return defaultValue;
+	}
+
+	public static byte getByteValue(String string, byte defaultValue) {
+		try {
+			if (AssertUtils.isNotEmpty(string)) {
+				return Byte.parseByte(string);
+			}
+		} catch (NumberFormatException e) {
+			LOGGER.debug("error getting byte from string: " + string, e);
+		}
+
+		return defaultValue;
+	}
+
+	public static char getCharValue(String string, char defaultValue) {
+		if (AssertUtils.isNotEmpty(string)) {
+			return string.charAt(0);
+		}
+
+		return defaultValue;
+	}
+
+	public static short getShortValue(String string, short defaultValue) {
+		try {
+			if (AssertUtils.isNotEmpty(string)) {
+				return Short.parseShort(string);
+			}
+		} catch (NumberFormatException e) {
+			LOGGER.debug("error getting short from string: " + string, e);
+		}
+
+		return defaultValue;
+	}
+
+	public static int getIntValue(String string, int defaultValue) {
+		try {
+			if (AssertUtils.isNotEmpty(string)) {
+				return Integer.parseInt(string);
+			}
+		} catch (NumberFormatException e) {
+			LOGGER.debug("error getting integer from string: " + string, e);
+		}
+
+		return defaultValue;
+	}
+
+	public static long getLongValue(String string, long defaultValue) {
+		try {
+			if (AssertUtils.isNotEmpty(string)) {
+				return Long.parseLong(string);
+			}
+		} catch (NumberFormatException e) {
+			LOGGER.debug("error getting long from string: " + string, e);
+		}
+
+		return defaultValue;
+	}
+
+	public static float getFloatValue(String string, float defaultValue) {
+		try {
+			if (AssertUtils.isNotEmpty(string)) {
+				return Float.parseFloat(string);
+			}
+		} catch (NumberFormatException e) {
+			LOGGER.debug("error getting long from string: " + string, e);
+		}
+
+		return defaultValue;
+	}
+
+	public static double getDoubleValue(String string, double defaultValue) {
+		try {
+			if (AssertUtils.isNotEmpty(string)) {
+				return Double.parseDouble(string);
+			}
+		} catch (NumberFormatException e) {
+			LOGGER.debug("error getting long from string: " + string, e);
+		}
+
+		return defaultValue;
+	}
+
+	public static byte[] deStringifyByteArray(String value) {
+		if (AssertUtils.isEmpty(value)) {
+			return null;
+		}
+
+		String[] tokens = value.split(COMMA_SEPARATOR_CHAR);
+		byte[] array = new byte[tokens.length];
+		for (int index = 0; index < tokens.length; index++) {
+			array[index] = Byte.parseByte(tokens[index]);
+		}
+
+		return array;
+	}
+
+	public static char[] deStringifyCharArray(String value) {
+		if (AssertUtils.isEmpty(value)) {
+			return null;
+		}
+
+		String[] tokens = value.split(COMMA_SEPARATOR_CHAR);
+		char[] array = new char[tokens.length];
+		for (int index = 0; index < tokens.length; index++) {
+			array[index] = tokens[index].charAt(0);
+		}
+
+		return array;
+	}
+
+	public static short[] deStringifyShortArray(String value) {
+		if (AssertUtils.isEmpty(value)) {
+			return null;
+		}
+
+		String[] tokens = value.split(COMMA_SEPARATOR_CHAR);
+		short[] array = new short[tokens.length];
+		for (int index = 0; index < tokens.length; index++) {
+			array[index] = Short.valueOf(tokens[index]);
+		}
+
+		return array;
+	}
+
+	public static boolean[] deStringifyBooleanArray(String value) {
+		if (AssertUtils.isEmpty(value)) {
+			return null;
+		}
+
+		String[] tokens = value.split(COMMA_SEPARATOR_CHAR);
+		boolean[] array = new boolean[tokens.length];
+		for (int index = 0; index < tokens.length; index++) {
+			array[index] = getBoolean(tokens[index]);
+		}
+
+		return array;
+	}
+
+	public static int[] deStringifyIntArray(String value) {
+		if (AssertUtils.isEmpty(value)) {
+			return null;
+		}
+
+		String[] tokens = value.split(COMMA_SEPARATOR_CHAR);
+		int[] array = new int[tokens.length];
+		for (int index = 0; index < tokens.length; index++) {
+			array[index] = Integer.parseInt(tokens[index]);
+		}
+
+		return array;
+	}
+
+	public static long[] deStringifyLongArray(String value) {
+		if (AssertUtils.isEmpty(value)) {
+			return null;
+		}
+
+		String[] tokens = value.split(COMMA_SEPARATOR_CHAR);
+		long[] array = new long[tokens.length];
+		for (int index = 0; index < tokens.length; index++) {
+			array[index] = Long.valueOf(tokens[index]);
+		}
+
+		return array;
+	}
+
+	public static float[] deStringifyFloatArray(String value) {
+		if (AssertUtils.isEmpty(value)) {
+			return null;
+		}
+
+		String[] tokens = value.split(COMMA_SEPARATOR_CHAR);
+		float[] array = new float[tokens.length];
+		for (int index = 0; index < tokens.length; index++) {
+			array[index] = Float.valueOf(tokens[index]);
+		}
+
+		return array;
+	}
+
+	public static double[] deStringifyDoubleArray(String value) {
+		if (AssertUtils.isEmpty(value)) {
+			return null;
+		}
+
+		String[] tokens = value.split(COMMA_SEPARATOR_CHAR);
+		double[] array = new double[tokens.length];
+		for (int index = 0; index < tokens.length; index++) {
+			array[index] = Double.valueOf(tokens[index]);
+		}
+
+		return array;
+	}
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/StringUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/StringUtils.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.jcrpersist.util;
 
 import org.slf4j.Logger;

--- a/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/StringUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/jcrpersist/util/StringUtils.java
@@ -29,8 +29,6 @@ import org.slf4j.LoggerFactory;
  * Part of the code of this class has been borrowed from the open-source project
  * <code>jerry-core</code> from https://github.com/sangupta/jerry-core.
  * 
- * @author sangupta
- *
  */
 public class StringUtils {
 

--- a/bundle/src/test/java/com/adobe/acs/commons/jcrpersist/util/AssertUtilsTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/jcrpersist/util/AssertUtilsTest.java
@@ -1,0 +1,35 @@
+package com.adobe.acs.commons.jcrpersist.util;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class AssertUtilsTest {
+	
+	@Test
+	public void testIsEmptyString() {
+		// strings
+		assertTrue(AssertUtils.isEmpty((String) null));
+		assertFalse(AssertUtils.isNotEmpty((String) null));
+
+		assertTrue(AssertUtils.isEmpty(""));
+		assertFalse(AssertUtils.isNotEmpty(""));
+
+		assertTrue(AssertUtils.isNotEmpty(" "));
+		assertFalse(AssertUtils.isEmpty(" "));
+
+		assertTrue(AssertUtils.isNotEmpty(" abc"));
+		assertFalse(AssertUtils.isEmpty(" abc"));
+	}
+	
+	@Test
+	public void testIsEmptyArray() {
+		assertTrue(AssertUtils.isEmpty((String[]) null));
+
+		assertTrue(AssertUtils.isEmpty((Object[]) null));
+		assertTrue(AssertUtils.isEmpty((Object[]) new Object[] { }));
+		assertFalse(AssertUtils.isEmpty((Object[]) new Object[] { new Object() }));
+
+		assertFalse(AssertUtils.isEmpty(new String[] { "", "" }));
+	}
+
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/jcrpersist/util/StringUtilsTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/jcrpersist/util/StringUtilsTest.java
@@ -1,0 +1,24 @@
+package com.adobe.acs.commons.jcrpersist.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StringUtilsTest {
+
+	@Test
+	public void testGetBoolean() {
+		Assert.assertFalse(StringUtils.getBoolean(null));
+		Assert.assertFalse(StringUtils.getBoolean(""));
+		Assert.assertFalse(StringUtils.getBoolean("abc"));
+		Assert.assertFalse(StringUtils.getBoolean("no"));
+
+		Assert.assertTrue(StringUtils.getBoolean("yes"));
+		Assert.assertTrue(StringUtils.getBoolean("yEs"));
+		Assert.assertTrue(StringUtils.getBoolean("YES"));
+		Assert.assertTrue(StringUtils.getBoolean("true"));
+		Assert.assertTrue(StringUtils.getBoolean("tRuE"));
+		Assert.assertTrue(StringUtils.getBoolean("TRUE"));
+	}
+
+	
+}

--- a/docs/jcr-persist.md
+++ b/docs/jcr-persist.md
@@ -1,0 +1,280 @@
+# JcrPersist
+
+`JcrPersist` is a simple no-intrusion ORM style framework for JCR/CRX. It allows you to read/write
+simple plain Java POJO on the JCR using Java reflection techniques. It needs no annotations
+to start with and provides multiple custom extension points for usage.
+
+All functionality of **JcrPersist** that can be used via annotations, can also be used programmatically
+using the **JcrPersist** APIs. This allows one to work with POJO objects whose source cannot be modified,
+such as from 3rd party frameworks like Twitter, Instagram, Facebook SDKs and all.
+
+Following are the primary differences from **Sling Models**:
+
+* It is 100% non-intrusive - no need to modify your POJO objects (extend from base-class/add-annotations) to work with
+* There are no build time steps to be made (no POM changes)
+* Any POJO can be used to both read/write objects
+* Collections (including implicit collections) are supported
+* Nested and composed objects are supported as well
+* All customizations can be done either by use of annotations (intrusive) or programmatically via `JcrPerist` APIs (non-intrusive).
+
+## Table of Contents
+
+   * [JcrPersist](#JcrPersist)
+      * [Usage](#usage)
+         * [Simple Example using Stocks](#simple-example-using-stocks)
+      * [Transient values](#transient-values)
+      * [Customization tweaks available](#customization-tweaks-available)
+         * [AEMPathProperty](#aempathproperty)
+         * [AEMProperty](#aemproperty)
+         * [AEMType](#aemtype)
+         * [AEMPropertyExclude](#aempropertyexclude)
+         * [AEMImplicitCollection](#aemimplicitcollection)
+      * [Extension points available](#extension-points-available)
+         * [TypeInstantiator](#typeinstantiator)
+         * [ValueMapReader](#valuemapreader)
+      * [TODO](#todo)
+      * [Developers](#developers)
+      
+## Usage
+
+### Simple Example using Stocks
+
+Consider the following Java POJO
+
+```java
+public class Stocks {
+
+	public long lastUpdated;
+	
+	public List<Stock> children;
+
+}
+
+public class Stock {
+
+	public String name;
+	
+	public double price;
+
+}
+``` 
+
+To read an object from the JCR,
+
+```java
+Stocks stocks = JcrPersist.read("/content/mysite/stocks", Stocks.class, resourceResolver);
+```
+
+To write the same updated `Stocks` instance back to JCR:
+
+```java
+JcrPersist.persist("/content/mysite/stocks", stocks, resourceResolver);
+``` 
+
+## Transient values
+
+`JcrPersist` by-default does not read/persist transient values. In case a transient attribute
+needs to be read, it can be annotated with `@AEMProperty` annotation (see below). Similarly,
+if a non-transient attribute needs to be ignored inside `JcrPerist` the `@AEMPropertyExclude` annotation
+can be be used for the same. See below for examples.
+
+```java
+public class Employee {
+
+	@AEMPath
+	public String employeeID;
+	
+	/**
+	 * This transient attribute will not be serialized by JcrPerist by default. Thus
+	 * to instruct JcrPerist to include this attribute as well, we can add an @AEMProperty
+	 * annotation to this attribute. This will ensure that the attribute gets serialized.
+	 */
+	@AEMProperty("myVisitedCount")
+	public transient int visitedCount;
+	
+	/**
+	 * This attribute is non-transient and thus to exclude this attribute
+	 * from JcrPerist serialization we add the annotation of @AEMPropertyExclude.
+	 */
+	@AEMPropertyExclude
+	public long salary;
+	
+}
+```
+
+The above can also be achieved using the following `JcrPerist` APIs without the need of having
+to add the annotations:
+
+```java
+// include the transient variable
+JcrPerist.includeField(Employee.class, "visitedCount", "myVisitedCount");
+
+// exclude the non-transient variable
+JcrPerist.excludeField(Employee.class, "salary");
+```
+
+## Customization tweaks available
+
+* AEMPathProperty
+* AEMProperty
+* AEMType
+* AEMPropertyExclude
+* AEMImplicitCollection
+
+### AEMPathProperty
+
+A path in the JCR repository can act as a unique key for any given object instance
+read or persisted. The path does not change, and if it does, then the object instance
+must be changed too.
+
+To declare the same, one can use the `@AEMPathProperty` annotation on a field and `JcrPerist`
+will use it in case available and not specified via API call:
+
+```java
+public class Stocks {
+
+	@AEMPathProperty
+	public String path;
+	
+	public long lastUpdated;
+	
+	public List<Stock> children;
+	
+}
+```
+
+```java
+// Once the instance is read via the call:
+Stocks stocks = JcrPerist.read("/content/mysite/stocks", Stocks.class, resourceResolver);
+
+// the value of stocks.path will point to /content/mysite/stocks
+Assert.assertEquals(stocks.path, "/content/mysite/stocks");
+```
+
+And once the path is set, the `save()` and `refresh()` APIs can be called:
+
+```java
+// the following call will refresh values in the instance from the JCR
+JcrPerist.refresh(stocks, resourceResolver);
+
+// and the following call will persist the values back in JCR
+JcrPerist.save(stocks, resourceResolver);
+```
+
+**Note:** The above `save()` and `refresh()` calls only work when a field is annotated
+with `@AEMPathProperty` annotation and the value is not-null.
+
+### AEMProperty
+
+When the attribute name does not match the JCR property name, `@AEMProperty` annotation
+can be used to signify the property name in JCR.
+
+```java
+public class Stocks {
+	
+	@AEMPathProperty
+	public String path;
+	
+	@AEMProperty("lastRefreshed")
+	public long lastUpdated;
+	
+	public List<Stock> children;
+	
+}
+```
+
+The same annotation can also be used to read declared transient variables. See above for more details.
+
+### AEMType
+
+The annotation indicates the `jcr:primary` type value to be used when persisting a class inside the JCR
+using `JcrPerist`. For example, the instances of the following class shall be persisted as `cq:Page` type when
+using `JcrPerist`.
+
+```java
+@AEMType(primaryType = "cq:Page", childType = "cq:PageContent")
+public class MyCustomPage {
+
+	// normal class attributes follow
+	
+}
+```
+
+Now if we perist an instance of this `MyCustomPage` class using the following, 2 nodes shall be created:
+
+* `/content/jcrpersist/pages/somePage` of the type of `cq:Page`
+* `/content/jcrpersist/pages/somePage/jcr:content` of the type of `cq:PageContent`
+
+```java
+JcrPerist.persist("/content/jcrpersist/pages/somePage", myCustomPageInstance, resourceResolver);
+```
+
+### AEMPropertyExclude
+
+This annotation is used over a class attribute to indicate that `JcrPerist` should skip the field from all
+serialization/deserialization methods. This ensures that a non-transient attribute can skip persistence.
+See above for more details.
+
+### AEMImplicitCollection
+
+This annotation indicates that the collection/array attribute of a given class is a direct
+implicit collection than being child nodes under the attribute name. 
+
+For example consider the following node hierarchy:
+
+```
+/content/mysite/stocks
+                  |
+                  +-- ADBE
+                  +-- APPL
+                  +-- GOOG 
+```
+
+The above can be modelled using the following class:
+
+```java
+public class MySite {
+
+	public List<Stock> stocks;
+
+}
+
+JcrPerist.read("/content/mysite", MySite.class, resourceResolver);
+```
+
+Now if we assume that the stocks node had its own properties, either directly, or using a
+`jcr:content` child node, we will miss on those properties. To facilitate the same, we can
+add the `@AEMImplicitCollection` annotation to the attribute. Thus, our `MySite` class would
+become:
+
+```java
+public class MySite {
+
+	public Stocks stocks;
+	
+}
+
+public class Stocks {
+
+	// attributes for /content/mysite/stocks node may follow here
+
+	@AEMImplicitCollection
+	public List<Stocks> children;
+
+}
+```
+
+The same can also be achieved using the following `JcrPerist` API:
+
+```java
+JcrPerist.setImplicitCollection(Stocks.class, "children");
+```
+
+## Extension points available
+
+* `TypeInstantiator` that provides for creating instances that do not have a no-arguments constructor
+* `ValueMapReader` for JCR objects that do not directly provide a `ValueMap` reading interface
+
+### TypeInstantiator
+
+### ValueMapReader


### PR DESCRIPTION
Hello - I am raising this PR to add a new framework/feature and to get a discussion started to see if-and-how it fits the world of the `AEM Commons` project. Below are more details on the framework. Please feel free to review/comment/ask-questions.

The code below is currently devoid of unit-tests, however, the code as part of this PR is 100% fully functional and tested using many support-classes. Am already working to re-create them into proper unit-tests, but would like to hear the feedback before completing that to ensure that any changes to this can be incorporated.

## JcrPersist

`JcrPersist` is a simple no-intrusion ORM style framework for JCR/CRX. It allows you to read/write
simple plain Java POJO on the JCR using Java reflection techniques. It needs no annotations
to start with and provides multiple custom extension points for usage.

All functionality of **JcrPersist** that can be used via annotations, can also be used programmatically using the **JcrPersist** APIs. This allows one to work with POJO objects whose source cannot be modified, such as from 3rd party frameworks like Twitter, Instagram, Facebook SDKs and all.

Following are the primary differences from **Sling Models**:

* It is 100% non-intrusive - no need to modify your POJO objects (extend from base-class/add-annotations) to work with
* There are no build time steps to be made (no POM changes)
* Any POJO can be used to both read/write objects
* Collections (including implicit collections) are supported
* Nested and composed objects are supported as well
* All customizations can be done either by use of annotations (intrusive) or programmatically via `JcrPerist` APIs (non-intrusive).

A simplest hello-world kind of example is as follows. Consider the following 2 value-objects:

```java
public class Stocks {

	public long lastUpdated;
	
	public List<Stock> children;

}

public class Stock {

	public String name;
	
	public double price;

}
``` 

To read an object from the JCR,

```java
Stocks stocks = JcrPersist.read("/content/mysite/stocks", Stocks.class, resourceResolver);
```

To write the same updated `Stocks` instance back to JCR:

```java
JcrPersist.persist("/content/mysite/stocks", stocks, resourceResolver);
``` 

More details can be found in the [docs/jcrpersist.md](https://github.com/sangupta/acs-aem-commons/blob/feature/jcr-persist/docs/jcr-persist.md) file (which is a part of this PR).