### PR TITLE
Utility functions for fetching properties from a Resource

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/util/ResourceUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/ResourceUtil.java
@@ -22,11 +22,7 @@ package com.adobe.acs.commons.util;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 
-import javax.jcr.Node;
-import javax.jcr.PathNotFoundException;
-import javax.jcr.Property;
-import javax.jcr.RepositoryException;
-import javax.jcr.Value;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -36,30 +32,6 @@ import java.util.List;
  */
 public abstract class ResourceUtil {
     /**
-     * Private ctor to hide the defualt public ctor.
-     */
-    private ResourceUtil() {
-    }
-
-    /**
-     * Get a single-value property from a resource.
-     *
-     * If the property does not exist, this function will return null instead
-     * of throwing a RepositoryException.
-     *
-     * @param resource The resource from which to get the property.
-     * @param namePattern Property name.
-     * @return Property value.
-     */
-    public static Property getProperty(Resource resource, String namePattern) throws RepositoryException {
-        try {
-            return resource.adaptTo(Node.class).getProperty(namePattern);
-        } catch (PathNotFoundException p) {
-            return null;
-        }
-    }
-
-    /**
      * Convenience method for getting a single-value boolean property from
      * a resource.
      *
@@ -67,9 +39,8 @@ public abstract class ResourceUtil {
      * @param namePattern Property name.
      * @return Property value if present, else false.
      */
-    public static boolean getPropertyBoolean(Resource resource, String namePattern) throws RepositoryException {
-        Property prop = getProperty(resource, namePattern);
-        return prop != null && prop.getBoolean();
+    public static boolean getPropertyBoolean(Resource resource, String namePattern) {
+        return resource.getValueMap().get(namePattern, false);
     }
 
     /**
@@ -80,9 +51,28 @@ public abstract class ResourceUtil {
      * @param namePattern Property name.
      * @return Property value.
      */
-    public static Calendar getPropertyDate(Resource resource, String namePattern) throws RepositoryException {
-        Property prop = getProperty(resource, namePattern);
-        return prop != null ? prop.getDate() : null;
+    public static Calendar getPropertyDate(Resource resource, String namePattern) {
+        return resource.getValueMap().get(namePattern, Calendar.class);
+    }
+
+    /**
+     * Conventience method for getting a single-value BigDecimal property from a resource.
+     * @param resource The resource from which to get the property.
+     * @param namePattern Property name.
+     * @return Property value.
+     */
+    public static BigDecimal getPropertyDecimal(Resource resource, String namePattern) {
+        return resource.getValueMap().get(namePattern, BigDecimal.class);
+    }
+
+    /**
+     * Conventience method for getting a single-value Double property from a resource.
+     * @param resource The resource from which to get the property.
+     * @param namePattern Property name.
+     * @return Property value.
+     */
+    public static Double getPropertyDouble(Resource resource, String namePattern) {
+        return resource.getValueMap().get(namePattern, Double.class);
     }
 
     /**
@@ -91,9 +81,8 @@ public abstract class ResourceUtil {
      * @param namePattern Property name.
      * @return Property value.
      */
-    public static Long getPropertyLong(Resource resource, String namePattern) throws RepositoryException {
-        Property prop = getProperty(resource, namePattern);
-        return prop != null ? prop.getLong() : null;
+    public static Long getPropertyLong(Resource resource, String namePattern) {
+        return resource.getValueMap().get(namePattern, Long.class);
     }
 
     /**
@@ -105,7 +94,7 @@ public abstract class ResourceUtil {
      * @param namePattern Name of the property storing the resource path.
      * @return The referenced resource.
      */
-    public static Resource getPropertyReference(Resource resource, String namePattern) throws RepositoryException {
+    public static Resource getPropertyReference(Resource resource, String namePattern) {
         String referencePath = getPropertyString(resource, namePattern);
         if (StringUtils.isNotBlank(referencePath)) {
             return resource.getResourceResolver().getResource(referencePath);
@@ -120,9 +109,8 @@ public abstract class ResourceUtil {
      * @param namePattern Property name.
      * @return Property value.
      */
-    public static String getPropertyString(Resource resource, String namePattern) throws RepositoryException {
-        Property prop = getProperty(resource, namePattern);
-        return prop != null ? prop.getString() : null;
+    public static String getPropertyString(Resource resource, String namePattern) {
+        return resource.getValueMap().get(namePattern, String.class);
     }
 
     /**
@@ -132,30 +120,14 @@ public abstract class ResourceUtil {
      * @param namePattern Property name.
      * @return Property values.
      */
-    public static List<String> getPropertyStrings(Resource resource, String namePattern) throws RepositoryException {
-        List<String> props = new ArrayList<>();
-        for (Value val : getPropertyValues(resource, namePattern)) {
-            props.add(val.getString());
-        }
-        return props;
-    }
-
-    /**
-     * Internal method to get all values for a multi-value property.
-     *
-     * @param resource The resource from which to get the property.
-     * @param namePattern Property name.
-     * @return Property values.
-     */
-    private static Value[] getPropertyValues(Resource resource, String namePattern) throws RepositoryException {
-        Property prop = getProperty(resource, namePattern);
-        if (prop != null) {
-            if (prop.isMultiple()) {
-                return prop.getValues();
-            } else {
-                return (new Value[]{prop.getValue()});
+    public static List<String> getPropertyStrings(Resource resource, String namePattern) {
+        String[] vals = resource.getValueMap().get(namePattern, String[].class);
+        List<String> valsList = new ArrayList<>();
+        if (vals != null) {
+            for (String val : vals) {
+                valsList.add(val);
             }
         }
-        return new Value[0];
+        return valsList;
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/util/ResourceUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/ResourceUtil.java
@@ -36,6 +36,12 @@ import java.util.List;
  */
 public abstract class ResourceUtil {
     /**
+     * Private ctor to hide the defualt public ctor.
+     */
+    private ResourceUtil() {
+    }
+
+    /**
      * Get a single-value property from a resource.
      *
      * If the property does not exist, this function will return null instead

--- a/bundle/src/main/java/com/adobe/acs/commons/util/ResourceUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/ResourceUtil.java
@@ -23,10 +23,10 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -52,6 +52,18 @@ public abstract class ResourceUtil {
     }
 
     /**
+     * Convenience method for getting a single-value Calendar property from
+     * a resource.
+     *
+     * @param resource The resource from which to get the property.
+     * @param namePattern Property name.
+     * @return Property value.
+     */
+    public static Calendar getPropertyCalendar(Resource resource, String namePattern) {
+        return resource.getValueMap().get(namePattern, Calendar.class);
+    }
+
+    /**
      * Convenience method for getting a single-value Date property from
      * a resource.
      *
@@ -59,8 +71,8 @@ public abstract class ResourceUtil {
      * @param namePattern Property name.
      * @return Property value.
      */
-    public static Calendar getPropertyDate(Resource resource, String namePattern) {
-        return resource.getValueMap().get(namePattern, Calendar.class);
+    public static Date getPropertyDate(Resource resource, String namePattern) {
+        return resource.getValueMap().get(namePattern, Date.class);
     }
 
     /**

--- a/bundle/src/main/java/com/adobe/acs/commons/util/ResourceUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/ResourceUtil.java
@@ -24,7 +24,9 @@ import org.apache.sling.api.resource.Resource;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -128,12 +130,6 @@ public abstract class ResourceUtil {
      */
     public static List<String> getPropertyStrings(Resource resource, String namePattern) {
         String[] vals = resource.getValueMap().get(namePattern, String[].class);
-        List<String> valsList = new ArrayList<>();
-        if (vals != null) {
-            for (String val : vals) {
-                valsList.add(val);
-            }
-        }
-        return valsList;
+        return vals != null ? Arrays.asList(vals) : Collections.EMPTY_LIST;
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/util/ResourceUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/ResourceUtil.java
@@ -32,6 +32,12 @@ import java.util.List;
  */
 public abstract class ResourceUtil {
     /**
+     * Private ctor to hide the defualt public ctor.
+     */
+    private ResourceUtil() {
+    }
+
+    /**
      * Convenience method for getting a single-value boolean property from
      * a resource.
      *

--- a/bundle/src/main/java/com/adobe/acs/commons/util/ResourceUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/ResourceUtil.java
@@ -1,0 +1,155 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.Resource;
+
+import javax.jcr.Node;
+import javax.jcr.PathNotFoundException;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+/**
+ * Utils for JCR resources.
+ */
+public abstract class ResourceUtil {
+    /**
+     * Get a single-value property from a resource.
+     *
+     * If the property does not exist, this function will return null instead
+     * of throwing a RepositoryException.
+     *
+     * @param resource The resource from which to get the property.
+     * @param namePattern Property name.
+     * @return Property value.
+     */
+    public static Property getProperty(Resource resource, String namePattern) throws RepositoryException {
+        try {
+            return resource.adaptTo(Node.class).getProperty(namePattern);
+        } catch (PathNotFoundException p) {
+            return null;
+        }
+    }
+
+    /**
+     * Convenience method for getting a single-value boolean property from
+     * a resource.
+     *
+     * @param resource The resource from which to get the property.
+     * @param namePattern Property name.
+     * @return Property value if present, else false.
+     */
+    public static boolean getPropertyBoolean(Resource resource, String namePattern) throws RepositoryException {
+        Property prop = getProperty(resource, namePattern);
+        return prop != null && prop.getBoolean();
+    }
+
+    /**
+     * Convenience method for getting a single-value Date property from
+     * a resource.
+     *
+     * @param resource The resource from which to get the property.
+     * @param namePattern Property name.
+     * @return Property value.
+     */
+    public static Calendar getPropertyDate(Resource resource, String namePattern) throws RepositoryException {
+        Property prop = getProperty(resource, namePattern);
+        return prop != null ? prop.getDate() : null;
+    }
+
+    /**
+     * Conventience method for getting a single-value Long property from a resource.
+     * @param resource The resource from which to get the property.
+     * @param namePattern Property name.
+     * @return Property value.
+     */
+    public static Long getPropertyLong(Resource resource, String namePattern) throws RepositoryException {
+        Property prop = getProperty(resource, namePattern);
+        return prop != null ? prop.getLong() : null;
+    }
+
+    /**
+     * Get a Resource from a path specified in a resource property.
+     *
+     * Returns null if the path cannot be resolved to a resource.
+     *
+     * @param resource The resource from which to get the property.
+     * @param namePattern Name of the property storing the resource path.
+     * @return The referenced resource.
+     */
+    public static Resource getPropertyReference(Resource resource, String namePattern) throws RepositoryException {
+        String referencePath = getPropertyString(resource, namePattern);
+        if (StringUtils.isNotBlank(referencePath)) {
+            return resource.getResourceResolver().getResource(referencePath);
+        }
+        return null;
+    }
+
+    /**
+     * Convenience method for getting a single-value String property from a resource.
+     *
+     * @param resource The resource from which to get the property.
+     * @param namePattern Property name.
+     * @return Property value.
+     */
+    public static String getPropertyString(Resource resource, String namePattern) throws RepositoryException {
+        Property prop = getProperty(resource, namePattern);
+        return prop != null ? prop.getString() : null;
+    }
+
+    /**
+     * Convenience method for getting a multi-value String property from a resource.
+     *
+     * @param resource The resource from which to get the property.
+     * @param namePattern Property name.
+     * @return Property values.
+     */
+    public static List<String> getPropertyStrings(Resource resource, String namePattern) throws RepositoryException {
+        List<String> props = new ArrayList<>();
+        for (Value val : getPropertyValues(resource, namePattern)) {
+            props.add(val.getString());
+        }
+        return props;
+    }
+
+    /**
+     * Internal method to get all values for a multi-value property.
+     *
+     * @param resource The resource from which to get the property.
+     * @param namePattern Property name.
+     * @return Property values.
+     */
+    private static Value[] getPropertyValues(Resource resource, String namePattern) throws RepositoryException {
+        Property prop = getProperty(resource, namePattern);
+        if (prop != null) {
+            if (prop.isMultiple()) {
+                return prop.getValues();
+            } else {
+                return (new Value[]{prop.getValue()});
+            }
+        }
+        return new Value[0];
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/util/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/package-info.java
@@ -20,7 +20,7 @@
 /**
  * Miscellaneous Utilities.
  */
-@Version("2.5.0")
+@Version("2.6.0")
 package com.adobe.acs.commons.util;
 
 import aQute.bnd.annotation.Version;

--- a/bundle/src/test/java/com/adobe/acs/commons/util/ResourceUtilTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/ResourceUtilTest.java
@@ -1,0 +1,157 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.util;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.GregorianCalendar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ResourceUtilTest {
+    @Rule
+    public final SlingContext context = new SlingContext(ResourceResolverType.JCR_MOCK);
+
+    private Resource resource;
+
+    @Before
+    public void setupJcrRepository() throws RepositoryException {
+        ResourceResolver resourceResolver = context.resourceResolver();
+
+        Session session = resourceResolver.adaptTo(Session.class);
+        Node mynode = session.getRootNode().addNode("mynode");
+        mynode.setProperty("bool_prop_true", true);
+        mynode.setProperty("bool_prop_false", false);
+        mynode.setProperty("date_prop", new GregorianCalendar(2016, 10, 15, 12, 34, 56));
+        mynode.setProperty("long_prop", 1234L);
+        mynode.setProperty("ref_prop", "/mynode/myothernode");
+        mynode.setProperty("ref_prop_bad_path", "/mynode/boguspath");
+        mynode.setProperty("string_prop", "prop val");
+        mynode.setProperty("strings_prop", new String[] {"a", "bcd", "e"});
+        Node myothernode = mynode.addNode("myothernode");
+        myothernode.setProperty("string_prop", "other node prop val");
+
+        resource = resourceResolver.getResource("/mynode");
+    }
+
+    @Test
+    public void testGetProperty() throws RepositoryException {
+        Property prop = ResourceUtil.getProperty(resource, "string_prop");
+
+        assertNotNull(prop);
+        assertEquals("prop val", prop.getString());
+    }
+
+    @Test
+    public void testGetPropertyReturnsNullIfPropertyNotFound() throws RepositoryException {
+        assertNull(ResourceUtil.getProperty(resource, "bogus_prop_name"));
+    }
+
+    @Test
+    public void testGetPropertyBoolean() throws RepositoryException {
+        assertTrue(ResourceUtil.getPropertyBoolean(resource, "bool_prop_true"));
+        assertFalse(ResourceUtil.getPropertyBoolean(resource, "bool_prop_false"));
+    }
+
+    @Test
+    public void testGetPropertyBooleanReturnsFalseWhenPropertyNotFound() throws RepositoryException {
+        assertFalse(ResourceUtil.getPropertyBoolean(resource, "bogus_prop_name"));
+    }
+
+    @Test
+    public void testGetPropertyDate() throws RepositoryException {
+        assertEquals(new GregorianCalendar(2016, 10, 15, 12, 34, 56), ResourceUtil.getPropertyDate(resource, "date_prop"));
+    }
+
+    @Test
+    public void testGetPropertyDateReturnsNullIfPropertyNotFound() throws RepositoryException {
+        assertNull(ResourceUtil.getPropertyDate(resource, "bogus_prop_name"));
+    }
+
+    @Test
+    public void testGetPropertyLong() throws RepositoryException {
+        assertEquals(new Long(1234L), ResourceUtil.getPropertyLong(resource, "long_prop"));
+    }
+
+    @Test
+    public void testGetPropertyLongReturnsNullIfPropertyNotFound() throws RepositoryException {
+        assertNull(ResourceUtil.getPropertyLong(resource, "bogus_prop_name"));
+    }
+
+    @Test
+    public void testGetPropertyReference() throws RepositoryException {
+        Resource reference = ResourceUtil.getPropertyReference(resource, "ref_prop");
+        assertNotNull(reference);
+        assertEquals("/mynode/myothernode", reference.getPath());
+    }
+
+    @Test
+    public void testGetPropertyReferenceReturnsNullIfPathNotFound() throws RepositoryException {
+        assertNull(ResourceUtil.getPropertyReference(resource, "ref_prop_bad_path"));
+    }
+
+    @Test
+    public void testGetPropertyReferenceReturnsNullIfPropertyNotFound() throws RepositoryException {
+        assertNull(ResourceUtil.getPropertyReference(resource, "bogus_prop_name"));
+    }
+
+    @Test
+    public void testGetPropertyString() throws RepositoryException {
+        assertEquals("prop val", ResourceUtil.getPropertyString(resource, "string_prop"));
+    }
+
+    @Test
+    public void testGetPropertyStringReturnsNullIfPropertyNotFound() throws RepositoryException {
+        assertNull(ResourceUtil.getPropertyString(resource, "bogus_prop_name"));
+    }
+
+    @Test
+    public void testGetPropertyStrings() throws RepositoryException {
+        assertEquals(Arrays.asList("a", "bcd", "e"), ResourceUtil.getPropertyStrings(resource, "strings_prop"));
+    }
+
+    @Test
+    public void testGetPropertyStringsReturnsListForSingleValue() throws RepositoryException {
+        assertEquals(Collections.singletonList("prop val"), ResourceUtil.getPropertyStrings(resource, "string_prop"));
+    }
+
+    @Test
+    public void testGetPropertyStringsReturnsEmptyListIfPropertyNotFound() throws RepositoryException {
+        assertEquals(new ArrayList<>(), ResourceUtil.getPropertyStrings(resource, "bogus_prop_name"));
+    }
+
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/util/ResourceUtilTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/ResourceUtilTest.java
@@ -87,8 +87,18 @@ public class ResourceUtilTest {
     }
 
     @Test
+    public void testGetPropertyCalendar() {
+        assertEquals(new GregorianCalendar(2016, 10, 15, 12, 34, 56), ResourceUtil.getPropertyCalendar(resource, "date_prop"));
+    }
+
+    @Test
+    public void testGetPropertyCalendarReturnsNullIfPropertyNotFound() {
+        assertNull(ResourceUtil.getPropertyCalendar(resource, "bogus_prop_name"));
+    }
+
+    @Test
     public void testGetPropertyDate() {
-        assertEquals(new GregorianCalendar(2016, 10, 15, 12, 34, 56), ResourceUtil.getPropertyDate(resource, "date_prop"));
+        assertEquals(new GregorianCalendar(2016, 10, 15, 12, 34, 56).getTime(), ResourceUtil.getPropertyDate(resource, "date_prop"));
     }
 
     @Test

--- a/bundle/src/test/java/com/adobe/acs/commons/util/ResourceUtilTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/ResourceUtilTest.java
@@ -28,9 +28,9 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import javax.jcr.Node;
-import javax.jcr.Property;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -55,9 +55,14 @@ public class ResourceUtilTest {
         Session session = resourceResolver.adaptTo(Session.class);
         Node mynode = session.getRootNode().addNode("mynode");
         mynode.setProperty("bool_prop_true", true);
+        mynode.setProperty("bool_prop_true_str", "true");
         mynode.setProperty("bool_prop_false", false);
+        mynode.setProperty("bool_prop_false_str", "false");
         mynode.setProperty("date_prop", new GregorianCalendar(2016, 10, 15, 12, 34, 56));
+        mynode.setProperty("dbl_prop", 1234.567d);
+        mynode.setProperty("dbl_prop_str", "1234.567");
         mynode.setProperty("long_prop", 1234L);
+        mynode.setProperty("long_prop_str", "1234");
         mynode.setProperty("ref_prop", "/mynode/myothernode");
         mynode.setProperty("ref_prop_bad_path", "/mynode/boguspath");
         mynode.setProperty("string_prop", "prop val");
@@ -69,88 +74,104 @@ public class ResourceUtilTest {
     }
 
     @Test
-    public void testGetProperty() throws RepositoryException {
-        Property prop = ResourceUtil.getProperty(resource, "string_prop");
-
-        assertNotNull(prop);
-        assertEquals("prop val", prop.getString());
-    }
-
-    @Test
-    public void testGetPropertyReturnsNullIfPropertyNotFound() throws RepositoryException {
-        assertNull(ResourceUtil.getProperty(resource, "bogus_prop_name"));
-    }
-
-    @Test
-    public void testGetPropertyBoolean() throws RepositoryException {
+    public void testGetPropertyBoolean() {
         assertTrue(ResourceUtil.getPropertyBoolean(resource, "bool_prop_true"));
+        assertTrue(ResourceUtil.getPropertyBoolean(resource, "bool_prop_true_str"));
         assertFalse(ResourceUtil.getPropertyBoolean(resource, "bool_prop_false"));
+        assertFalse(ResourceUtil.getPropertyBoolean(resource, "bool_prop_false_str"));
     }
 
     @Test
-    public void testGetPropertyBooleanReturnsFalseWhenPropertyNotFound() throws RepositoryException {
+    public void testGetPropertyBooleanReturnsFalseWhenPropertyNotFound() {
         assertFalse(ResourceUtil.getPropertyBoolean(resource, "bogus_prop_name"));
     }
 
     @Test
-    public void testGetPropertyDate() throws RepositoryException {
+    public void testGetPropertyDate() {
         assertEquals(new GregorianCalendar(2016, 10, 15, 12, 34, 56), ResourceUtil.getPropertyDate(resource, "date_prop"));
     }
 
     @Test
-    public void testGetPropertyDateReturnsNullIfPropertyNotFound() throws RepositoryException {
+    public void testGetPropertyDateReturnsNullIfPropertyNotFound() {
         assertNull(ResourceUtil.getPropertyDate(resource, "bogus_prop_name"));
     }
 
     @Test
-    public void testGetPropertyLong() throws RepositoryException {
-        assertEquals(new Long(1234L), ResourceUtil.getPropertyLong(resource, "long_prop"));
+    public void testGetPropertyDecimal() {
+        assertEquals(new BigDecimal("1234.567"), ResourceUtil.getPropertyDecimal(resource, "dbl_prop"));
+        assertEquals(new BigDecimal("1234.567"), ResourceUtil.getPropertyDecimal(resource, "dbl_prop_str"));
+        assertEquals(new BigDecimal("1234"), ResourceUtil.getPropertyDecimal(resource, "long_prop"));
+        assertEquals(new BigDecimal("1234"), ResourceUtil.getPropertyDecimal(resource, "long_prop_str"));
     }
 
     @Test
-    public void testGetPropertyLongReturnsNullIfPropertyNotFound() throws RepositoryException {
+    public void testGetPropertyDecimalReturnsNullIfPropertyNotFound() {
+        assertNull(ResourceUtil.getPropertyDecimal(resource, "bogus_prop_name"));
+    }
+
+    @Test
+    public void testGetPropertyDouble() {
+        assertEquals(new Double(1234.567d), ResourceUtil.getPropertyDouble(resource, "dbl_prop"));
+        assertEquals(new Double(1234.567d), ResourceUtil.getPropertyDouble(resource, "dbl_prop_str"));
+        assertEquals(new Double(1234L), ResourceUtil.getPropertyDouble(resource, "long_prop"));
+        assertEquals(new Double(1234L), ResourceUtil.getPropertyDouble(resource, "long_prop_str"));
+    }
+
+    @Test
+    public void testGetPropertyDoubleReturnsNullIfPropertyNotFound() {
+        assertNull(ResourceUtil.getPropertyDouble(resource, "bogus_prop_name"));
+    }
+
+    @Test
+    public void testGetPropertyLong() {
+        assertEquals(new Long(1234L), ResourceUtil.getPropertyLong(resource, "long_prop"));
+        assertEquals(new Long(1234L), ResourceUtil.getPropertyLong(resource, "long_prop_str"));
+    }
+
+    @Test
+    public void testGetPropertyLongReturnsNullIfPropertyNotFound() {
         assertNull(ResourceUtil.getPropertyLong(resource, "bogus_prop_name"));
     }
 
     @Test
-    public void testGetPropertyReference() throws RepositoryException {
+    public void testGetPropertyReference() {
         Resource reference = ResourceUtil.getPropertyReference(resource, "ref_prop");
         assertNotNull(reference);
         assertEquals("/mynode/myothernode", reference.getPath());
     }
 
     @Test
-    public void testGetPropertyReferenceReturnsNullIfPathNotFound() throws RepositoryException {
+    public void testGetPropertyReferenceReturnsNullIfPathNotFound() {
         assertNull(ResourceUtil.getPropertyReference(resource, "ref_prop_bad_path"));
     }
 
     @Test
-    public void testGetPropertyReferenceReturnsNullIfPropertyNotFound() throws RepositoryException {
+    public void testGetPropertyReferenceReturnsNullIfPropertyNotFound() {
         assertNull(ResourceUtil.getPropertyReference(resource, "bogus_prop_name"));
     }
 
     @Test
-    public void testGetPropertyString() throws RepositoryException {
+    public void testGetPropertyString() {
         assertEquals("prop val", ResourceUtil.getPropertyString(resource, "string_prop"));
     }
 
     @Test
-    public void testGetPropertyStringReturnsNullIfPropertyNotFound() throws RepositoryException {
+    public void testGetPropertyStringReturnsNullIfPropertyNotFound() {
         assertNull(ResourceUtil.getPropertyString(resource, "bogus_prop_name"));
     }
 
     @Test
-    public void testGetPropertyStrings() throws RepositoryException {
+    public void testGetPropertyStrings() {
         assertEquals(Arrays.asList("a", "bcd", "e"), ResourceUtil.getPropertyStrings(resource, "strings_prop"));
     }
 
     @Test
-    public void testGetPropertyStringsReturnsListForSingleValue() throws RepositoryException {
+    public void testGetPropertyStringsReturnsListForSingleValue() {
         assertEquals(Collections.singletonList("prop val"), ResourceUtil.getPropertyStrings(resource, "string_prop"));
     }
 
     @Test
-    public void testGetPropertyStringsReturnsEmptyListIfPropertyNotFound() throws RepositoryException {
+    public void testGetPropertyStringsReturnsEmptyListIfPropertyNotFound() {
         assertEquals(new ArrayList<>(), ResourceUtil.getPropertyStrings(resource, "bogus_prop_name"));
     }
 


### PR DESCRIPTION
Handful of fully tested utility functions for grabbing properties off of a Resource without having to change to adapt to a `Node` in the calling code.  Of particular use is the `getPropertyStrings()` function which automatically handles the case where a value is a single value in the JCR instead of an array and `getPropertyReference()` which grabs a resource reference.