### PR TITLE
class attribute fix composite multifield touchui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 - #842 - Fix issue with Environment Indicator title being reset
 - #1143 - Remove current page from result from PagesReferenceProvider
 - #1156 - Remove unnecessary initialization of `window.Granite.author`
+- #1160 - Fix fieldset selector to allow custom class attribute for touchui composite multifield
 
 ## [3.11.0] - 2017-10-18
 

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
@@ -105,7 +105,7 @@
         //reads multifield data from server, creates the nested composite multifields and fills them
         addDataInFields: function () {
             var cmf = this, mNames = [],
-                $fieldSets = $("[" + cmf.DATA_ACS_COMMONS_NESTED + "][class='coral-Form-fieldset']"),
+                $fieldSets = $("[" + cmf.DATA_ACS_COMMONS_NESTED + "][class~='coral-Form-fieldset']"),
                 $form = $fieldSets.closest("form.foundation-form"),
                 actionUrl = $form.attr("action") + ".json",
                 mValues, $field, name, $multifield;


### PR DESCRIPTION
Fixed the selector to allow custom class attribute such as
"section class="your-own-class coral-Form-fieldset" data-name="./data" data-acs-commons-nested="JSON_STORE"