### PR TITLE
ACS AEM Commons should not have compile scope dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 - #1213 - Fixing Redirect Manager Action Load Issues 
 - #1204 - Unclosed stream in VersionedClientlibsTransformerFactory
 - #1205 - Calculate MD5 based on minified clientlib (in case minification is enabled). This is a workaround around the AEM limitation to only correctly invalidate either the minified or unminified clientlib).
+- #1217 - Make compile-scope dependencies provided-scope and add enforcer rule to ensure no compile scope dependencies are added in the future.
 
 ### Added
 

--- a/bundle-twitter/pom.xml
+++ b/bundle-twitter/pom.xml
@@ -81,7 +81,7 @@
             <groupId>com.adobe.acs</groupId>
             <artifactId>acs-aem-commons-bundle</artifactId>
             <version>${project.version}</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -66,7 +66,7 @@
                         </Import-Package>
                         <Embed-Dependency>guava</Embed-Dependency>
                         <Sling-Model-Packages>
-                        	com.adobe.acs.commons.redirectmaps.models,
+                            com.adobe.acs.commons.redirectmaps.models,
                             com.adobe.acs.commons.version.model,
                             com.adobe.acs.commons.wcm.comparisons.model,
                             com.adobe.acs.commons.workflow.bulk.execution.model,
@@ -164,6 +164,7 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.5</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -364,6 +365,7 @@
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.models.api</artifactId>
             <version>1.2.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.jackrabbit</groupId>
@@ -451,7 +453,7 @@
             <groupId>com.google.code.tld-generator</groupId>
             <artifactId>tld-generator</artifactId>
             <version>1.1</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
             <optional>true</optional>
             <exclusions>
                 <exclusion>

--- a/content/pom.xml
+++ b/content/pom.xml
@@ -165,11 +165,13 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>acs-aem-commons-bundle</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>acs-aem-commons-bundle-twitter</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.jcr</groupId>
@@ -224,6 +226,7 @@
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
             <version>3.2.1</version>
+            <scope>provided</scope>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,21 @@
                             </rules>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>enforce-banned-dependencies</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <bannedDependencies>
+                                    <excludes>
+                                        <exclude>*:*:*:*:compile</exclude>
+                                    </excludes>
+                                </bannedDependencies>
+                            </rules>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>


### PR DESCRIPTION
It looks like we have unintentionally added some compile-scope dependencies and/or added them in error.