### PR TITLE
#1283 - Updated PagesReferenceProvider to return the path to the cq:P…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 [Unreleased]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-3.14.12...HEAD
 
+### Fixed
+- #1283: Updated PagesReferenceProvider to return the path to the cq:Page rather than cq:PageContent as the reference.
+
 ### Changed
 - #1284 - Expose the shared and global properties resources via bindings.
 

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PagesReferenceProvider.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PagesReferenceProvider.java
@@ -132,7 +132,7 @@ public final class PagesReferenceProvider implements ReferenceProvider {
     private Reference getReference(Page page) {
         return new Reference(TYPE_PAGE,
                 String.format("%s (Page)", page.getName()),
-                page.getContentResource(),
+                page.getContentResource().getParent(),
                 getLastModifiedTimeOfResource(page));
     }
 

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PagesReferenceProviderTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PagesReferenceProviderTest.java
@@ -170,6 +170,15 @@ public class PagesReferenceProviderTest {
 
     }
 
+    @Test
+    public void testPageReferenceResourcePath() throws Exception {
+        // The references resource should point to the cq:Page and not the [cq:Pages]/jcr:content per https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/1283
+        List<Reference> actual = instance.findReferences(context.resourceResolver().getResource("/content/geometrixx/oneref/jcr:content"));
+        assertNotNull(actual);
+        assertEquals(1, actual.size());
+        assertEquals("/content/geometrixx/en", actual.get(0).getResource().getPath());
+    }
+
     private Page registerPage(String path, String name) {
         Page result = mock(Page.class, path);
         when(pageManager.getContainingPage(path)).thenReturn(result);


### PR DESCRIPTION
…age rather than cq:PageContent as the reference.

Fixes issue: https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/1283

I adjusted the code to it uses the cq:Page path and not the [cq:Page]/jcr:content as the reference. I tested it in AEM 6.2 and in AEM 6.4 GA and both quite the expected payloads up for replication.

@justinedelson  / @kalyanar - would be great for a quick sanity check... not sure why this didn't use the path to the [cq:Page] to begin with.

![image](https://user-images.githubusercontent.com/1451868/38287899-57f37d66-379b-11e8-93a0-04e9173c2ec0.png)
