### PR TITLE
Removing possible empty initialization of Granite.author

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-limit-parsys.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-limit-parsys.js
@@ -154,4 +154,4 @@
             extendComponentDrop();
         }
     });
-}(jQuery, jQuery(document), (window.Granite.author = window.Granite.author || {})));
+}(jQuery, jQuery(document), Granite.author));


### PR DESCRIPTION
https://github.com/Adobe-Consulting-Services/acs-aem-commons/blob/905efac7fda3509f5535c05fc60fd2f5eb776846/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/source/touchui-limit-parsys.js#L157

If someone who helped contribute to this item can help verify, that would be great!  Not positive why this initialization is there, and it's causing issues.

This line causes Granite.author to be initialized no matter what.  However, in all.js's setup of the file uploader, Granite.author (called ns.author there) is checked for initialization before proceeding.  Its empty initialization, then, breaks file uploader dialogs that are loaded in fullscreen dialogs.

For example, try loading up we.retail on a server with ACS commons installed, then try editing any image while your window is small enough that the editor opens in a full-screen separate URL.  The image uploader will not function due to a console error here:

`    function getAllowUploadFromDesign(element) {
        // In case the dialog has been opened outside of the Editor context, be conservative and restrict the upload
        if (!ns.author) {
            return;
        }`

This is not the case on any server where the above linked line has been removed. 

Seems like any lines above referencing gAuthor already must be resilient enough to not need further error handling since they would already be failing on the empty object, so I'm just turning off the empty initialization here.