### PR TITLE
Check for Sitemap Servlet character encoding to be empty

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/SiteMapServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/SiteMapServlet.java
@@ -155,7 +155,7 @@ public final class SiteMapServlet extends SlingSafeMethodsServlet {
     protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {
         response.setContentType(request.getResponseContentType());
-        if (characterEncoding != null) {
+        if (StringUtils.isNotEmpty(this.characterEncoding)) {
             response.setCharacterEncoding(characterEncoding);
         }
         ResourceResolver resourceResolver = request.getResourceResolver();


### PR DESCRIPTION
### Summary
Our team discovered that when a character encoding was not defined when editing the configuration in `/system/console/configMgr` or sometimes when using a config file if `character.encoding` was not defined the configuration value would default to "", which broke the xml encoder. 
I simply added a quick check using String Utils to see make sure it is not empty or null before resetting the request.

### Test Plan
1. Edit the Site Map Configuration in `/system/console/configMgr` without defining  `character.encoding`
2. Access the sitemap as normal using `.sitemap.xml` on the defined page component
3. Note that the Sitemap renders using the default character encoding.