### PR TITLE
fixing the recurssive call for S3 Asset upload.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ### Fixed
 
+- #1291 - S3 Asset Ingestor stops after 1000 Assets attempting to be imported
 - #1286 - Error page handler now verifies parent resource is not a NonExistingResource
 - #1288 - Restrict the redirect map file upload to .txt file extension
 

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/S3AssetIngestor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/S3AssetIngestor.java
@@ -153,7 +153,7 @@ public class S3AssetIngestor extends AssetIngestor {
             }
         });
         if (listing.isTruncated()) {
-            createFolders(manager, s3Client.listNextBatchOfObjects(listing));
+        	importAssets(manager, s3Client.listNextBatchOfObjects(listing));
         }
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/S3AssetIngestor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/S3AssetIngestor.java
@@ -153,7 +153,7 @@ public class S3AssetIngestor extends AssetIngestor {
             }
         });
         if (listing.isTruncated()) {
-        	importAssets(manager, s3Client.listNextBatchOfObjects(listing));
+            importAssets(manager, s3Client.listNextBatchOfObjects(listing));
         }
     }
 


### PR DESCRIPTION
This is to enable to recursively upload the Assets from S3. Instead of calling ImportAssets, call was being made to CreateFolders. 

First the S3 would always give only 1K objects in the getObjectList, which was getting processed as part of the ImportAssets. Once this list was exhausted, the next set of list was requested and the same ImportAssets method was supposed to be called. Instead the call was being made to CreateFolder. The correction is been made.