### PR TITLE
Fixing Redirect Manager Action Load Issues 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 [Unreleased]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-3.13.0...HEAD
 
 ### Fixed
+- #1213 - Fixing Redirect Manager Action Load Issues 
 - #1204 - Unclosed stream in VersionedClientlibsTransformerFactory
 - #1205 - Calculate MD5 based on minified clientlib (in case minification is enabled). This is a workaround around the AEM limitation to only correctly invalidate either the minified or unminified clientlib).
 

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/clientlibs/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/clientlibs/app.js
@@ -22,7 +22,8 @@ angular.module('acs-commons-redirectmappage-app', ['acsCoral', 'ACS.Commons.noti
     .controller('MainCtrl', ['$scope', '$http', '$timeout', 'NotificationsService',
     function ($scope, $http, $timeout, NotificationsService) {
 
-        $scope.updateRedirectMap = function () {
+        $scope.updateRedirectMap = function (e) {
+        	e.preventDefault();
         	
 			NotificationsService.running(true);
 
@@ -42,7 +43,8 @@ angular.module('acs-commons-redirectmappage-app', ['acsCoral', 'ACS.Commons.noti
             return false;
         };
         
-        $scope.postValues = function (id) {
+        $scope.postValues = function (e, id) {
+        	e.preventDefault();
         	
 			NotificationsService.running(true);
 

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/content.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/content.jsp
@@ -21,7 +21,7 @@
 					<p>
 						<fmt:message key="The redirect map file will be combined with the redirects configured in AEM to create the final set of redirects." />
 					</p>
-					<form action="${resource.path}" method="post" class="coral-Form--aligned" id="fn-acsCommons-update-redirect" ng-submit="updateRedirectMap()" enctype="multipart/form-data">
+					<form action="${resource.path}" method="post" class="coral-Form--aligned" id="fn-acsCommons-update-redirect" ng-submit="updateRedirectMap($event)" enctype="multipart/form-data">
 				    	<input type="hidden" name="./redirectMap.txt@TypeHint" value="nt:file" />
 						
 						<div class="coral-Form-fieldwrapper">
@@ -57,7 +57,7 @@
 					<c:forEach var="redirects" items="${sling2:listChildren(redirectParent)}">
 				    	<cq:include path="${redirects.path}" resourceType="${redirects.resourceType}" />
 					</c:forEach>
-					<form action="${resource.path}/redirects/*" method="post" class="coral-Form--aligned" id="fn-acsCommons-add-redirectconfig" ng-submit="postValues('fn-acsCommons-add-redirectconfig')">
+					<form action="${resource.path}/redirects/*" method="post" class="coral-Form--aligned" id="fn-acsCommons-add-redirectconfig" ng-submit="postValues($event,'fn-acsCommons-add-redirectconfig')">
 						<input type="hidden" name="sling:resourceType" value="acs-commons/components/utilities/redirects" />
 						<input type="hidden" name="jcr:created" />
 						<input type="hidden" name="jcr:createdBy" />

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirects/redirects.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirects/redirects.jsp
@@ -3,7 +3,7 @@
 <%@taglib prefix="sling2" uri="http://sling.apache.org/taglibs/sling" %>
 <cq:setContentBundle />
 <div class="coral-Well">
-	<form action="${resource.path}" method="post" class="coral-Form--aligned" id="fn-acsCommons-save_redirects_${resource.name}" ng-submit="postValues('fn-acsCommons-save_redirects_${resource.name}')">
+	<form action="${resource.path}" method="post" class="coral-Form--aligned" id="fn-acsCommons-save_redirects_${resource.name}" ng-submit="postValues($event,'fn-acsCommons-save_redirects_${resource.name}')">
 		<input type="hidden" name="jcr:modified" />
 		<input type="hidden" name="jcr:modifiedBy" />
 		<div class="coral-Form-fieldwrapper">
@@ -70,7 +70,7 @@
 			<button class="coral-Button coral-Button--primary">Save</button>
 		</div>
 	</form>
-	<form action="${resource.path}" method="post" class="coral-Form--aligned" id="fn-acsCommons-remove_redirects_${resource.name}" ng-submit="postValues('fn-acsCommons-remove_redirects_${resource.name}')">
+	<form action="${resource.path}" method="post" class="coral-Form--aligned" id="fn-acsCommons-remove_redirects_${resource.name}" ng-submit="postValues($event,'fn-acsCommons-remove_redirects_${resource.name}')">
 		<input type="hidden"  name=":operation" value="delete" />
 		<div class="coral-Form-fieldwrapper" >
 			<button class="coral-Button coral-Button--warning">Remove</button>


### PR DESCRIPTION
Fixed an issue where the angular events were propagating which caused issues if AEM took longer to respond than usual where it would display the Raw sling page or double up actions