### PR TITLE
Feature/httpcache jsp compatibility

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImpl.java
@@ -399,13 +399,7 @@ public class HttpCacheEngineImpl extends AnnotatedStandardMBean implements HttpC
 
         // Copy the cached data into the servlet output stream.
         try {
-            try{
-                IOUtils.copy(cacheContent.getInputDataStream(), response.getOutputStream());
-            }catch(IllegalStateException ex) {
-                //for JspResponseServletWrapper and other response wrappers that do not support outputstream.
-                //this will only work for text/html responses.
-                IOUtils.copy(cacheContent.getInputDataStream(), response.getWriter());
-            }
+            serveCacheContentIntoResponse(response, cacheContent);
 
             return true;
         } catch (IOException e) {
@@ -531,8 +525,8 @@ public class HttpCacheEngineImpl extends AnnotatedStandardMBean implements HttpC
 
     }
 
-    //-------------------------<Mbean specific implementation>
 
+    //-------------------------<Mbean specific implementation>
     public HttpCacheEngineImpl() throws NotCompliantMBeanException {
         super(HttpCacheEngineMBean.class);
     }
@@ -630,5 +624,24 @@ public class HttpCacheEngineImpl extends AnnotatedStandardMBean implements HttpC
         }
 
         return tabularData;
+    }
+
+    /**
+     * Serves the cache content into the sling response.
+     * Has a fallback for wrappers that do not support the outputstream.
+     * @param response
+     * @param cacheContent
+     * @throws IOException
+     */
+    private void serveCacheContentIntoResponse(SlingHttpServletResponse response, CacheContent cacheContent)
+            throws IOException
+    {
+        try{
+            IOUtils.copy(cacheContent.getInputDataStream(), response.getOutputStream());
+        }catch(IllegalStateException ex) {
+            //for JspResponseServletWrapper and other response wrappers that do not support outputstream.
+            //this will only work for text/html responses.
+            IOUtils.copy(cacheContent.getInputDataStream(), response.getWriter());
+        }
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImpl.java
@@ -641,7 +641,7 @@ public class HttpCacheEngineImpl extends AnnotatedStandardMBean implements HttpC
         }catch(IllegalStateException ex) {
             //for JspResponseServletWrapper and other response wrappers that do not support outputstream.
             //this will only work for text/html responses.
-            IOUtils.copy(cacheContent.getInputDataStream(), response.getWriter());
+            IOUtils.copy(cacheContent.getInputDataStream(), response.getWriter(), response.getCharacterEncoding());
         }
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImpl.java
@@ -399,9 +399,12 @@ public class HttpCacheEngineImpl extends AnnotatedStandardMBean implements HttpC
 
         // Copy the cached data into the servlet output stream.
         try {
-            IOUtils.copy(cacheContent.getInputDataStream(), response.getOutputStream());
-            if (log.isDebugEnabled()) {
-                log.debug("Response delivered from cache for the url [ {} ]", request.getRequestURI());
+            try{
+                IOUtils.copy(cacheContent.getInputDataStream(), response.getOutputStream());
+            }catch(IllegalStateException ex) {
+                //for JspResponseServletWrapper and other response wrappers that do not support outputstream.
+                //this will only work for text/html responses.
+                IOUtils.copy(cacheContent.getInputDataStream(), response.getWriter());
             }
 
             return true;


### PR DESCRIPTION
For JspResponseServletWrapper and other response wrappers that do not support outputstream.
This will only work for text/html responses.