### PR TITLE
HTTPCache: Added support for JSP sling:include and cq:include.

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImpl.java
@@ -399,9 +399,12 @@ public class HttpCacheEngineImpl extends AnnotatedStandardMBean implements HttpC
 
         // Copy the cached data into the servlet output stream.
         try {
-            IOUtils.copy(cacheContent.getInputDataStream(), response.getOutputStream());
-            if (log.isDebugEnabled()) {
-                log.debug("Response delivered from cache for the url [ {} ]", request.getRequestURI());
+            try{
+                IOUtils.copy(cacheContent.getInputDataStream(), response.getOutputStream());
+            }catch(IllegalStateException ex) {
+                //for JspResponseServletWrapper and other response wrappers that do not support outputstream.
+                //this will only work for text/html responses.
+                IOUtils.copy(cacheContent.getInputDataStream(), response.getWriter());
             }
 
             return true;


### PR DESCRIPTION
This will only work for text/html.

Currently, the JSP cq:include and sling:include tags don't work with the HTTP cache because the JspResponseOutputWrapper only supports the printwriter.