### PR TITLE
remove number suffix from component instance name to compare with design name

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/classicui-configure-parsys-placeholder.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/source/js/classicui-configure-parsys-placeholder.js
@@ -90,7 +90,7 @@
 
             if (cellSearchPathInfo) {
                 for(var i = 0; i < parNames.length; i++) {
-                    var prop = parNames[i];
+                    var prop = parNames[i].replace(/_\d+$/, "");
                     if (_.has(cellSearchPathInfo, prop)) { 
                         cellSearchPathInfo = cellSearchPathInfo[prop];
                     } 


### PR DESCRIPTION
This is for the classic ui parsys configuration. We have an aem component based on bootstrap panelgroup which creates several instances of a parsys. AEM adds a numeric suffix to each instance name. This suffix must be removed to find the corresponding design name. 