### PR TITLE
Add the shared and global properties resources to the bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 [Unreleased]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-3.14.10...HEAD
 
+### Changed
+- #1284 - Expose the shared and global properties resources via bindings.
+
 ## [3.14.10] - 2018-03-08
 
 ### Added

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/SharedComponentProperties.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/SharedComponentProperties.java
@@ -28,6 +28,9 @@ public interface SharedComponentProperties {
     String GLOBAL_PROPERTIES = "globalProperties";
     String MERGED_PROPERTIES = "mergedProperties";
 
+    String SHARED_PROPERTIES_RESOURCE = SHARED_PROPERTIES + "Resource";
+    String GLOBAL_PROPERTIES_RESOURCE = GLOBAL_PROPERTIES + "Resource";
+
     String NN_GLOBAL_COMPONENT_PROPERTIES = "global-component-properties";
     String NN_SHARED_COMPONENT_PROPERTIES = "shared-component-properties";
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesBindingsValuesProvider.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesBindingsValuesProvider.java
@@ -84,6 +84,7 @@ public class SharedComponentPropertiesBindingsValuesProvider implements Bindings
             Resource globalPropsResource = resource.getResourceResolver().getResource(globalPropsPath);
             if (globalPropsResource != null) {
                 bindings.put(SharedComponentProperties.GLOBAL_PROPERTIES, globalPropsResource.getValueMap());
+                bindings.put(SharedComponentProperties.GLOBAL_PROPERTIES_RESOURCE, globalPropsResource);
             }
 
             String sharedPropsPath = pageRoot.getPath() + "/jcr:content/" + SharedComponentProperties.NN_SHARED_COMPONENT_PROPERTIES +  "/"
@@ -91,6 +92,7 @@ public class SharedComponentPropertiesBindingsValuesProvider implements Bindings
             Resource sharedPropsResource = resource.getResourceResolver().getResource(sharedPropsPath);
             if (sharedPropsResource != null) {
                 bindings.put(SharedComponentProperties.SHARED_PROPERTIES, sharedPropsResource.getValueMap());
+                bindings.put(SharedComponentProperties.SHARED_PROPERTIES_RESOURCE, sharedPropsResource);
             }
         } else {
             log.debug("Could not determine shared properties root for resource {}", resource.getPath());

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Shared Component Properties.
  */
-@aQute.bnd.annotation.Version("1.0.0")
+@aQute.bnd.annotation.Version("1.1.0")
 package com.adobe.acs.commons.wcm.properties.shared;

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesBindingsValuesProviderTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesBindingsValuesProviderTest.java
@@ -1,0 +1,97 @@
+package com.adobe.acs.commons.wcm.properties.shared.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.adobe.acs.commons.wcm.PageRootProvider;
+import com.adobe.acs.commons.wcm.properties.shared.SharedComponentProperties;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.components.Component;
+import com.day.cq.wcm.api.components.ComponentManager;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.powermock.reflect.Whitebox;
+
+import java.util.HashMap;
+import javax.script.Bindings;
+import javax.script.SimpleBindings;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SharedComponentPropertiesBindingsValuesProviderTest {
+
+  public static final String SITE_ROOT = "/content/acs-commons";
+  public static final String RESOURCE_TYPE = "acs-commons/components/content/generic-text";
+
+  private PageRootProvider pageRootProvider;
+  private Resource resource;
+  private Resource sharedPropsResource;
+  private Resource globalPropsResource;
+  private Page page;
+  private Bindings bindings;
+  private Component component;
+  private ResourceResolver resourceResolver;
+  private ComponentManager componentManager;
+  private ValueMap sharedProps;
+  private ValueMap globalProps;
+
+  @Before
+  public void setUp() throws Exception {
+    resource = mock(Resource.class);
+    pageRootProvider = mock(PageRootProvider.class);
+    page = mock(Page.class);
+    bindings = new SimpleBindings();
+    component = mock(Component.class);
+    sharedPropsResource = mock(Resource.class);
+    globalPropsResource = mock(Resource.class);
+    resourceResolver = mock(ResourceResolver.class);
+    componentManager = mock(ComponentManager.class);
+
+    String globalPropsPath = SITE_ROOT + "/jcr:content/" + SharedComponentProperties.NN_GLOBAL_COMPONENT_PROPERTIES;
+    String sharedPropsPath = SITE_ROOT + "/jcr:content/" + SharedComponentProperties.NN_SHARED_COMPONENT_PROPERTIES +  "/"
+        + RESOURCE_TYPE;
+
+    bindings.put("resource", resource);
+
+    when(resource.getResourceResolver()).thenReturn(resourceResolver);
+    when(resourceResolver.getResource(sharedPropsPath)).thenReturn(sharedPropsResource);
+    when(resourceResolver.getResource(globalPropsPath)).thenReturn(globalPropsResource);
+    when(resourceResolver.adaptTo(ComponentManager.class)).thenReturn(componentManager);
+    when(componentManager.getComponentOfResource(resource)).thenReturn(component);
+
+    when(page.getPath()).thenReturn(SITE_ROOT);
+    when(pageRootProvider.getRootPage(resource)).thenReturn(page);
+    when(component.getResourceType()).thenReturn(RESOURCE_TYPE);
+    when(sharedPropsResource.getName()).thenReturn("Shared Properties Resource");
+    when(globalPropsResource.getName()).thenReturn("Global Properties Resource");
+
+    sharedProps = new ValueMapDecorator(new HashMap<String, Object>());
+    globalProps = new ValueMapDecorator(new HashMap<String, Object>());
+    sharedProps.put("shared", "value");
+    globalProps.put("global", "value");
+
+    when(globalPropsResource.getValueMap()).thenReturn(globalProps);
+    when(sharedPropsResource.getValueMap()).thenReturn(sharedProps);
+  }
+
+  @Test
+  public void addBindings() {
+    final SharedComponentPropertiesBindingsValuesProvider sharedComponentPropertiesBindingsValuesProvider
+        = new SharedComponentPropertiesBindingsValuesProvider();
+
+    Whitebox.setInternalState(sharedComponentPropertiesBindingsValuesProvider, "pageRootProvider", pageRootProvider);
+
+    sharedComponentPropertiesBindingsValuesProvider.addBindings(bindings);
+
+    assertEquals(sharedPropsResource, bindings.get(SharedComponentProperties.SHARED_PROPERTIES_RESOURCE));
+    assertEquals(globalPropsResource, bindings.get(SharedComponentProperties.GLOBAL_PROPERTIES_RESOURCE));
+    assertEquals(sharedProps, bindings.get(SharedComponentProperties.SHARED_PROPERTIES));
+    assertEquals(globalProps, bindings.get(SharedComponentProperties.GLOBAL_PROPERTIES));
+  }
+}


### PR DESCRIPTION
The shared resources are required when working with CoralUI 3 multi-field values in HTL.
