### PR TITLE
Issue #1150: Attempt to fix the invalid date in the dialog for the empty datetime value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 - #1148 - Properly handle blank character encoding in SiteMapServlet
 - #1122 - Add clientlib category to touchui-widgets to load in Create Page wizard.
+- #1150 - Fix the empty datetime value displayed as "invalid date" in the touchui dialog 
 
 ## [3.11.0] - 2017-10-18
 

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-widgets-init.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-widgets-init.js
@@ -87,8 +87,14 @@
         setDateField: function ($field, value) {
             var date = moment(new Date(value));
             var $parent = $field.parent();
-            $parent.find("input.coral-Textfield").val(date.format($parent.attr("data-displayed-format")));
-            $field.val(date.format($parent.attr("data-stored-format")));
+            if (date.isValid()) {
+                $parent.find("input.coral-Textfield").val(date.format($parent.attr("data-displayed-format")));
+                $field.val(date.format($parent.attr("data-stored-format")));
+            }
+            else {
+                $parent.find("input.coral-Textfield").val(value);
+                $field.val(value);
+            }
         },
 
         isRichTextField: function ($field) {


### PR DESCRIPTION
The issue is that if the datetime field has an empty value, moment format method will return "Invalid date". The fix is to check first if the date object is valid. If invalid, it should return value as is without modifying. 