### PR TITLE
Feature/httpcache jcrstorage bugfixes

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/jcr/impl/JCRHttpCacheStoreImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/jcr/impl/JCRHttpCacheStoreImpl.java
@@ -156,7 +156,7 @@ public class JCRHttpCacheStoreImpl extends AbstractJCRCacheMBean<CacheKey, Cache
     public static final int     DEFAULT_SAVEDELTA           = 500;
 
     // 1 week.
-    public static final int     DEFAULT_EXPIRETIMEINSECONDS = 604800;
+    public static final int     DEFAULT_EXPIRETIMEINSECONDS = -1;
 
     private static final Logger log = LoggerFactory.getLogger(JCRHttpCacheStoreImpl.class);
 

--- a/content/src/main/content/jcr_root/var/acs-commons/httpcache/root/_rep_policy.xml
+++ b/content/src/main/content/jcr_root/var/acs-commons/httpcache/root/_rep_policy.xml
@@ -4,6 +4,6 @@
     <allow
             jcr:primaryType="rep:GrantACE"
             rep:principalName="acs-commons-httpcache-jcr-storage-service"
-            rep:privileges="{Name}[jcr:read,jcr:write]"
+            rep:privileges="{Name}[jcr:all]"
     />
 </jcr:root>


### PR DESCRIPTION
I thought I tested this before. But now when I run the code on a fresh 6.3 instance, I get an AccessDenied exception. the jcr:all seems necessary on the system user for the HTTPCache JCR storage.