### PR TITLE
added a config option to generate extensionless urls in sitemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 - #989 - Dynamic Loading for optional Touch UI ClientLibraries.
 - #1218 - New Report Builder Feature.
+- #1228 - Added config option to have extensionless URLs in sitemap
 
 ### Changed
 

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/SiteMapServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/SiteMapServlet.java
@@ -80,7 +80,7 @@ public final class SiteMapServlet extends SlingSafeMethodsServlet {
     private static final boolean DEFAULT_INCLUDE_INHERITANCE_VALUE = false;
 
     private static final String DEFAULT_EXTERNALIZER_DOMAIN = "publish";
-    
+
     private static final boolean DEFAULT_EXTENSIONLESS_URLS = false;
 
     @Property(value = DEFAULT_EXTERNALIZER_DOMAIN, label = "Externalizer Domain", description = "Must correspond to a configuration of the Externalizer component.")
@@ -106,10 +106,10 @@ public final class SiteMapServlet extends SlingSafeMethodsServlet {
 
     @Property(boolValue = DEFAULT_INCLUDE_INHERITANCE_VALUE, label = "Include Inherit Value", description = "If true searches for the frequency and priority attribute in the current page if null looks in the parent.")
     private static final String PROP_INCLUDE_INHERITANCE_VALUE = "include.inherit";
-    
+
     @Property(boolValue = DEFAULT_EXTENSIONLESS_URLS, label = "Extensionless URLs", description = "If true, external links included in sitemap are generated without .html extension")
     private static final String PROP_EXTENSIONLESS_URLS = "extensionless.urls";
-    
+
     @Property(label = "Character Encoding", description = "If not set, the container's default is used (ISO-8859-1 for Jetty)")
     private static final String PROP_CHARACTER_ENCODING_PROPERTY = "character.encoding";
 
@@ -133,9 +133,9 @@ public final class SiteMapServlet extends SlingSafeMethodsServlet {
     private List<String> damAssetTypes;
 
     private String excludeFromSiteMapProperty;
-    
+
     private String characterEncoding;
-    
+
     private boolean extensionlessUrls;
 
     @Activate
@@ -154,10 +154,9 @@ public final class SiteMapServlet extends SlingSafeMethodsServlet {
                 .asList(PropertiesUtil.toStringArray(properties.get(PROP_DAM_ASSETS_TYPES), new String[0]));
         this.excludeFromSiteMapProperty = PropertiesUtil.toString(properties.get(PROP_EXCLUDE_FROM_SITEMAP_PROPERTY),
                 NameConstants.PN_HIDE_IN_NAV);
-        this.characterEncoding = PropertiesUtil.toString(properties.get(PROP_CHARACTER_ENCODING_PROPERTY),
-                null);
+        this.characterEncoding = PropertiesUtil.toString(properties.get(PROP_CHARACTER_ENCODING_PROPERTY), null);
         this.extensionlessUrls = PropertiesUtil.toBoolean(properties.get(PROP_EXTENSIONLESS_URLS),
-        		DEFAULT_EXTENSIONLESS_URLS);
+                DEFAULT_EXTENSIONLESS_URLS);
     }
 
     @Override
@@ -232,13 +231,13 @@ public final class SiteMapServlet extends SlingSafeMethodsServlet {
         }
         stream.writeStartElement(NS, "url");
         String loc = "";
-        
-        if(!extensionlessUrls){
-        	loc = externalizer.externalLink(resolver, externalizerDomain, String.format("%s.html", page.getPath()));
+
+        if (!extensionlessUrls) {
+            loc = externalizer.externalLink(resolver, externalizerDomain, String.format("%s.html", page.getPath()));
         } else {
-        	loc = externalizer.externalLink(resolver, externalizerDomain, String.format("%s/", page.getPath()));
+            loc = externalizer.externalLink(resolver, externalizerDomain, String.format("%s/", page.getPath()));
         }
-        
+
         writeElement(stream, "loc", loc);
 
         if (includeLastModified) {
@@ -249,7 +248,8 @@ public final class SiteMapServlet extends SlingSafeMethodsServlet {
         }
 
         if (includeInheritValue) {
-            HierarchyNodeInheritanceValueMap hierarchyNodeInheritanceValueMap = new HierarchyNodeInheritanceValueMap(page.getContentResource());
+            HierarchyNodeInheritanceValueMap hierarchyNodeInheritanceValueMap = new HierarchyNodeInheritanceValueMap(
+                    page.getContentResource());
             writeFirstPropertyValue(stream, "changefreq", changefreqProperties, hierarchyNodeInheritanceValueMap);
             writeFirstPropertyValue(stream, "priority", priorityProperties, hierarchyNodeInheritanceValueMap);
         } else {
@@ -257,7 +257,6 @@ public final class SiteMapServlet extends SlingSafeMethodsServlet {
             writeFirstPropertyValue(stream, "changefreq", changefreqProperties, properties);
             writeFirstPropertyValue(stream, "priority", priorityProperties, properties);
         }
-        
 
         stream.writeEndElement();
     }
@@ -282,7 +281,8 @@ public final class SiteMapServlet extends SlingSafeMethodsServlet {
         Resource contentResource = asset.adaptTo(Resource.class).getChild(JcrConstants.JCR_CONTENT);
         if (contentResource != null) {
             if (includeInheritValue) {
-                HierarchyNodeInheritanceValueMap hierarchyNodeInheritanceValueMap = new HierarchyNodeInheritanceValueMap(contentResource);
+                HierarchyNodeInheritanceValueMap hierarchyNodeInheritanceValueMap = new HierarchyNodeInheritanceValueMap(
+                        contentResource);
                 writeFirstPropertyValue(stream, "changefreq", changefreqProperties, hierarchyNodeInheritanceValueMap);
                 writeFirstPropertyValue(stream, "priority", priorityProperties, hierarchyNodeInheritanceValueMap);
             } else {

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/SiteMapServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/SiteMapServlet.java
@@ -80,6 +80,8 @@ public final class SiteMapServlet extends SlingSafeMethodsServlet {
     private static final boolean DEFAULT_INCLUDE_INHERITANCE_VALUE = false;
 
     private static final String DEFAULT_EXTERNALIZER_DOMAIN = "publish";
+    
+    private static final boolean DEFAULT_EXTENSIONLESS_URLS = false;
 
     @Property(value = DEFAULT_EXTERNALIZER_DOMAIN, label = "Externalizer Domain", description = "Must correspond to a configuration of the Externalizer component.")
     private static final String PROP_EXTERNALIZER_DOMAIN = "externalizer.domain";
@@ -104,6 +106,9 @@ public final class SiteMapServlet extends SlingSafeMethodsServlet {
 
     @Property(boolValue = DEFAULT_INCLUDE_INHERITANCE_VALUE, label = "Include Inherit Value", description = "If true searches for the frequency and priority attribute in the current page if null looks in the parent.")
     private static final String PROP_INCLUDE_INHERITANCE_VALUE = "include.inherit";
+    
+    @Property(boolValue = DEFAULT_EXTENSIONLESS_URLS, label = "Extensionless URLs", description = "If true, external links included in sitemap are generated without .html extension")
+    private static final String PROP_EXTENSIONLESS_URLS = "extensionless.urls";
     
     @Property(label = "Character Encoding", description = "If not set, the container's default is used (ISO-8859-1 for Jetty)")
     private static final String PROP_CHARACTER_ENCODING_PROPERTY = "character.encoding";
@@ -130,6 +135,8 @@ public final class SiteMapServlet extends SlingSafeMethodsServlet {
     private String excludeFromSiteMapProperty;
     
     private String characterEncoding;
+    
+    private boolean extensionlessUrls;
 
     @Activate
     protected void activate(Map<String, Object> properties) {
@@ -149,6 +156,8 @@ public final class SiteMapServlet extends SlingSafeMethodsServlet {
                 NameConstants.PN_HIDE_IN_NAV);
         this.characterEncoding = PropertiesUtil.toString(properties.get(PROP_CHARACTER_ENCODING_PROPERTY),
                 null);
+        this.extensionlessUrls = PropertiesUtil.toBoolean(properties.get(PROP_EXTENSIONLESS_URLS),
+        		DEFAULT_EXTENSIONLESS_URLS);
     }
 
     @Override
@@ -222,8 +231,14 @@ public final class SiteMapServlet extends SlingSafeMethodsServlet {
             return;
         }
         stream.writeStartElement(NS, "url");
-
-        String loc = externalizer.externalLink(resolver, externalizerDomain, String.format("%s.html", page.getPath()));
+        String loc = "";
+        
+        if(!extensionlessUrls){
+        	loc = externalizer.externalLink(resolver, externalizerDomain, String.format("%s.html", page.getPath()));
+        } else {
+        	loc = externalizer.externalLink(resolver, externalizerDomain, String.format("%s/", page.getPath()));
+        }
+        
         writeElement(stream, "loc", loc);
 
         if (includeLastModified) {


### PR DESCRIPTION
Added a config option to generate extensionless urls in sitemap. By default, URLs will have .html extension but if extensionless.urls property is set to 'true', there will be none.