### PR TITLE
Feature/multifield datepicker value not loaded in touchui dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 - #1156 - Remove unnecessary initialization of `window.Granite.author`
 - #1158 - Corrected incorrect date parsing/formatting in AuditLogSearch
 - #1160 - Fix fieldset selector to allow custom class attribute for touchui composite multifield
+- #1167 - Fix an error which reads the wrong name attribute for datepicker component
 
 ## [3.11.0] - 2017-10-18
 

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield-nodestore.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield-nodestore.js
@@ -213,8 +213,8 @@
 
             function fillValue($form, fieldSetName, $field, counter){
                 var name, value;
-                // for userpicker and richtext $field length is 2, excluding richtext
-                if($field.length > 1 && !$field.parent().hasClass("richtext-container")) {
+                // for userpicker, richtext and datepicker, $field length is 2 but only userpicker use the second name value
+                if($field.length > 1 && !$field.parent().hasClass("richtext-container") && !$field.parent().hasClass("coral-DatePicker")) {
                     name = $($field[1]).attr("name");
                 } else {
                     name = $field.attr("name");

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
@@ -218,8 +218,8 @@
 
         fillValue: function ($field, record) {
             var name, value;
-            // for userpicker $field length is 2
-            if($field.length > 1 && !$field.parent().hasClass("richtext-container")) {
+            // for userpicker, richtext and datepicker, $field length is 2 but only userpicker use the second name value
+            if($field.length > 1 && !$field.parent().hasClass("richtext-container") && !$field.parent().hasClass("coral-DatePicker")) {
                 name = $($field[1]).attr("name");
             } else {
                 name = $field.attr("name");


### PR DESCRIPTION
Like richtext field, the datepicker field should load the name from the first input instead of the second. The second input name is for typehint.