### PR TITLE
Verify parent resource is not a NonExistingResource.

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/errorpagehandler/impl/ErrorPageHandlerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/errorpagehandler/impl/ErrorPageHandlerImpl.java
@@ -541,7 +541,7 @@ public final class ErrorPageHandlerImpl implements ErrorPageHandlerService {
 
         // Quick check for the Parent; Handles common case of deactivated pages
         final Resource parent = resource.getParent();
-        if (parent != null) {
+        if (parent != null && !ResourceUtil.isNonExistingResource(resource)) {
             log.debug("Found real aggregate resource via getParent() at [ {} ]", parent.getPath());
             return parent;
         }


### PR DESCRIPTION
On AEM 6.3.1.2 calling getParent() on a NonExistingResource can
return NonExistingResource even if the resource exists in the repository.