### PR TITLE
Make sure report tabulation is thread-safe

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/AssetReport.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/AssetReport.java
@@ -197,7 +197,7 @@ public class AssetReport extends ProcessDefinition implements Serializable {
         }
     }
 
-    private void tabulate(String path, Column counter, long amount) {
+    private synchronized void tabulate(String path, Column counter, long amount) {
         if (getDepth(path) < depthLimit && path.length() >= baseFolder.length()) {
             synchronized (report) {
                 EnumMap<Column, Long> row = getReportRow(path);


### PR DESCRIPTION
Added synchronization to the tabulation method to avoid race conditions