### PR TITLE
Use Java7 idiom 

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/dam/audio/impl/FFMpegAudioUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/dam/audio/impl/FFMpegAudioUtils.java
@@ -25,6 +25,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class FFMpegAudioUtils {
 
@@ -65,18 +67,11 @@ public class FFMpegAudioUtils {
     }
 
     public static final File createTempDir(File parentDir) throws IOException {
-        File tempDir = null;
-        try {
-            tempDir = File.createTempFile("cqdam", null, parentDir);
-            if (!tempDir.delete()) {
-                throw new IOException("Unable to delete temp directory.");
-            }
-            if (!tempDir.mkdir()) {
-                throw new IOException("Unable to create temp directory.");
-            }
-        } catch (IOException e) {
-            log.warn("could not create temp directory in the [{}] with the exception", parentDir, e);
+        Path tempPath = Files.createTempDirectory(parentDir.toPath(),"cqdam");
+        File tmpDir = tempPath.toFile();
+        if (!tmpDir.mkdir()) {
+            throw new IOException(String.format("Unable to create temp directory in directory [%s]", parentDir));
         }
-        return tempDir;
+        return tmpDir;
     }
 }


### PR DESCRIPTION
Sonar complained about the use of the workaround, which was suggested at SO for Java6. As we don't have the dependency on Java 6 anymore, get rid of it.

Additionally we should not swallow the exception, but just throw it.