### PR TITLE
Redirect Manager Enhancement: Entry Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 - #1278 - EvolutionContext refactored to contain a method returning version history
 - #1344 - Update Felix Plugin URL for Ensure Oak Index to match documentation/example code.
 
+### Added
+- #1347 - Redirect Map Entry editor
+
 ### Changed
 - #1343 - CodeClimate now checks for license header
 

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/AddEntryServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/AddEntryServlet.java
@@ -1,0 +1,89 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.redirectmaps.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import javax.servlet.ServletException;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.felix.scr.annotations.sling.SlingServlet;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.acs.commons.redirectmaps.models.MapEntry;
+import com.adobe.acs.commons.redirectmaps.models.RedirectMapModel;
+import com.day.cq.commons.jcr.JcrConstants;
+import com.google.common.net.MediaType;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * Servlet for adding a line into the redirect map text file
+ */
+@SlingServlet(methods = { "POST" }, resourceTypes = {
+		"acs-commons/components/utilities/redirectmappage" }, selectors = {
+				"addentry" }, extensions = { "json" }, metatype = false)
+public class AddEntryServlet extends SlingAllMethodsServlet {
+
+	private static final long serialVersionUID = -1704915461516132101L;
+	private static final Logger log = LoggerFactory.getLogger(AddEntryServlet.class);
+	private Gson gson = new Gson();
+
+	protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
+			throws ServletException, IOException {
+		log.trace("doPost");
+
+		int idx = Integer.parseInt(request.getParameter("idx"), 10);
+		String source = request.getParameter("source");
+		String target = request.getParameter("target");
+		log.debug("Removing entry with {} {} at {}",source, target, idx);
+
+		InputStream is = request.getResource().getChild(RedirectMapModel.MAP_FILE_NODE).adaptTo(InputStream.class);
+		List<String> lines = IOUtils.readLines(is);
+		log.debug("Loaded {} lines", lines.size());
+
+		lines.add(idx, source+" "+target);
+		log.debug("Added entry...");
+
+		ModifiableValueMap mvm = request.getResource().getChild(RedirectMapModel.MAP_FILE_NODE)
+				.getChild(JcrConstants.JCR_CONTENT).adaptTo(ModifiableValueMap.class);
+		mvm.put(JcrConstants.JCR_DATA, StringUtils.join(lines, "\n"));
+		request.getResourceResolver().commit();
+		request.getResourceResolver().refresh();
+		log.debug("Changes saved...");
+
+		log.debug("Requesting redirect maps from {}", request.getResource());
+		RedirectMapModel redirectMap = request.getResource().adaptTo(RedirectMapModel.class);
+
+		response.setContentType(MediaType.JSON_UTF_8.toString());
+
+		IOUtils.write(gson.toJson(redirectMap.getEntries(), new TypeToken<List<MapEntry>>() {
+		}.getType()), response.getOutputStream(), StandardCharsets.UTF_8);
+	}
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/AddEntryServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/AddEntryServlet.java
@@ -21,7 +21,6 @@ package com.adobe.acs.commons.redirectmaps.impl;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import javax.servlet.ServletException;
@@ -32,16 +31,11 @@ import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.ModifiableValueMap;
-import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.acs.commons.redirectmaps.models.MapEntry;
 import com.adobe.acs.commons.redirectmaps.models.RedirectMapModel;
 import com.day.cq.commons.jcr.JcrConstants;
-import com.google.common.net.MediaType;
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 
 /**
  * Servlet for adding a line into the redirect map text file
@@ -49,11 +43,10 @@ import com.google.gson.reflect.TypeToken;
 @SlingServlet(methods = { "POST" }, resourceTypes = {
         "acs-commons/components/utilities/redirectmappage" }, selectors = {
                 "addentry" }, extensions = { "json" }, metatype = false)
-public class AddEntryServlet extends SlingAllMethodsServlet {
+public class AddEntryServlet extends RedirectEntriesServlet {
 
     private static final long serialVersionUID = -1704915461516132101L;
     private static final Logger log = LoggerFactory.getLogger(AddEntryServlet.class);
-    private Gson gson = new Gson();
 
     protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {
@@ -78,12 +71,6 @@ public class AddEntryServlet extends SlingAllMethodsServlet {
         request.getResourceResolver().refresh();
         log.debug("Changes saved...");
 
-        log.debug("Requesting redirect maps from {}", request.getResource());
-        RedirectMapModel redirectMap = request.getResource().adaptTo(RedirectMapModel.class);
-
-        response.setContentType(MediaType.JSON_UTF_8.toString());
-
-        IOUtils.write(gson.toJson(redirectMap.getEntries(), new TypeToken<List<MapEntry>>() {
-        }.getType()), response.getOutputStream(), StandardCharsets.UTF_8);
+        super.doGet(request, response);
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/AddEntryServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/AddEntryServlet.java
@@ -47,43 +47,43 @@ import com.google.gson.reflect.TypeToken;
  * Servlet for adding a line into the redirect map text file
  */
 @SlingServlet(methods = { "POST" }, resourceTypes = {
-		"acs-commons/components/utilities/redirectmappage" }, selectors = {
-				"addentry" }, extensions = { "json" }, metatype = false)
+        "acs-commons/components/utilities/redirectmappage" }, selectors = {
+                "addentry" }, extensions = { "json" }, metatype = false)
 public class AddEntryServlet extends SlingAllMethodsServlet {
 
-	private static final long serialVersionUID = -1704915461516132101L;
-	private static final Logger log = LoggerFactory.getLogger(AddEntryServlet.class);
-	private Gson gson = new Gson();
+    private static final long serialVersionUID = -1704915461516132101L;
+    private static final Logger log = LoggerFactory.getLogger(AddEntryServlet.class);
+    private Gson gson = new Gson();
 
-	protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
-			throws ServletException, IOException {
-		log.trace("doPost");
+    protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
+            throws ServletException, IOException {
+        log.trace("doPost");
 
-		int idx = Integer.parseInt(request.getParameter("idx"), 10);
-		String source = request.getParameter("source");
-		String target = request.getParameter("target");
-		log.debug("Removing entry with {} {} at {}",source, target, idx);
+        int idx = Integer.parseInt(request.getParameter("idx"), 10);
+        String source = request.getParameter("source");
+        String target = request.getParameter("target");
+        log.debug("Removing entry with {} {} at {}",source, target, idx);
 
-		InputStream is = request.getResource().getChild(RedirectMapModel.MAP_FILE_NODE).adaptTo(InputStream.class);
-		List<String> lines = IOUtils.readLines(is);
-		log.debug("Loaded {} lines", lines.size());
+        InputStream is = request.getResource().getChild(RedirectMapModel.MAP_FILE_NODE).adaptTo(InputStream.class);
+        List<String> lines = IOUtils.readLines(is);
+        log.debug("Loaded {} lines", lines.size());
 
-		lines.add(idx, source+" "+target);
-		log.debug("Added entry...");
+        lines.add(idx, source+" "+target);
+        log.debug("Added entry...");
 
-		ModifiableValueMap mvm = request.getResource().getChild(RedirectMapModel.MAP_FILE_NODE)
-				.getChild(JcrConstants.JCR_CONTENT).adaptTo(ModifiableValueMap.class);
-		mvm.put(JcrConstants.JCR_DATA, StringUtils.join(lines, "\n"));
-		request.getResourceResolver().commit();
-		request.getResourceResolver().refresh();
-		log.debug("Changes saved...");
+        ModifiableValueMap mvm = request.getResource().getChild(RedirectMapModel.MAP_FILE_NODE)
+                .getChild(JcrConstants.JCR_CONTENT).adaptTo(ModifiableValueMap.class);
+        mvm.put(JcrConstants.JCR_DATA, StringUtils.join(lines, "\n"));
+        request.getResourceResolver().commit();
+        request.getResourceResolver().refresh();
+        log.debug("Changes saved...");
 
-		log.debug("Requesting redirect maps from {}", request.getResource());
-		RedirectMapModel redirectMap = request.getResource().adaptTo(RedirectMapModel.class);
+        log.debug("Requesting redirect maps from {}", request.getResource());
+        RedirectMapModel redirectMap = request.getResource().adaptTo(RedirectMapModel.class);
 
-		response.setContentType(MediaType.JSON_UTF_8.toString());
+        response.setContentType(MediaType.JSON_UTF_8.toString());
 
-		IOUtils.write(gson.toJson(redirectMap.getEntries(), new TypeToken<List<MapEntry>>() {
-		}.getType()), response.getOutputStream(), StandardCharsets.UTF_8);
-	}
+        IOUtils.write(gson.toJson(redirectMap.getEntries(), new TypeToken<List<MapEntry>>() {
+        }.getType()), response.getOutputStream(), StandardCharsets.UTF_8);
+    }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RedirectEntriesServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RedirectEntriesServlet.java
@@ -1,0 +1,65 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.redirectmaps.impl;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import javax.servlet.ServletException;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.felix.scr.annotations.sling.SlingServlet;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.acs.commons.redirectmaps.models.MapEntry;
+import com.adobe.acs.commons.redirectmaps.models.RedirectMapModel;
+import com.google.common.net.MediaType;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * Servlet rendering the redirect map to a JSON Array
+ */
+@SlingServlet(methods = { "GET" }, resourceTypes = { "acs-commons/components/utilities/redirectmappage" }, selectors = {
+		"redirectentries" }, extensions = { "json" }, metatype = false)
+public class RedirectEntriesServlet extends SlingSafeMethodsServlet {
+
+	private static final long serialVersionUID = -2825679173210628699L;
+	private static final Logger log = LoggerFactory.getLogger(RedirectEntriesServlet.class);
+	private Gson gson = new Gson();
+
+	protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
+			throws ServletException, IOException {
+		log.trace("doGet");
+
+		log.debug("Requesting redirect maps from {}", request.getResource());
+		RedirectMapModel redirectMap = request.getResource().adaptTo(RedirectMapModel.class);
+
+		response.setContentType(MediaType.JSON_UTF_8.toString());
+
+		IOUtils.write(gson.toJson(redirectMap.getEntries(), new TypeToken<List<MapEntry>>() {
+		}.getType()), response.getOutputStream(), StandardCharsets.UTF_8);
+	}
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RedirectEntriesServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RedirectEntriesServlet.java
@@ -20,24 +20,15 @@
 package com.adobe.acs.commons.redirectmaps.impl;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
 
 import javax.servlet.ServletException;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.adobe.acs.commons.redirectmaps.models.MapEntry;
-import com.adobe.acs.commons.redirectmaps.models.RedirectMapModel;
-import com.google.common.net.MediaType;
-import com.google.gson.Gson;
-import com.google.gson.reflect.TypeToken;
 
 /**
  * Servlet rendering the redirect map to a JSON Array
@@ -48,18 +39,12 @@ public class RedirectEntriesServlet extends SlingSafeMethodsServlet {
 
     private static final long serialVersionUID = -2825679173210628699L;
     private static final Logger log = LoggerFactory.getLogger(RedirectEntriesServlet.class);
-    private Gson gson = new Gson();
 
     protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {
         log.trace("doGet");
 
-        log.debug("Requesting redirect maps from {}", request.getResource());
-        RedirectMapModel redirectMap = request.getResource().adaptTo(RedirectMapModel.class);
-
-        response.setContentType(MediaType.JSON_UTF_8.toString());
-
-        IOUtils.write(gson.toJson(redirectMap.getEntries(), new TypeToken<List<MapEntry>>() {
-        }.getType()), response.getOutputStream(), StandardCharsets.UTF_8);
+        RedirectEntriesUtils.writeEntriesToResponse(request, response);
     }
+    
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RedirectEntriesServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RedirectEntriesServlet.java
@@ -43,23 +43,23 @@ import com.google.gson.reflect.TypeToken;
  * Servlet rendering the redirect map to a JSON Array
  */
 @SlingServlet(methods = { "GET" }, resourceTypes = { "acs-commons/components/utilities/redirectmappage" }, selectors = {
-		"redirectentries" }, extensions = { "json" }, metatype = false)
+        "redirectentries" }, extensions = { "json" }, metatype = false)
 public class RedirectEntriesServlet extends SlingSafeMethodsServlet {
 
-	private static final long serialVersionUID = -2825679173210628699L;
-	private static final Logger log = LoggerFactory.getLogger(RedirectEntriesServlet.class);
-	private Gson gson = new Gson();
+    private static final long serialVersionUID = -2825679173210628699L;
+    private static final Logger log = LoggerFactory.getLogger(RedirectEntriesServlet.class);
+    private Gson gson = new Gson();
 
-	protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
-			throws ServletException, IOException {
-		log.trace("doGet");
+    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
+            throws ServletException, IOException {
+        log.trace("doGet");
 
-		log.debug("Requesting redirect maps from {}", request.getResource());
-		RedirectMapModel redirectMap = request.getResource().adaptTo(RedirectMapModel.class);
+        log.debug("Requesting redirect maps from {}", request.getResource());
+        RedirectMapModel redirectMap = request.getResource().adaptTo(RedirectMapModel.class);
 
-		response.setContentType(MediaType.JSON_UTF_8.toString());
+        response.setContentType(MediaType.JSON_UTF_8.toString());
 
-		IOUtils.write(gson.toJson(redirectMap.getEntries(), new TypeToken<List<MapEntry>>() {
-		}.getType()), response.getOutputStream(), StandardCharsets.UTF_8);
-	}
+        IOUtils.write(gson.toJson(redirectMap.getEntries(), new TypeToken<List<MapEntry>>() {
+        }.getType()), response.getOutputStream(), StandardCharsets.UTF_8);
+    }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RedirectEntriesUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RedirectEntriesUtils.java
@@ -1,0 +1,97 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.redirectmaps.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.servlet.ServletException;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.api.resource.PersistenceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.acs.commons.redirectmaps.models.MapEntry;
+import com.adobe.acs.commons.redirectmaps.models.RedirectMapModel;
+import com.day.cq.commons.jcr.JcrConstants;
+import com.google.common.net.MediaType;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * Utilities for interacting with the redirect entries
+ */
+public class RedirectEntriesUtils {
+
+	private static final Gson gson = new Gson();
+
+	private static final Logger log = LoggerFactory.getLogger(RedirectEntriesUtils.class);
+
+	protected static final List<String> readEntries(SlingHttpServletRequest request) throws IOException {
+		List<String> lines = null;
+		InputStream is = null;
+		try {
+			is = request.getResource().getChild(RedirectMapModel.MAP_FILE_NODE).adaptTo(InputStream.class);
+			lines = IOUtils.readLines(is);
+			log.debug("Loaded {} lines", lines.size());
+		} finally {
+			IOUtils.closeQuietly(is);
+		}
+		return lines;
+	}
+
+	protected static final void updateRedirectMap(SlingHttpServletRequest request, List<String> entries)
+			throws PersistenceException {
+		ModifiableValueMap mvm = request.getResource().getChild(RedirectMapModel.MAP_FILE_NODE)
+				.getChild(JcrConstants.JCR_CONTENT).adaptTo(ModifiableValueMap.class);
+		mvm.put(JcrConstants.JCR_DATA, StringUtils.join(entries, "\n"));
+		request.getResourceResolver().commit();
+		request.getResourceResolver().refresh();
+		log.debug("Changes saved...");
+	}
+
+	protected static final void writeEntriesToResponse(SlingHttpServletRequest request,
+			SlingHttpServletResponse response) throws ServletException, IOException {
+		log.trace("writeEntriesToResponse");
+
+		log.debug("Requesting redirect maps from {}", request.getResource());
+		RedirectMapModel redirectMap = request.getResource().adaptTo(RedirectMapModel.class);
+
+		response.setContentType(MediaType.JSON_UTF_8.toString());
+
+		JsonElement entries = gson.toJsonTree(redirectMap.getEntries(), new TypeToken<List<MapEntry>>() {
+		}.getType());
+		Iterator<JsonElement> it = entries.getAsJsonArray().iterator();
+		for (int i = 0; it.hasNext(); i++) {
+			it.next().getAsJsonObject().addProperty("id", i);
+		}
+
+		IOUtils.write(entries.toString(), response.getOutputStream(), StandardCharsets.UTF_8);
+	}
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RedirectEntriesUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RedirectEntriesUtils.java
@@ -50,7 +50,7 @@ import com.google.gson.reflect.TypeToken;
 public class RedirectEntriesUtils {
 
     private RedirectEntriesUtils() {
-    };
+    }
 
     private static final Gson gson = new Gson();
 

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RemoveEntryServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RemoveEntryServlet.java
@@ -47,41 +47,41 @@ import com.google.gson.reflect.TypeToken;
  * Servlet for removing a line from the redirect map text file
  */
 @SlingServlet(methods = { "POST" }, resourceTypes = {
-		"acs-commons/components/utilities/redirectmappage" }, selectors = {
-				"removeentry" }, extensions = { "json" }, metatype = false)
+        "acs-commons/components/utilities/redirectmappage" }, selectors = {
+                "removeentry" }, extensions = { "json" }, metatype = false)
 public class RemoveEntryServlet extends SlingAllMethodsServlet {
 
-	private static final long serialVersionUID = -5963945855717054678L;
-	private static final Logger log = LoggerFactory.getLogger(RemoveEntryServlet.class);
-	private Gson gson = new Gson();
+    private static final long serialVersionUID = -5963945855717054678L;
+    private static final Logger log = LoggerFactory.getLogger(RemoveEntryServlet.class);
+    private Gson gson = new Gson();
 
-	protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
-			throws ServletException, IOException {
-		log.trace("doPost");
+    protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
+            throws ServletException, IOException {
+        log.trace("doPost");
 
-		int idx = Integer.parseInt(request.getParameter("idx"), 10);
-		log.debug("Removing index {}", idx);
+        int idx = Integer.parseInt(request.getParameter("idx"), 10);
+        log.debug("Removing index {}", idx);
 
-		InputStream is = request.getResource().getChild(RedirectMapModel.MAP_FILE_NODE).adaptTo(InputStream.class);
-		List<String> lines = IOUtils.readLines(is);
-		log.debug("Loaded {} lines", lines.size());
+        InputStream is = request.getResource().getChild(RedirectMapModel.MAP_FILE_NODE).adaptTo(InputStream.class);
+        List<String> lines = IOUtils.readLines(is);
+        log.debug("Loaded {} lines", lines.size());
 
-		lines.remove(idx);
-		log.debug("Removed line...");
+        lines.remove(idx);
+        log.debug("Removed line...");
 
-		ModifiableValueMap mvm = request.getResource().getChild(RedirectMapModel.MAP_FILE_NODE)
-				.getChild(JcrConstants.JCR_CONTENT).adaptTo(ModifiableValueMap.class);
-		mvm.put(JcrConstants.JCR_DATA, StringUtils.join(lines, "\n"));
-		request.getResourceResolver().commit();
-		request.getResourceResolver().refresh();
-		log.debug("Changes saved...");
+        ModifiableValueMap mvm = request.getResource().getChild(RedirectMapModel.MAP_FILE_NODE)
+                .getChild(JcrConstants.JCR_CONTENT).adaptTo(ModifiableValueMap.class);
+        mvm.put(JcrConstants.JCR_DATA, StringUtils.join(lines, "\n"));
+        request.getResourceResolver().commit();
+        request.getResourceResolver().refresh();
+        log.debug("Changes saved...");
 
-		log.debug("Requesting redirect maps from {}", request.getResource());
-		RedirectMapModel redirectMap = request.getResource().adaptTo(RedirectMapModel.class);
+        log.debug("Requesting redirect maps from {}", request.getResource());
+        RedirectMapModel redirectMap = request.getResource().adaptTo(RedirectMapModel.class);
 
-		response.setContentType(MediaType.JSON_UTF_8.toString());
+        response.setContentType(MediaType.JSON_UTF_8.toString());
 
-		IOUtils.write(gson.toJson(redirectMap.getEntries(), new TypeToken<List<MapEntry>>() {
-		}.getType()), response.getOutputStream(), StandardCharsets.UTF_8);
-	}
+        IOUtils.write(gson.toJson(redirectMap.getEntries(), new TypeToken<List<MapEntry>>() {
+        }.getType()), response.getOutputStream(), StandardCharsets.UTF_8);
+    }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RemoveEntryServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RemoveEntryServlet.java
@@ -49,11 +49,10 @@ import com.google.gson.reflect.TypeToken;
 @SlingServlet(methods = { "POST" }, resourceTypes = {
         "acs-commons/components/utilities/redirectmappage" }, selectors = {
                 "removeentry" }, extensions = { "json" }, metatype = false)
-public class RemoveEntryServlet extends SlingAllMethodsServlet {
+public class RemoveEntryServlet extends RedirectEntriesServlet {
 
     private static final long serialVersionUID = -5963945855717054678L;
     private static final Logger log = LoggerFactory.getLogger(RemoveEntryServlet.class);
-    private Gson gson = new Gson();
 
     protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {
@@ -76,12 +75,6 @@ public class RemoveEntryServlet extends SlingAllMethodsServlet {
         request.getResourceResolver().refresh();
         log.debug("Changes saved...");
 
-        log.debug("Requesting redirect maps from {}", request.getResource());
-        RedirectMapModel redirectMap = request.getResource().adaptTo(RedirectMapModel.class);
-
-        response.setContentType(MediaType.JSON_UTF_8.toString());
-
-        IOUtils.write(gson.toJson(redirectMap.getEntries(), new TypeToken<List<MapEntry>>() {
-        }.getType()), response.getOutputStream(), StandardCharsets.UTF_8);
+        super.doGet(request, response);
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RemoveEntryServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RemoveEntryServlet.java
@@ -35,27 +35,27 @@ import org.slf4j.LoggerFactory;
  * Servlet for removing a line from the redirect map text file
  */
 @SlingServlet(methods = { "POST" }, resourceTypes = {
-		"acs-commons/components/utilities/redirectmappage" }, selectors = {
-				"removeentry" }, extensions = { "json" }, metatype = false)
+        "acs-commons/components/utilities/redirectmappage" }, selectors = {
+                "removeentry" }, extensions = { "json" }, metatype = false)
 public class RemoveEntryServlet extends SlingAllMethodsServlet {
 
-	private static final long serialVersionUID = -5963945855717054678L;
-	private static final Logger log = LoggerFactory.getLogger(RemoveEntryServlet.class);
+    private static final long serialVersionUID = -5963945855717054678L;
+    private static final Logger log = LoggerFactory.getLogger(RemoveEntryServlet.class);
 
-	protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
-			throws ServletException, IOException {
-		log.trace("doPost");
+    protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
+            throws ServletException, IOException {
+        log.trace("doPost");
 
-		int idx = Integer.parseInt(request.getParameter("idx"), 10);
-		log.debug("Removing index {}", idx);
+        int idx = Integer.parseInt(request.getParameter("idx"), 10);
+        log.debug("Removing index {}", idx);
 
-		List<String> lines = RedirectEntriesUtils.readEntries(request);
+        List<String> lines = RedirectEntriesUtils.readEntries(request);
 
-		lines.remove(idx);
-		log.debug("Removed line...");
+        lines.remove(idx);
+        log.debug("Removed line...");
 
         RedirectEntriesUtils.updateRedirectMap(request, lines);
 
         RedirectEntriesUtils.writeEntriesToResponse(request, response);
-	}
+    }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RemoveEntryServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RemoveEntryServlet.java
@@ -1,0 +1,87 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.redirectmaps.impl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import javax.servlet.ServletException;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.felix.scr.annotations.sling.SlingServlet;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.acs.commons.redirectmaps.models.MapEntry;
+import com.adobe.acs.commons.redirectmaps.models.RedirectMapModel;
+import com.day.cq.commons.jcr.JcrConstants;
+import com.google.common.net.MediaType;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * Servlet for removing a line from the redirect map text file
+ */
+@SlingServlet(methods = { "POST" }, resourceTypes = {
+		"acs-commons/components/utilities/redirectmappage" }, selectors = {
+				"removeentry" }, extensions = { "json" }, metatype = false)
+public class RemoveEntryServlet extends SlingAllMethodsServlet {
+
+	private static final long serialVersionUID = -5963945855717054678L;
+	private static final Logger log = LoggerFactory.getLogger(RemoveEntryServlet.class);
+	private Gson gson = new Gson();
+
+	protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
+			throws ServletException, IOException {
+		log.trace("doPost");
+
+		int idx = Integer.parseInt(request.getParameter("idx"), 10);
+		log.debug("Removing index {}", idx);
+
+		InputStream is = request.getResource().getChild(RedirectMapModel.MAP_FILE_NODE).adaptTo(InputStream.class);
+		List<String> lines = IOUtils.readLines(is);
+		log.debug("Loaded {} lines", lines.size());
+
+		lines.remove(idx);
+		log.debug("Removed line...");
+
+		ModifiableValueMap mvm = request.getResource().getChild(RedirectMapModel.MAP_FILE_NODE)
+				.getChild(JcrConstants.JCR_CONTENT).adaptTo(ModifiableValueMap.class);
+		mvm.put(JcrConstants.JCR_DATA, StringUtils.join(lines, "\n"));
+		request.getResourceResolver().commit();
+		request.getResourceResolver().refresh();
+		log.debug("Changes saved...");
+
+		log.debug("Requesting redirect maps from {}", request.getResource());
+		RedirectMapModel redirectMap = request.getResource().adaptTo(RedirectMapModel.class);
+
+		response.setContentType(MediaType.JSON_UTF_8.toString());
+
+		IOUtils.write(gson.toJson(redirectMap.getEntries(), new TypeToken<List<MapEntry>>() {
+		}.getType()), response.getOutputStream(), StandardCharsets.UTF_8);
+	}
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/models/MapEntry.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/models/MapEntry.java
@@ -23,87 +23,93 @@ package com.adobe.acs.commons.redirectmaps.models;
  * Simple POJO for map entry items based on Vanity paths for Redirect Maps.
  */
 public class MapEntry {
-	private final String origin;
-	private final String source;
-	private String status;
-	private final String target;
-	private boolean valid = true;;
+    private final String origin;
+    private final String source;
+    private String status;
+    private final String target;
+    private boolean valid = true;
 
-	public MapEntry(String source, String target, String origin) {
-		source = source.trim();
-		this.source = source;
-		this.target = target;
-		this.origin = origin;
-	}
+    public MapEntry(String source, String target, String origin) {
+        source = source.trim();
+        this.source = source;
+        this.target = target;
+        this.origin = origin;
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		MapEntry other = (MapEntry) obj;
-		if (origin == null) {
-			if (other.origin != null)
-				return false;
-		} else if (!origin.equals(other.origin))
-			return false;
-		if (source == null) {
-			if (other.source != null)
-				return false;
-		} else if (!source.equals(other.source))
-			return false;
-		if (target == null) {
-			if (other.target != null)
-				return false;
-		} else if (!target.equals(other.target))
-			return false;
-		return true;
-	}
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        MapEntry other = (MapEntry) obj;
+        if (origin == null) {
+            if (other.origin != null)
+                return false;
+        } else if (!origin.equals(other.origin)) {
+            return false;
+        }
+        if (source == null) {
+            if (other.source != null)
+                return false;
+        } else if (!source.equals(other.source)) {
+            return false;
+        }
+        if (target == null) {
+            if (other.target != null)
+                return false;
+        } else if (!target.equals(other.target)) {
+            return false;
+        }
+        return true;
+    }
 
-	public String getOrigin() {
-		return origin;
-	}
+    public String getOrigin() {
+        return origin;
+    }
 
-	public String getSource() {
-		return source;
-	}
+    public String getSource() {
+        return source;
+    }
 
-	public String getStatus() {
-		return status;
-	}
+    public String getStatus() {
+        return status;
+    }
 
-	public String getTarget() {
-		return target;
-	}
+    public String getTarget() {
+        return target;
+    }
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((origin == null) ? 0 : origin.hashCode());
-		result = prime * result + ((source == null) ? 0 : source.hashCode());
-		result = prime * result + ((target == null) ? 0 : target.hashCode());
-		return result;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((origin == null) ? 0 : origin.hashCode());
+        result = prime * result + ((source == null) ? 0 : source.hashCode());
+        result = prime * result + ((target == null) ? 0 : target.hashCode());
+        return result;
+    }
 
-	public boolean isValid() {
-		return valid;
-	}
+    public boolean isValid() {
+        return valid;
+    }
 
-	public void setStatus(String status) {
-		this.status = status;
-	}
+    public void setStatus(String status) {
+        this.status = status;
+    }
 
-	public void setValid(boolean valid) {
-		this.valid = valid;
-	}
+    public void setValid(boolean valid) {
+        this.valid = valid;
+    }
 
-	@Override
-	public String toString() {
-		return "MapEntry [origin=" + origin + ", source=" + source + ", status=" + status + ", target=" + target
-				+ ", valid=" + valid + "]";
-	}
+    @Override
+    public String toString() {
+        return "MapEntry [origin=" + origin + ", source=" + source + ", status=" + status + ", target=" + target
+                + ", valid=" + valid + "]";
+    }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/models/MapEntry.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/models/MapEntry.java
@@ -36,42 +36,6 @@ public class MapEntry {
         this.origin = origin;
     }
 
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        MapEntry other = (MapEntry) obj;
-        if (origin == null) {
-            if (other.origin != null) {
-                return false;
-            }
-        } else if (!origin.equals(other.origin)) {
-            return false;
-        }
-        if (source == null) {
-            if (other.source != null) {
-                return false;
-            }
-        } else if (!source.equals(other.source)) {
-            return false;
-        }
-        if (target == null) {
-            if (other.target != null) {
-                return false;
-            }
-        } else if (!target.equals(other.target)) {
-            return false;
-        }
-        return true;
-    }
-
     public String getOrigin() {
         return origin;
     }
@@ -86,16 +50,6 @@ public class MapEntry {
 
     public String getTarget() {
         return target;
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((origin == null) ? 0 : origin.hashCode());
-        result = prime * result + ((source == null) ? 0 : source.hashCode());
-        result = prime * result + ((target == null) ? 0 : target.hashCode());
-        return result;
     }
 
     public boolean isValid() {

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/models/MapEntry.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/models/MapEntry.java
@@ -19,50 +19,91 @@
  */
 package com.adobe.acs.commons.redirectmaps.models;
 
-import org.apache.sling.api.resource.Resource;
-
 /**
  * Simple POJO for map entry items based on Vanity paths for Redirect Maps.
  */
 public class MapEntry {
-    private final Resource resource;
-    private final String source;
-    private final String target;
-    private final boolean valid;
+	private final String origin;
+	private final String source;
+	private String status;
+	private final String target;
+	private boolean valid = true;;
 
-    public MapEntry(Resource resource, String source, String target) {
-        source = source.trim();
-        if (source.matches(".*\\s.*")) {
-            RedirectMapModel.log.warn("Source path {} for content {} contains whitespace", source, resource);
-            valid = false;
-        } else {
-            valid = true;
-        }
-        this.source = source;
-        this.target = target;
-        this.resource = resource;
+	public MapEntry(String source, String target, String origin) {
+		source = source.trim();
+		this.source = source;
+		this.target = target;
+		this.origin = origin;
+	}
 
-    }
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		MapEntry other = (MapEntry) obj;
+		if (origin == null) {
+			if (other.origin != null)
+				return false;
+		} else if (!origin.equals(other.origin))
+			return false;
+		if (source == null) {
+			if (other.source != null)
+				return false;
+		} else if (!source.equals(other.source))
+			return false;
+		if (target == null) {
+			if (other.target != null)
+				return false;
+		} else if (!target.equals(other.target))
+			return false;
+		return true;
+	}
 
-    public Resource getResource() {
-        return resource;
-    }
+	public String getOrigin() {
+		return origin;
+	}
 
-    public String getSource() {
-        return source;
-    }
+	public String getSource() {
+		return source;
+	}
 
-    public String getTarget() {
-        return target;
-    }
+	public String getStatus() {
+		return status;
+	}
 
-    public boolean isValid() {
-        return valid;
-    }
+	public String getTarget() {
+		return target;
+	}
 
-    @Override
-    public String toString() {
-        return "MapEntry [resource=" + resource + ", source=" + source + ", target=" + target + ", valid=" + valid
-                + "]";
-    }
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((origin == null) ? 0 : origin.hashCode());
+		result = prime * result + ((source == null) ? 0 : source.hashCode());
+		result = prime * result + ((target == null) ? 0 : target.hashCode());
+		return result;
+	}
+
+	public boolean isValid() {
+		return valid;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public void setValid(boolean valid) {
+		this.valid = valid;
+	}
+
+	@Override
+	public String toString() {
+		return "MapEntry [origin=" + origin + ", source=" + source + ", status=" + status + ", target=" + target
+				+ ", valid=" + valid + "]";
+	}
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/models/MapEntry.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/models/MapEntry.java
@@ -49,20 +49,23 @@ public class MapEntry {
         }
         MapEntry other = (MapEntry) obj;
         if (origin == null) {
-            if (other.origin != null)
+            if (other.origin != null) {
                 return false;
+            }
         } else if (!origin.equals(other.origin)) {
             return false;
         }
         if (source == null) {
-            if (other.source != null)
+            if (other.source != null) {
                 return false;
+            }
         } else if (!source.equals(other.source)) {
             return false;
         }
         if (target == null) {
-            if (other.target != null)
+            if (other.target != null) {
                 return false;
+            }
         } else if (!target.equals(other.target)) {
             return false;
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/models/RedirectMapModel.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/models/RedirectMapModel.java
@@ -51,173 +51,173 @@ import com.day.cq.commons.jcr.JcrConstants;
 @Model(adaptables = Resource.class)
 public class RedirectMapModel {
 
-	private static final Logger log = LoggerFactory.getLogger(RedirectMapModel.class);
+    private static final Logger log = LoggerFactory.getLogger(RedirectMapModel.class);
 
-	private static final String NO_TARGET_MSG = "No target found in entry %s";
-	private static final String SOURCE_WHITESPACE_MSG = "Source path %s for content %s contains whitespace";
-	private static final String WHITESPACE_MSG = "Extra whitespace found in entry %s";;
-	
-	public static final String MAP_FILE_NODE="redirectMap.txt";
+    private static final String NO_TARGET_MSG = "No target found in entry %s";
+    private static final String SOURCE_WHITESPACE_MSG = "Source path %s for content %s contains whitespace";
+    private static final String WHITESPACE_MSG = "Extra whitespace found in entry %s";
+    
+    public static final String MAP_FILE_NODE="redirectMap.txt";
 
-	@Inject
-	@Optional
-	@Named(MAP_FILE_NODE)
-	private Resource redirectMap;
+    @Inject
+    @Optional
+    @Named(MAP_FILE_NODE)
+    private Resource redirectMap;
 
-	@Inject
-	@Optional
-	private List<RedirectConfigModel> redirects;
+    @Inject
+    @Optional
+    private List<RedirectConfigModel> redirects;
 
-	@Inject
-	@Source("sling-object")
-	private ResourceResolver resourceResolver;
+    @Inject
+    @Source("sling-object")
+    private ResourceResolver resourceResolver;
 
-	private List<MapEntry> addItems(RedirectConfigModel config, Iterator<Resource> items, String suffix) {
-		List<MapEntry> entries = new ArrayList<MapEntry>();
-		while (items.hasNext()) {
-			Resource item = items.next();
-			String path = item.getPath();
-			ValueMap properties = item.getChild(JcrConstants.JCR_CONTENT).getValueMap();
-			FakeSlingHttpServletRequest mockRequest = new FakeSlingHttpServletRequest(resourceResolver,
-					config.getProtocol(), config.getDomain(), (config.getProtocol().equals("https") ? 443 : 80));
-			String pageUrl = config.getProtocol() + "://" + config.getDomain()
-					+ resourceResolver.map(mockRequest, item.getPath() + suffix);
+    private List<MapEntry> addItems(RedirectConfigModel config, Iterator<Resource> items, String suffix) {
+        List<MapEntry> entries = new ArrayList<MapEntry>();
+        while (items.hasNext()) {
+            Resource item = items.next();
+            String path = item.getPath();
+            ValueMap properties = item.getChild(JcrConstants.JCR_CONTENT).getValueMap();
+            FakeSlingHttpServletRequest mockRequest = new FakeSlingHttpServletRequest(resourceResolver,
+                    config.getProtocol(), config.getDomain(), (config.getProtocol().equals("https") ? 443 : 80));
+            String pageUrl = config.getProtocol() + "://" + config.getDomain()
+                    + resourceResolver.map(mockRequest, item.getPath() + suffix);
 
-			String[] sources = properties.get(config.getProperty(), String[].class);
-			for (String source : sources) {
-				MapEntry entry = new MapEntry(source, pageUrl, item.getPath());
-				if(source.matches(".*\\s+.*")) {
-					String msg = String.format(SOURCE_WHITESPACE_MSG, entry.getSource(), path);
-					log.warn(msg);
-					entry.setStatus(msg);
-					entry.setValid(false);
-				}
-				entries.add(entry);
-			}
-		}
-		return entries;
-	}
+            String[] sources = properties.get(config.getProperty(), String[].class);
+            for (String source : sources) {
+                MapEntry entry = new MapEntry(source, pageUrl, item.getPath());
+                if(source.matches(".*\\s+.*")) {
+                    String msg = String.format(SOURCE_WHITESPACE_MSG, entry.getSource(), path);
+                    log.warn(msg);
+                    entry.setStatus(msg);
+                    entry.setValid(false);
+                }
+                entries.add(entry);
+            }
+        }
+        return entries;
+    }
 
-	private List<MapEntry> gatherEntries(RedirectConfigModel config) {
-		log.trace("gatherEntries");
+    private List<MapEntry> gatherEntries(RedirectConfigModel config) {
+        log.trace("gatherEntries");
 
-		log.debug("Getting all of the entries for {}", config.getResource());
+        log.debug("Getting all of the entries for {}", config.getResource());
 
-		List<MapEntry> entries = new ArrayList<MapEntry>();
+        List<MapEntry> entries = new ArrayList<MapEntry>();
 
-		String pageQuery = "SELECT * FROM [cq:Page] WHERE [jcr:content/" + config.getProperty()
-				+ "] IS NOT NULL AND (ISDESCENDANTNODE([" + config.getPath() + "]) OR [jcr:path]='" + config.getPath()
-				+ "')";
-		log.debug("Finding pages with redirects with query: {}", pageQuery);
-		entries.addAll(addItems(config, resourceResolver.findResources(pageQuery, Query.JCR_SQL2), ".html"));
-		String assetQuery = "SELECT * FROM [dam:Asset] WHERE [jcr:content/" + config.getProperty()
-				+ "] IS NOT NULL AND (ISDESCENDANTNODE([" + config.getPath() + "]) OR [jcr:path]='" + config.getPath()
-				+ "')";
-		log.debug("Finding assets with redirects with query: {}", assetQuery);
-		entries.addAll(addItems(config, resourceResolver.findResources(assetQuery, Query.JCR_SQL2), ""));
-		return entries;
-	}
+        String pageQuery = "SELECT * FROM [cq:Page] WHERE [jcr:content/" + config.getProperty()
+                + "] IS NOT NULL AND (ISDESCENDANTNODE([" + config.getPath() + "]) OR [jcr:path]='" + config.getPath()
+                + "')";
+        log.debug("Finding pages with redirects with query: {}", pageQuery);
+        entries.addAll(addItems(config, resourceResolver.findResources(pageQuery, Query.JCR_SQL2), ".html"));
+        String assetQuery = "SELECT * FROM [dam:Asset] WHERE [jcr:content/" + config.getProperty()
+                + "] IS NOT NULL AND (ISDESCENDANTNODE([" + config.getPath() + "]) OR [jcr:path]='" + config.getPath()
+                + "')";
+        log.debug("Finding assets with redirects with query: {}", assetQuery);
+        entries.addAll(addItems(config, resourceResolver.findResources(assetQuery, Query.JCR_SQL2), ""));
+        return entries;
+    }
 
-	public List<MapEntry> getEntries() throws IOException {
-		log.trace("getEntries");
+    public List<MapEntry> getEntries() throws IOException {
+        log.trace("getEntries");
 
-		List<MapEntry> entries = new ArrayList<MapEntry>();
-		InputStream is = redirectMap.adaptTo(InputStream.class);
-		for (String line : IOUtils.readLines(is)) {
-			MapEntry entry = toEntry(line);
-			if (entry != null) {
-				entries.add(entry);
-			}
-		}
+        List<MapEntry> entries = new ArrayList<MapEntry>();
+        InputStream is = redirectMap.adaptTo(InputStream.class);
+        for (String line : IOUtils.readLines(is)) {
+            MapEntry entry = toEntry(line);
+            if (entry != null) {
+                entries.add(entry);
+            }
+        }
 
-		if (redirects != null) {
-			redirects.forEach(r -> entries.addAll(gatherEntries(r)));
-		} else {
-			log.debug("No redirect configurations specified");
-		}
-		return entries;
-	}
+        if (redirects != null) {
+            redirects.forEach(r -> entries.addAll(gatherEntries(r)));
+        } else {
+            log.debug("No redirect configurations specified");
+        }
+        return entries;
+    }
 
-	/**
-	 * Get all of the entries from the cq:Pages and dam:Assets which contain
-	 * whitespace in their vanity URL.
-	 *
-	 * @return
-	 */
-	public List<MapEntry> getInvalidEntries() {
-		log.trace("getInvalidEntries");
-		List<MapEntry> invalidEntries = new ArrayList<MapEntry>();
-		if (redirects != null) {
-			for (RedirectConfigModel config : redirects) {
-				invalidEntries
-						.addAll(gatherEntries(config).stream().filter(e -> !e.isValid()).collect(Collectors.toList()));
-			}
-		}
-		log.debug("Found {} invalid entries", invalidEntries.size());
-		return invalidEntries;
-	}
+    /**
+     * Get all of the entries from the cq:Pages and dam:Assets which contain
+     * whitespace in their vanity URL.
+     *
+     * @return
+     */
+    public List<MapEntry> getInvalidEntries() {
+        log.trace("getInvalidEntries");
+        List<MapEntry> invalidEntries = new ArrayList<MapEntry>();
+        if (redirects != null) {
+            for (RedirectConfigModel config : redirects) {
+                invalidEntries
+                        .addAll(gatherEntries(config).stream().filter(e -> !e.isValid()).collect(Collectors.toList()));
+            }
+        }
+        log.debug("Found {} invalid entries", invalidEntries.size());
+        return invalidEntries;
+    }
 
-	/**
-	 * Get the contents of the RedirectMap as a String
-	 *
-	 * @return
-	 * @throws IOException
-	 */
-	public String getRedirectMap() throws IOException {
-		log.debug("Retrieving redirect map from {}", redirectMap);
+    /**
+     * Get the contents of the RedirectMap as a String
+     *
+     * @return
+     * @throws IOException
+     */
+    public String getRedirectMap() throws IOException {
+        log.debug("Retrieving redirect map from {}", redirectMap);
 
-		StringBuilder sb = new StringBuilder();
+        StringBuilder sb = new StringBuilder();
 
-		if (redirectMap != null) {
-			log.debug("Loading RedirectMap file from {}", redirectMap);
-			sb.append("# Redirect Map File\n");
-			InputStream is = redirectMap.adaptTo(InputStream.class);
-			sb.append(IOUtils.toString(is));
-		} else {
-			log.debug("No redirect map specified");
-		}
+        if (redirectMap != null) {
+            log.debug("Loading RedirectMap file from {}", redirectMap);
+            sb.append("# Redirect Map File\n");
+            InputStream is = redirectMap.adaptTo(InputStream.class);
+            sb.append(IOUtils.toString(is));
+        } else {
+            log.debug("No redirect map specified");
+        }
 
-		if (redirects != null) {
-			for (RedirectConfigModel config : redirects) {
-				writeEntries(config, sb);
-			}
-		} else {
-			log.debug("No redirect configurations specified");
-		}
-		return sb.toString();
-	}
+        if (redirects != null) {
+            for (RedirectConfigModel config : redirects) {
+                writeEntries(config, sb);
+            }
+        } else {
+            log.debug("No redirect configurations specified");
+        }
+        return sb.toString();
+    }
 
-	private MapEntry toEntry(String l) {
-		String[] seg = l.split("\\s+");
+    private MapEntry toEntry(String l) {
+        String[] seg = l.split("\\s+");
 
-		MapEntry entry = null;
-		if (StringUtils.isBlank(l) || l.startsWith("#")) {
-			// Skip as the line is empty or a comment
-		} else if (seg.length == 2) {
-			entry = new MapEntry(seg[0], seg[1], "File");
-		} else if (seg.length > 2) {
-			entry = new MapEntry(seg[0], seg[1], "File");
-			entry.setValid(false);
-			entry.setStatus(String.format(WHITESPACE_MSG, l));
-		} else {
-			entry = new MapEntry(seg[0], "", "File");
-			entry.setValid(false);
-			entry.setStatus(String.format(NO_TARGET_MSG, l));
-		}
-		return entry;
-	}
+        MapEntry entry = null;
+        if (StringUtils.isBlank(l) || l.startsWith("#")) {
+            // Skip as the line is empty or a comment
+        } else if (seg.length == 2) {
+            entry = new MapEntry(seg[0], seg[1], "File");
+        } else if (seg.length > 2) {
+            entry = new MapEntry(seg[0], seg[1], "File");
+            entry.setValid(false);
+            entry.setStatus(String.format(WHITESPACE_MSG, l));
+        } else {
+            entry = new MapEntry(seg[0], "", "File");
+            entry.setValid(false);
+            entry.setStatus(String.format(NO_TARGET_MSG, l));
+        }
+        return entry;
+    }
 
-	private void writeEntries(RedirectConfigModel config, StringBuilder sb) {
-		log.trace("writeEntries");
+    private void writeEntries(RedirectConfigModel config, StringBuilder sb) {
+        log.trace("writeEntries");
 
-		List<MapEntry> entries = this.gatherEntries(config);
+        List<MapEntry> entries = this.gatherEntries(config);
 
-		sb.append("\n# Dynamic entries for " + config.getResource().getPath() + "\n");
-		for (MapEntry entry : entries) {
-			if (entry.isValid()) {
-				sb.append(entry.getSource() + " " + entry.getTarget() + "\n");
-			}
-		}
-	}
+        sb.append("\n# Dynamic entries for " + config.getResource().getPath() + "\n");
+        for (MapEntry entry : entries) {
+            if (entry.isValid()) {
+                sb.append(entry.getSource() + " " + entry.getTarget() + "\n");
+            }
+        }
+    }
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/models/RedirectMapModel.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/models/RedirectMapModel.java
@@ -86,7 +86,7 @@ public class RedirectMapModel {
 			String[] sources = properties.get(config.getProperty(), String[].class);
 			for (String source : sources) {
 				MapEntry entry = new MapEntry(source, pageUrl, item.getPath());
-				if (!entry.isValid()) {
+				if(source.matches(".*\\s+.*")) {
 					String msg = String.format(SOURCE_WHITESPACE_MSG, entry.getSource(), path);
 					log.warn(msg);
 					entry.setStatus(msg);

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/models/RedirectMapModel.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/models/RedirectMapModel.java
@@ -24,12 +24,14 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.jcr.query.Query;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
@@ -49,116 +51,173 @@ import com.day.cq.commons.jcr.JcrConstants;
 @Model(adaptables = Resource.class)
 public class RedirectMapModel {
 
-    static final Logger log = LoggerFactory.getLogger(RedirectMapModel.class);
+	private static final Logger log = LoggerFactory.getLogger(RedirectMapModel.class);
 
-    @Inject
-    @Optional
-    @Named("redirectMap.txt")
-    private Resource redirectMap;
+	private static final String NO_TARGET_MSG = "No target found in entry %s";
+	private static final String SOURCE_WHITESPACE_MSG = "Source path %s for content %s contains whitespace";
+	private static final String WHITESPACE_MSG = "Extra whitespace found in entry %s";;
+	
+	public static final String MAP_FILE_NODE="redirectMap.txt";
 
-    @Inject
-    @Optional
-    private List<RedirectConfigModel> redirects;
+	@Inject
+	@Optional
+	@Named(MAP_FILE_NODE)
+	private Resource redirectMap;
 
-    @Inject
-    @Source("sling-object")
-    private ResourceResolver resourceResolver;
+	@Inject
+	@Optional
+	private List<RedirectConfigModel> redirects;
 
-    private List<MapEntry> addItems(RedirectConfigModel config, Iterator<Resource> items, StringBuilder sb,
-            String suffix) {
-        List<MapEntry> invalidEntries = new ArrayList<MapEntry>();
-        while (items.hasNext()) {
-            Resource item = items.next();
-            String path = item.getPath();
-            ValueMap properties = item.getChild(JcrConstants.JCR_CONTENT).getValueMap();
-            FakeSlingHttpServletRequest mockRequest = new FakeSlingHttpServletRequest(resourceResolver,
-                    config.getProtocol(), config.getDomain(), (config.getProtocol().equals("https") ? 443 : 80));
-            String pageUrl = config.getProtocol() + "://" + config.getDomain()
-                    + resourceResolver.map(mockRequest, item.getPath() + suffix);
+	@Inject
+	@Source("sling-object")
+	private ResourceResolver resourceResolver;
 
-            String[] sources = properties.get(config.getProperty(), String[].class);
-            for (String source : sources) {
-                MapEntry entry = new MapEntry(item, source, pageUrl);
-                if (!entry.isValid()) {
-                    log.warn("Source path {} for content {} contains whitespace", entry.getSource(), path);
-                    invalidEntries.add(entry);
-                } else {
-                    sb.append(entry.getSource() + " " + entry.getTarget() + "\n");
-                }
-            }
-        }
-        return invalidEntries;
-    }
+	private List<MapEntry> addItems(RedirectConfigModel config, Iterator<Resource> items, String suffix) {
+		List<MapEntry> entries = new ArrayList<MapEntry>();
+		while (items.hasNext()) {
+			Resource item = items.next();
+			String path = item.getPath();
+			ValueMap properties = item.getChild(JcrConstants.JCR_CONTENT).getValueMap();
+			FakeSlingHttpServletRequest mockRequest = new FakeSlingHttpServletRequest(resourceResolver,
+					config.getProtocol(), config.getDomain(), (config.getProtocol().equals("https") ? 443 : 80));
+			String pageUrl = config.getProtocol() + "://" + config.getDomain()
+					+ resourceResolver.map(mockRequest, item.getPath() + suffix);
 
-    private List<MapEntry> gatherEntries(RedirectConfigModel config, StringBuilder sb) {
-        log.trace("gatherEntries");
+			String[] sources = properties.get(config.getProperty(), String[].class);
+			for (String source : sources) {
+				MapEntry entry = new MapEntry(source, pageUrl, item.getPath());
+				if (!entry.isValid()) {
+					String msg = String.format(SOURCE_WHITESPACE_MSG, entry.getSource(), path);
+					log.warn(msg);
+					entry.setStatus(msg);
+					entry.setValid(false);
+				}
+				entries.add(entry);
+			}
+		}
+		return entries;
+	}
 
-        log.debug("Getting all of the entries for {}", config.getResource());
+	private List<MapEntry> gatherEntries(RedirectConfigModel config) {
+		log.trace("gatherEntries");
 
-        List<MapEntry> invalidEntries = new ArrayList<MapEntry>();
+		log.debug("Getting all of the entries for {}", config.getResource());
 
-        sb.append("\n# Dynamic entries for " + config.getResource().getPath() + "\n");
+		List<MapEntry> entries = new ArrayList<MapEntry>();
 
-        String pageQuery = "SELECT * FROM [cq:Page] WHERE [jcr:content/" + config.getProperty()
-                + "] IS NOT NULL AND (ISDESCENDANTNODE([" + config.getPath() + "]) OR [jcr:path]='" + config.getPath()
-                + "')";
-        log.debug("Finding pages with redirects with query: {}", pageQuery);
-        invalidEntries.addAll(addItems(config, resourceResolver.findResources(pageQuery, Query.JCR_SQL2), sb, ".html"));
-        String assetQuery = "SELECT * FROM [dam:Asset] WHERE [jcr:content/" + config.getProperty()
-                + "] IS NOT NULL AND (ISDESCENDANTNODE([" + config.getPath() + "]) OR [jcr:path]='" + config.getPath()
-                + "')";
-        log.debug("Finding assets with redirects with query: {}", assetQuery);
-        invalidEntries.addAll(addItems(config, resourceResolver.findResources(assetQuery, Query.JCR_SQL2), sb, ""));
-        return invalidEntries;
-    }
+		String pageQuery = "SELECT * FROM [cq:Page] WHERE [jcr:content/" + config.getProperty()
+				+ "] IS NOT NULL AND (ISDESCENDANTNODE([" + config.getPath() + "]) OR [jcr:path]='" + config.getPath()
+				+ "')";
+		log.debug("Finding pages with redirects with query: {}", pageQuery);
+		entries.addAll(addItems(config, resourceResolver.findResources(pageQuery, Query.JCR_SQL2), ".html"));
+		String assetQuery = "SELECT * FROM [dam:Asset] WHERE [jcr:content/" + config.getProperty()
+				+ "] IS NOT NULL AND (ISDESCENDANTNODE([" + config.getPath() + "]) OR [jcr:path]='" + config.getPath()
+				+ "')";
+		log.debug("Finding assets with redirects with query: {}", assetQuery);
+		entries.addAll(addItems(config, resourceResolver.findResources(assetQuery, Query.JCR_SQL2), ""));
+		return entries;
+	}
 
-    /**
-     * Get all of the entries from the cq:Pages and dam:Assets which contain
-     * whitespace in their vanity URL.
-     *
-     * @return
-     */
-    public List<MapEntry> getInvalidEntries() {
-        log.trace("getInvalidEntries");
-        List<MapEntry> invalidEntries = new ArrayList<MapEntry>();
-        StringBuilder sb = new StringBuilder();
-        if (redirects != null) {
-            for (RedirectConfigModel config : redirects) {
-                invalidEntries.addAll(gatherEntries(config, sb));
-            }
-        }
-        log.debug("Found {} invalid entries", invalidEntries.size());
-        return invalidEntries;
-    }
+	public List<MapEntry> getEntries() throws IOException {
+		log.trace("getEntries");
 
-    /**
-     * Get the contents of the RedirectMap as a String
-     *
-     * @return
-     * @throws IOException
-     */
-    public String getRedirectMap() throws IOException {
-        log.debug("Retrieving redirect map from {}", redirectMap);
+		List<MapEntry> entries = new ArrayList<MapEntry>();
+		InputStream is = redirectMap.adaptTo(InputStream.class);
+		for (String line : IOUtils.readLines(is)) {
+			MapEntry entry = toEntry(line);
+			if (entry != null) {
+				entries.add(entry);
+			}
+		}
 
-        StringBuilder sb = new StringBuilder();
+		if (redirects != null) {
+			redirects.forEach(r -> entries.addAll(gatherEntries(r)));
+		} else {
+			log.debug("No redirect configurations specified");
+		}
+		return entries;
+	}
 
-        if (redirectMap != null) {
-            log.debug("Loading RedirectMap file from {}", redirectMap);
-            sb.append("# Redirect Map File\n");
-            InputStream is = redirectMap.adaptTo(InputStream.class);
-            sb.append(IOUtils.toString(is));
-        } else {
-            log.debug("No redirect map specified");
-        }
+	/**
+	 * Get all of the entries from the cq:Pages and dam:Assets which contain
+	 * whitespace in their vanity URL.
+	 *
+	 * @return
+	 */
+	public List<MapEntry> getInvalidEntries() {
+		log.trace("getInvalidEntries");
+		List<MapEntry> invalidEntries = new ArrayList<MapEntry>();
+		if (redirects != null) {
+			for (RedirectConfigModel config : redirects) {
+				invalidEntries
+						.addAll(gatherEntries(config).stream().filter(e -> !e.isValid()).collect(Collectors.toList()));
+			}
+		}
+		log.debug("Found {} invalid entries", invalidEntries.size());
+		return invalidEntries;
+	}
 
-        if (redirects != null) {
-            for (RedirectConfigModel config : redirects) {
-                gatherEntries(config, sb);
-            }
-        } else {
-            log.debug("No redirect configurations specified");
-        }
-        return sb.toString();
-    }
+	/**
+	 * Get the contents of the RedirectMap as a String
+	 *
+	 * @return
+	 * @throws IOException
+	 */
+	public String getRedirectMap() throws IOException {
+		log.debug("Retrieving redirect map from {}", redirectMap);
+
+		StringBuilder sb = new StringBuilder();
+
+		if (redirectMap != null) {
+			log.debug("Loading RedirectMap file from {}", redirectMap);
+			sb.append("# Redirect Map File\n");
+			InputStream is = redirectMap.adaptTo(InputStream.class);
+			sb.append(IOUtils.toString(is));
+		} else {
+			log.debug("No redirect map specified");
+		}
+
+		if (redirects != null) {
+			for (RedirectConfigModel config : redirects) {
+				writeEntries(config, sb);
+			}
+		} else {
+			log.debug("No redirect configurations specified");
+		}
+		return sb.toString();
+	}
+
+	private MapEntry toEntry(String l) {
+		String[] seg = l.split("\\s+");
+
+		MapEntry entry = null;
+		if (StringUtils.isBlank(l) || l.startsWith("#")) {
+			// Skip as the line is empty or a comment
+		} else if (seg.length == 2) {
+			entry = new MapEntry(seg[0], seg[1], "File");
+		} else if (seg.length > 2) {
+			entry = new MapEntry(seg[0], seg[1], "File");
+			entry.setValid(false);
+			entry.setStatus(String.format(WHITESPACE_MSG, l));
+		} else {
+			entry = new MapEntry(seg[0], "", "File");
+			entry.setValid(false);
+			entry.setStatus(String.format(NO_TARGET_MSG, l));
+		}
+		return entry;
+	}
+
+	private void writeEntries(RedirectConfigModel config, StringBuilder sb) {
+		log.trace("writeEntries");
+
+		List<MapEntry> entries = this.gatherEntries(config);
+
+		sb.append("\n# Dynamic entries for " + config.getResource().getPath() + "\n");
+		for (MapEntry entry : entries) {
+			if (entry.isValid()) {
+				sb.append(entry.getSource() + " " + entry.getTarget() + "\n");
+			}
+		}
+	}
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/models/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/models/package-info.java
@@ -17,5 +17,5 @@
  * limitations under the License.
  * #L%
  */
-@aQute.bnd.annotation.Version("3.14.4")
+@aQute.bnd.annotation.Version("4.0.0")
 package com.adobe.acs.commons.redirectmaps.models;

--- a/bundle/src/test/java/com/adobe/acs/commons/redirectmaps/impl/TestServlets.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirectmaps/impl/TestServlets.java
@@ -1,0 +1,251 @@
+package com.adobe.acs.commons.redirectmaps.impl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.commons.testing.sling.MockResourceResolver;
+import org.apache.tika.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.acs.commons.redirectmaps.models.RedirectConfigModel;
+import com.adobe.acs.commons.redirectmaps.models.RedirectMapModel;
+import com.day.cq.commons.jcr.JcrConstants;
+
+import junitx.util.PrivateAccessor;
+
+public class TestServlets {
+
+    private static final Logger log = LoggerFactory.getLogger(TestServlets.class);
+
+    @Mock
+    private SlingHttpServletRequest mockSlingRequest;
+
+    @Mock
+    private SlingHttpServletResponse mockSlingResponse;
+
+    @Mock
+    private Resource mockResource;
+
+    @Mock
+    private Resource mockMapResource;
+
+    @Mock
+    private Resource mockMapContentResource;
+
+    private String value = null;
+
+    private ModifiableValueMap mvm = new ModifiableValueMap() {
+
+        @Override
+        public <T> T get(String name, Class<T> type) {
+    
+            return null;
+        }
+
+        @Override
+        public <T> T get(String name, T defaultValue) {
+    
+            return null;
+        }
+
+        @Override
+        public int size() {
+    
+            return 0;
+        }
+
+        @Override
+        public boolean isEmpty() {
+    
+            return false;
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+    
+            return false;
+        }
+
+        @Override
+        public boolean containsValue(Object value) {
+    
+            return false;
+        }
+
+        @Override
+        public Object get(Object key) {
+    
+            return null;
+        }
+
+        @Override
+        public Object put(String key, Object v) {
+            value = (String) v;
+            return v;
+        }
+
+        @Override
+        public Object remove(Object key) {
+    
+            return null;
+        }
+
+        @Override
+        public void putAll(Map<? extends String, ? extends Object> m) {
+    
+
+        }
+
+        @Override
+        public void clear() {
+    
+
+        }
+
+        @Override
+        public Set<String> keySet() {
+    
+            return null;
+        }
+
+        @Override
+        public Collection<Object> values() {
+    
+            return null;
+        }
+
+        @Override
+        public Set<Entry<String, Object>> entrySet() {
+    
+            return null;
+        }
+
+    };
+    
+    private ServletOutputStream os = new ServletOutputStream() {
+
+        @Override
+        public void write(int b) throws IOException {
+            
+        }
+        
+    };
+    
+
+    @InjectMocks
+    private RedirectMapModel model;
+    
+    private List<RedirectConfigModel> redirectConfigs = new ArrayList<RedirectConfigModel>() {
+        private static final long serialVersionUID = 1L;
+
+        {
+            add(new RedirectConfigModel() {
+
+                @Override
+                public String getDomain() {
+                    return "www.adobe.com";
+                }
+
+                @Override
+                public String getPath() {
+                    return "/content/adobe";
+                }
+
+                @Override
+                public String getProperty() {
+                    return "vanity";
+                }
+
+                @Override
+                public String getProtocol() {
+                    return "https";
+                }
+
+                @Override
+                public Resource getResource() {
+                    return mock(Resource.class);
+                }
+            });
+        }
+    };
+    
+    @Before
+    public void init() throws IOException, NoSuchFieldException {
+        log.info("init");
+
+        MockitoAnnotations.initMocks(this);
+
+        MockResourceResolver mockResolver =     new MockResourceResolver() {
+            public Iterator<Resource> findResources(String query, String language) {
+                return new ArrayList<Resource>().iterator();
+
+            }
+        };
+
+        log.debug("Setting up the request...");
+        doReturn(mockResource).when(mockSlingRequest).getResource();
+        doReturn("0").when(mockSlingRequest).getParameter("idx");
+        doReturn("/source").when(mockSlingRequest).getParameter("source");
+        doReturn("/target").when(mockSlingRequest).getParameter("target");
+        doReturn(mockResolver).when(mockSlingRequest).getResourceResolver();
+        doReturn(os).when(mockSlingResponse).getOutputStream();
+
+        log.debug("Setting up the resources...");
+        doReturn(mockMapResource).when(mockResource).getChild(RedirectMapModel.MAP_FILE_NODE);
+        PrivateAccessor.setField(model, "redirects", redirectConfigs);
+        PrivateAccessor.setField(model, "redirectMap", mockMapResource);
+        PrivateAccessor.setField(model, "resourceResolver", mockResolver);
+        doReturn(model).when(mockResource).adaptTo(RedirectMapModel.class);
+        doReturn(IOUtils.toInputStream("/source1 /target1\n/source2 /target2")).when(mockMapResource)
+                .adaptTo(InputStream.class);
+        doReturn(mockMapContentResource).when(mockMapResource).getChild(JcrConstants.JCR_CONTENT);
+        doReturn(mvm).when(mockMapContentResource).adaptTo(ModifiableValueMap.class);
+    }
+
+    @Test
+    public void testAddEntryServlet() throws ServletException, IOException {
+        log.info("testAddEntryServlet");
+        AddEntryServlet addEntryServlet = new AddEntryServlet();
+        addEntryServlet.doPost(mockSlingRequest, mockSlingResponse);
+        
+        assertTrue(value.contains("/source /target"));
+        log.info(value);
+        log.info("Test successful!");
+    }
+    
+
+    @Test
+    public void testRemoveEntryServlet() throws ServletException, IOException {
+        log.info("testRemoveEntryServlet");
+        RemoveEntryServlet addEntryServlet = new RemoveEntryServlet();
+        addEntryServlet.doPost(mockSlingRequest, mockSlingResponse);
+        
+        assertFalse(value.contains("/source1 /target1"));
+        log.info(value);
+        log.info("Test successful!");
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/redirectmaps/models/MapEntryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirectmaps/models/MapEntryTest.java
@@ -68,6 +68,7 @@ public class MapEntryTest {
 		assertEquals(invalid.getOrigin(), "File");
 		assertEquals(invalid.getSource(), source);
 		assertEquals(invalid.getTarget(), mockResource.getPath());
+		log.debug(invalid.toString());
 
 		log.info("Test successful!");
 	}
@@ -86,6 +87,7 @@ public class MapEntryTest {
 		assertEquals(valid.getOrigin(), mockResource.getPath());
 		assertEquals(valid.getSource(), source);
 		assertEquals(valid.getTarget(), mockResource.getPath());
+		log.debug(valid.toString());
 
 		log.info("Test successful!");
 	}

--- a/bundle/src/test/java/com/adobe/acs/commons/redirectmaps/models/MapEntryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirectmaps/models/MapEntryTest.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 public class MapEntryTest {
 
 	private Resource mockResource = null;
-	
+
 	private static final Logger log = LoggerFactory.getLogger(MapEntryTest.class);
 
 	@Before
@@ -51,37 +51,37 @@ public class MapEntryTest {
 
 	@Test
 	public void testInvalidMapEntry() {
-		
+
 		log.info("testInvalidMapEntry");
 		String source = "/vanity 2";
-		MapEntry invalid = new MapEntry(mockResource, source, mockResource.getPath());
-		
+		MapEntry invalid = new MapEntry(source, mockResource.getPath(), "File");
+
 		log.info("Asserting that entry is invalid");
 		assertFalse(invalid.isValid());
-		
+
 		log.info("Asserting that matches expected values");
-		assertEquals(invalid.getResource(),mockResource);
+		assertEquals(invalid.getOrigin(), "File");
 		assertEquals(invalid.getSource(), source);
 		assertEquals(invalid.getTarget(), mockResource.getPath());
-		
+
 		log.info("Test successful!");
 	}
 
 	@Test
 	public void testValidMapEntry() {
-		
+
 		log.info("testValidMapEntry");
 		String source = "/vanity-2";
-		MapEntry valid = new MapEntry(mockResource, source, mockResource.getPath());
-		
+		MapEntry valid = new MapEntry(source, mockResource.getPath(), mockResource.getPath());
+
 		log.info("Asserting that entry is valid");
 		assertTrue(valid.isValid());
-		
+
 		log.info("Asserting that matches expected values");
-		assertEquals(valid.getResource(),mockResource);
+		assertEquals(valid.getOrigin(), mockResource.getPath());
 		assertEquals(valid.getSource(), source);
 		assertEquals(valid.getTarget(), mockResource.getPath());
-		
+
 		log.info("Test successful!");
 	}
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/redirectmaps/models/MapEntryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirectmaps/models/MapEntryTest.java
@@ -21,6 +21,7 @@ package com.adobe.acs.commons.redirectmaps.models;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.sling.api.resource.Resource;
@@ -56,8 +57,12 @@ public class MapEntryTest {
 		String source = "/vanity 2";
 		MapEntry invalid = new MapEntry(source, mockResource.getPath(), "File");
 
+		invalid.setValid(false);
+		invalid.setStatus("Invalid!");
+		
 		log.info("Asserting that entry is invalid");
 		assertFalse(invalid.isValid());
+		assertNotNull(invalid.getStatus());
 
 		log.info("Asserting that matches expected values");
 		assertEquals(invalid.getOrigin(), "File");

--- a/bundle/src/test/java/com/adobe/acs/commons/redirectmaps/models/RedirectMapModelTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirectmaps/models/RedirectMapModelTest.java
@@ -32,10 +32,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import javax.jcr.RepositoryException;
 import javax.jcr.query.Query;
 
-import junitx.util.PrivateAccessor;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
@@ -46,128 +44,128 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.day.cq.commons.jcr.JcrConstants;
 
+import junitx.util.PrivateAccessor;
+
 @RunWith(MockitoJUnitRunner.class)
 public class RedirectMapModelTest {
 
-	private static final String[] vanities = new String[] { "/vanity1", "/vanity 2" };
-	private Resource searchResultsResource;
+    private static final String[] vanities = new String[] { "/vanity1", "/vanity 2" };
+    private Resource searchResultsResource;
 
-	@Mock
-	private ResourceResolver resolver;
+    @Mock
+    private ResourceResolver resolver;
 
-	@Mock
-	private Resource redirectMapResource;
+    @Mock
+    private Resource redirectMapResource;
 
-	private List<RedirectConfigModel> redirectConfigs = new ArrayList<RedirectConfigModel>() {
-		private static final long serialVersionUID = 1L;
+    private List<RedirectConfigModel> redirectConfigs = new ArrayList<RedirectConfigModel>() {
+        private static final long serialVersionUID = 1L;
 
-		{
-			add(new RedirectConfigModel() {
+        {
+            add(new RedirectConfigModel() {
 
-				@Override
-				public String getDomain() {
-					return "www.adobe.com";
-				}
+                @Override
+                public String getDomain() {
+                    return "www.adobe.com";
+                }
 
-				@Override
-				public String getPath() {
-					return "/content/adobe";
-				}
+                @Override
+                public String getPath() {
+                    return "/content/adobe";
+                }
 
-				@Override
-				public String getProperty() {
-					return "vanity";
-				}
+                @Override
+                public String getProperty() {
+                    return "vanity";
+                }
 
-				@Override
-				public String getProtocol() {
-					return "https";
-				}
+                @Override
+                public String getProtocol() {
+                    return "https";
+                }
 
-				@Override
-				public Resource getResource() {
-					return mock(Resource.class);
-				}
-			});
-		}
-	};
+                @Override
+                public Resource getResource() {
+                    return mock(Resource.class);
+                }
+            });
+        }
+    };
 
-	@InjectMocks
-	private RedirectMapModel model;
+    @InjectMocks
+    private RedirectMapModel model;
 
-	private static final Logger log = LoggerFactory.getLogger(RedirectMapModelTest.class);
+    private static final Logger log = LoggerFactory.getLogger(RedirectMapModelTest.class);
 
-	@Before
-	public void init() throws Exception {
-		log.info("init");
+    @Before
+    public void init() throws Exception {
+        log.info("init");
 
-		PrivateAccessor.setField(model, "redirects", redirectConfigs);
+        PrivateAccessor.setField(model, "redirects", redirectConfigs);
 
-		searchResultsResource = mock(Resource.class);
+        searchResultsResource = mock(Resource.class);
 
-		Resource childResource = mock(Resource.class);
-		doReturn(childResource).when(searchResultsResource).getChild(JcrConstants.JCR_CONTENT);
+        Resource childResource = mock(Resource.class);
+        doReturn(childResource).when(searchResultsResource).getChild(JcrConstants.JCR_CONTENT);
 
-		ValueMap properties = new ValueMapDecorator(new HashMap<String, Object>() {
-			private static final long serialVersionUID = 1L;
-			{
-				put("vanity", vanities);
-			}
-		});
-		doReturn(properties).when(childResource).getValueMap();
-		doReturn("/content/adobe/en").when(searchResultsResource).getPath();
+        ValueMap properties = new ValueMapDecorator(new HashMap<String, Object>() {
+            private static final long serialVersionUID = 1L;
+            {
+                put("vanity", vanities);
+            }
+        });
+        doReturn(properties).when(childResource).getValueMap();
+        doReturn("/content/adobe/en").when(searchResultsResource).getPath();
 
-		doReturn(IOUtils.toInputStream("/vanity3\thttp://www.adobe.com")).when(redirectMapResource)
-				.adaptTo(InputStream.class);
+        doReturn(IOUtils.toInputStream("/vanity3\thttp://www.adobe.com")).when(redirectMapResource)
+                .adaptTo(InputStream.class);
 
-		doReturn(new ArrayList<Resource>() {
-			private static final long serialVersionUID = 1L;
-			{
-				add(searchResultsResource);
-			}
-		}.iterator()).when(resolver).findResources(
-				"SELECT * FROM [cq:Page] WHERE [jcr:content/vanity] IS NOT NULL AND (ISDESCENDANTNODE([/content/adobe]) OR [jcr:path]='/content/adobe')",
-				Query.JCR_SQL2);
+        doReturn(new ArrayList<Resource>() {
+            private static final long serialVersionUID = 1L;
+            {
+                add(searchResultsResource);
+            }
+        }.iterator()).when(resolver).findResources(
+                "SELECT * FROM [cq:Page] WHERE [jcr:content/vanity] IS NOT NULL AND (ISDESCENDANTNODE([/content/adobe]) OR [jcr:path]='/content/adobe')",
+                Query.JCR_SQL2);
 
-		doReturn(new ArrayList<Resource>().iterator()).when(resolver).findResources(
-				"SELECT * FROM [dam:Asset] WHERE [jcr:content/vanity] IS NOT NULL AND (ISDESCENDANTNODE([/content/adobe]) OR [jcr:path]='/content/adobe')",
-				Query.JCR_SQL2);
+        doReturn(new ArrayList<Resource>().iterator()).when(resolver).findResources(
+                "SELECT * FROM [dam:Asset] WHERE [jcr:content/vanity] IS NOT NULL AND (ISDESCENDANTNODE([/content/adobe]) OR [jcr:path]='/content/adobe')",
+                Query.JCR_SQL2);
 
-	}
+    }
 
-	@Test
-	public void testGetInvalidEntries() {
+    @Test
+    public void testGetInvalidEntries() {
 
-		log.info("testGetInvalidEntries");
-		List<MapEntry> mapEntries = model.getInvalidEntries();
+        log.info("testGetInvalidEntries");
+        List<MapEntry> mapEntries = model.getInvalidEntries();
 
-		log.info("Asserting that the invalid results are found");
-		assertNotNull(mapEntries);
-		assertEquals(1, mapEntries.size());
-		assertEquals("/vanity 2", mapEntries.get(0).getSource());
+        log.info("Asserting that the invalid results are found");
+        assertNotNull(mapEntries);
+        assertEquals(1, mapEntries.size());
+        assertEquals("/vanity 2", mapEntries.get(0).getSource());
 
-		log.info("Test successful!");
-	}
+        log.info("Test successful!");
+    }
 
-	@Test
-	public void testGetRedirectMap() throws IOException {
+    @Test
+    public void testGetRedirectMap() throws IOException {
 
-		log.info("testGetInvalidEntries");
-		String redirectMap = model.getRedirectMap();
+        log.info("testGetInvalidEntries");
+        String redirectMap = model.getRedirectMap();
 
-		log.info("Asserting the expected redirect map found");
-		assertNotNull(redirectMap);
-		assertFalse(redirectMap.contains("/vanity 2"));
-		assertTrue(redirectMap.contains("/vanity1"));
-		assertTrue(redirectMap.contains("/vanity3"));
-		log.info("Test successful!");
-	}
+        log.info("Asserting the expected redirect map found");
+        assertNotNull(redirectMap);
+        assertFalse(redirectMap.contains("/vanity 2"));
+        assertTrue(redirectMap.contains("/vanity1"));
+        assertTrue(redirectMap.contains("/vanity3"));
+        log.info("Test successful!");
+    }
 }

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/clientlibs/app.css
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/clientlibs/app.css
@@ -22,6 +22,11 @@
 	padding: 1em 0;
 }
 
+.entry-invalid {
+	background-color: #fa7d73;
+	color: #323232;
+}
+
 .fixed-height {
 	max-height: 500px;
     overflow: scroll;

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/clientlibs/app.css
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/clientlibs/app.css
@@ -1,11 +1,63 @@
+
+.form-row{
+	padding-bottom: 1em;
+	clear:both;
+}
+
+.form-row input{
+	width: 75%;
+}
+
+.form-row label{
+	font-weight: bold;
+    padding: 10px 0;
+    width: 100px;
+    display: inline-block;
+}
+
+.form-row span{
+	margin-left: 75px;
+}
 .coral-Heading {
 	padding: 1em 0;
 }
 
-pre {
+.fixed-height {
 	max-height: 500px;
+    overflow: scroll;
 }
 
 section {
 	padding: .5em;
+}
+
+#entry-table {
+    table-layout: fixed;
+    width: 100%;
+    white-space: nowrap;
+    border-spacing: 0;
+    border-collapse: separate;
+    padding: 10px 0;
+}
+
+#entry-table tbody {
+    margin: .2em;
+    background-color:white;
+}
+
+#entry-table td {
+    padding: .2em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+#entry-table thead tr {
+    height: 25px;
+    text-align: left;
+    background-color:silver;
+}
+
+.narrow-cell {
+    width: 50px;
 }

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/clientlibs/app.css
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/clientlibs/app.css
@@ -1,39 +1,44 @@
 
 .form-row{
-	padding-bottom: 1em;
-	clear:both;
+    padding-bottom: 1em;
+    clear:both;
 }
 
 .form-row input{
-	width: 75%;
+    width: 75%;
 }
 
 .form-row label{
-	font-weight: bold;
+    font-weight: bold;
     padding: 10px 0;
     width: 100px;
     display: inline-block;
 }
 
 .form-row span{
-	margin-left: 75px;
+    margin-left: 75px;
 }
 .coral-Heading {
-	padding: 1em 0;
+    padding: 1em 0;
 }
 
 .entry-invalid {
-	background-color: #fa7d73;
-	color: #323232;
+    background-color: #fa7d73;
+    color: #323232;
 }
 
 .fixed-height {
-	max-height: 500px;
+    max-height: 500px;
     overflow: scroll;
 }
 
+pre {
+    background-color: white;
+    padding: .5em;
+}
+
 section {
-	padding: .5em;
+    padding: .5em;
 }
 
 #entry-table {

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/clientlibs/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/clientlibs/app.js
@@ -27,6 +27,7 @@ angular.module('acs-commons-redirectmappage-app', ['acsCoral', 'ACS.Commons.noti
 		};
     	
     	$scope.entries = [];
+    	$scope.redirectMap = '';
 
         $scope.updateRedirectMap = function (e) {
         	e.preventDefault();
@@ -72,13 +73,33 @@ angular.module('acs-commons-redirectmappage-app', ['acsCoral', 'ACS.Commons.noti
 			}).success(function (data, status, headers, config) {
 
 				var time = new Date().getTime() - start;
-				data.time=time;
 				$scope.entries = data || {};
 				NotificationsService.running(false);
 				NotificationsService.add('success', 'SUCCESS', 'Found '+data.length+' entries in '+time+'ms!');
+				$scope.loadRedirectMap();
 			}).error(function (data, status, headers, config) {
 				NotificationsService.running(false);
 				NotificationsService.add('error', 'ERROR', 'Unable load redirect entries!');
+			});
+			
+			
+		};
+		
+		$scope.loadRedirectMap = function(){
+			var start = new Date().getTime();
+			NotificationsService.running(true);
+			$scope.redirectMap = '';
+			$http({
+				method: 'GET',
+				url: $scope.app.uri+'.redirectmap.txt'
+			}).success(function (data, status, headers, config) {
+				var time = new Date().getTime() - start;
+				$scope.redirectMap = data || '';
+				NotificationsService.running(false);
+				NotificationsService.add('success', 'SUCCESS', 'Loaded redirect map in '+time+'ms!');
+			}).error(function (data, status, headers, config) {
+				NotificationsService.running(false);
+				NotificationsService.add('error', 'ERROR', 'Unable load redirect map!');
 			});
 		};
 
@@ -95,6 +116,7 @@ angular.module('acs-commons-redirectmappage-app', ['acsCoral', 'ACS.Commons.noti
 				$scope.entries = data || {};
 				NotificationsService.running(false);
 				NotificationsService.add('success', 'SUCCESS', 'Redirect map updated!');
+				$scope.loadRedirectMap();
 			}).error(function (data, status, headers, config) {
 				NotificationsService.running(false);
 				NotificationsService.add('error', 'ERROR', 'Unable remove entry '+idx+'!');
@@ -146,6 +168,7 @@ angular.module('acs-commons-redirectmappage-app', ['acsCoral', 'ACS.Commons.noti
 				$scope.entries = data || {};
 				NotificationsService.running(false);
 				NotificationsService.add('success', 'SUCCESS', 'Entry added!');
+				$scope.loadRedirectMap();
 			}).error(function (data, status, headers, config) {
 				NotificationsService.running(false);
 				NotificationsService.add('error', 'ERROR', 'Unable to add entry!');

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/content.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/content.jsp
@@ -124,12 +124,12 @@
 				<section>
 					<h2 class="coral-Heading coral-Heading--2"><fmt:message key="View Entries" /></h2>
 					<p>
-						<fmt:message key="List of all of the entries in the redirect map files and gathered from the configuration. Click the button to remove / edit." />
+						<fmt:message key="Select Find Entries to load a list of the entries in the redirect map files and gathered from the configuration. Click the button to remove / edit." />
 					</p>
 					<form ng-submit="filterEntries()" id="filter-form">
-						<input is="coral-textfield" placeholder="Filter by source or target" name="filter" value="">
+						<input is="coral-textfield" placeholder="* for all or search term" name="filter" value="">
 						<button is="coral-button" iconsize="S">
-							Filter
+							Find Entries
 						</button>
 					</form>
 					<br/>
@@ -146,7 +146,7 @@
                                 </tr>
                             </thead>
                             <tbody >
-                                <tr ng-repeat="entry in entries" class="{{entry.valid ? '' : 'entry-invalid'}}">
+                                <tr ng-repeat="entry in filteredEntries" class="{{entry.valid ? '' : 'entry-invalid'}}">
                                     <td class="narrow-cell">{{$index}}</td>
                                     <td title="{{entry.source}}">{{entry.source}}</td>
                                     <td title="{{entry.target}}">

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/content.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/content.jsp
@@ -11,6 +11,7 @@
 		<coral-tablist target="main-panel-1">
 			<coral-tab><fmt:message key="Configure" /></coral-tab>
 			<coral-tab><fmt:message key="Edit Entries" /></coral-tab>
+			<coral-tab><fmt:message key="Preview" /></coral-tab>
 		</coral-tablist>
 		<coral-panelstack id="main-panel-1">
 			<coral-panel class="coral-Well">
@@ -70,44 +71,61 @@
 			<sling2:adaptTo adaptable="${resource}" adaptTo="com.adobe.acs.commons.redirectmaps.models.RedirectMapModel" var="redirectMapModel" />
 			<coral-panel class="coral-Well">
 				<section>
-					<h2 class="coral-Heading coral-Heading--2"><fmt:message key="View / Edit Map" /></h2>
+					<h2 class="coral-Heading coral-Heading--2"><fmt:message key="Add Entry" /></h2>
+					<p>
+						<fmt:message key="Add an entry into the redirect map file in the specified location." />
+					</p>
 					<form ng-submit="addEntry()" id="entry-form">
-                        <fieldset>
-                            <h3>Add Entry</h3>
-                            <div class="form-row">
-                                <label acs-coral-heading>
-                                    Source
-                                </label>
-                                <span>
-                                    <input type="text" name="source" class="coral-Textfield"  ng-required="true" placeholder="Path to redirect"/>
-                                </span>
-                            </div>
-                            <div class="form-row">
-                                <label acs-coral-heading>
-                                    Target
-                                </label>
-                                <span>
-                                    <input type="text" name="target" class="coral-Textfield"  ng-required="true" placeholder="URL to redirect to"/>
-                                </span>
-                            </div>
-                            <div class="form-row">
-                                <label acs-coral-heading>
-                                    Index
-                                </label>
-                                <span>
-                                    <input type="number" name="idx" list="idx" ng-required="true" class="coral-Textfield" placeholder="Index to add the entry within the file"/>
-                                    <datalist id="idx">
-                                        <option value="0">First</option>
-                                        <option value="{{entries.length}}">Last</option>
-                                    </datalist>
-                                </span>
-                            </div>
-                            <button is="coral-button" iconsize="S">
-                                Add Entry
-                            </button>
-                        </fieldset>
+                        <div class="form-row">
+                            <label acs-coral-heading>
+                                Source
+                            </label>
+                            <span>
+                                <input type="text" name="source" class="coral-Textfield"  ng-required="true" placeholder="Path to redirect"/>
+                            </span>
+                        </div>
+                        <div class="form-row">
+                            <label acs-coral-heading>
+                                Target
+                            </label>
+                            <span>
+                                <input type="text" name="target" class="coral-Textfield"  ng-required="true" placeholder="URL to redirect to"/>
+                            </span>
+                        </div>
+                        <div class="form-row">
+                            <label acs-coral-heading>
+                                Index
+                            </label>
+                            <span>
+                                <input type="number" name="idx" list="idx" ng-required="true" class="coral-Textfield" placeholder="Index to add the entry within the file"/>
+                                <datalist id="idx">
+                                    <option value="0">First</option>
+                                    <option value="{{entries.length}}">Last</option>
+                                </datalist>
+                            </span>
+                        </div>
+                        <button is="coral-button" iconsize="S">
+                            Add Entry
+                        </button>
 					</form>
-					<br/>
+				</section>
+				<section  ng-if="(entries | filter: {valid : false}).length > 0">
+					<coral-alert size="L" variant="warning">
+						<coral-alert-header><fmt:message key="Invalid Redirect Maps "/></coral-alert-header>
+						<coral-alert-content>
+							<ul>
+								<li ng-repeat="entry in entries | filter: {valid : false}">
+									{{entry.status}}
+								</li>
+							</ul>
+						</coral-alert-content>
+					</coral-alert>
+				</section>
+				<section>
+					<h2 class="coral-Heading coral-Heading--2"><fmt:message key="View Entries" /></h2>
+					<p>
+						<fmt:message key="List of all of the entries in the redirect map files and gathered from the configuration. Click the button to remove / edit." />
+					</p>
 					<form ng-submit="filterEntries()" id="filter-form">
 						<input is="coral-textfield" placeholder="Filter by source or target" name="filter" value="">
 						<button is="coral-button" iconsize="S">
@@ -128,7 +146,7 @@
                                 </tr>
                             </thead>
                             <tbody >
-                                <tr ng-repeat="entry in entries" >
+                                <tr ng-repeat="entry in entries" class="{{entry.valid ? '' : 'entry-invalid'}}">
                                     <td class="narrow-cell">{{$index}}</td>
                                     <td title="{{entry.source}}">{{entry.source}}</td>
                                     <td title="{{entry.target}}">
@@ -150,6 +168,22 @@
                             </tbody>
                         </table>
                     </div>
+				</section>
+			</coral-panel>
+			<coral-panel class="coral-Well">
+				<section>
+					<h2 class="coral-Heading coral-Heading--2"><fmt:message key="Download Preview" /></h2>
+					<c:if test="${redirectMap != null}">
+						<a class="coral-Link" href="${resource.path}.redirectmap.txt">
+							<fmt:message key="Download Combined Redirect Map File" />
+						</a>
+						<br/>
+						Published Path: ${resource.path}.redirectmap.txt
+					</c:if>
+				</section>
+				<section>
+					<h2 class="coral-Heading coral-Heading--2"><fmt:message key="Preview" /></h2>
+					<pre class="fixed-height">{{redirectMap}}</pre>
 				</section>
 			</coral-panel>
     	</coral-panelstack>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/content.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/content.jsp
@@ -147,7 +147,7 @@
                             </thead>
                             <tbody >
                                 <tr ng-repeat="entry in filteredEntries" class="{{entry.valid ? '' : 'entry-invalid'}}">
-                                    <td class="narrow-cell">{{$index}}</td>
+                                    <td class="narrow-cell">{{entry.id}}</td>
                                     <td title="{{entry.source}}">{{entry.source}}</td>
                                     <td title="{{entry.target}}">
                                         {{entry.target}}

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/content.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/content.jsp
@@ -2,7 +2,7 @@
 <%@include file="/libs/foundation/global.jsp" %>
 <%@taglib prefix="sling2" uri="http://sling.apache.org/taglibs/sling" %>
 <cq:setContentBundle />
-<div ng-controller="MainCtrl" ng-init="init();">
+<div ng-controller="MainCtrl" ng-init="app.uri = '${resourcePath}'; init();">
 
 	<br/><hr/><br/>
 	
@@ -10,7 +10,7 @@
 	<coral-tabview>
 		<coral-tablist target="main-panel-1">
 			<coral-tab><fmt:message key="Configure" /></coral-tab>
-			<coral-tab><fmt:message key="Preview" /></coral-tab>
+			<coral-tab><fmt:message key="Edit Entries" /></coral-tab>
 		</coral-tablist>
 		<coral-panelstack id="main-panel-1">
 			<coral-panel class="coral-Well">
@@ -67,32 +67,89 @@
 					</form>
 				</section>
 			</coral-panel>
+			<sling2:adaptTo adaptable="${resource}" adaptTo="com.adobe.acs.commons.redirectmaps.models.RedirectMapModel" var="redirectMapModel" />
 			<coral-panel class="coral-Well">
 				<section>
-					<h2 class="coral-Heading coral-Heading--2"><fmt:message key="Redirect Preview" /></h2>
-					<c:if test="${redirectMap != null}">
-						<a class="coral-Link" href="${resource.path}.redirectmap.txt">
-							<fmt:message key="Download Combined Redirect Map File" />
-						</a>
-						<br/>
-						Published Path: ${resource.path}.redirectmap.txt
-					</c:if>
-					<sling2:adaptTo adaptable="${resource}" adaptTo="com.adobe.acs.commons.redirectmaps.models.RedirectMapModel" var="redirectMapModel" />
-					<c:if test="${fn:length(redirectMapModel.invalidEntries) > 0}">
-						<coral-alert size="L" variant="error">
-							<coral-alert-header><fmt:message key="Invalid Redirect Sources "/></coral-alert-header>
-							<coral-alert-content>
-								<ul>
-									<c:forEach var="invalidEntry" items="${redirectMapModel.invalidEntries}">
-										<li>
-											<fmt:message key="Entry "/> <strong>${invalidEntry.source}</strong> <fmt:message key=" on page "/> <a class="coral-Link" target="_blank" href="/sites.html${invalidEntry.resource.path}">${invalidEntry.resource.path}</a> <fmt:message key=" contains whitespace "/>
-										</li>
-									</c:forEach>
-								</ul>
-							</coral-alert-content>
-						</coral-alert>
-					</c:if>
-					<pre>${redirectMapModel.redirectMap}</pre>
+					<h2 class="coral-Heading coral-Heading--2"><fmt:message key="View / Edit Map" /></h2>
+					<form ng-submit="addEntry()" id="entry-form">
+                        <fieldset>
+                            <h3>Add Entry</h3>
+                            <div class="form-row">
+                                <label acs-coral-heading>
+                                    Source
+                                </label>
+                                <span>
+                                    <input type="text" name="source" class="coral-Textfield"  ng-required="true" placeholder="Path to redirect"/>
+                                </span>
+                            </div>
+                            <div class="form-row">
+                                <label acs-coral-heading>
+                                    Target
+                                </label>
+                                <span>
+                                    <input type="text" name="target" class="coral-Textfield"  ng-required="true" placeholder="URL to redirect to"/>
+                                </span>
+                            </div>
+                            <div class="form-row">
+                                <label acs-coral-heading>
+                                    Index
+                                </label>
+                                <span>
+                                    <input type="number" name="idx" list="idx" ng-required="true" class="coral-Textfield" placeholder="Index to add the entry within the file"/>
+                                    <datalist id="idx">
+                                        <option value="0">First</option>
+                                        <option value="{{entries.length}}">Last</option>
+                                    </datalist>
+                                </span>
+                            </div>
+                            <button is="coral-button" iconsize="S">
+                                Add Entry
+                            </button>
+                        </fieldset>
+					</form>
+					<br/>
+					<form ng-submit="filterEntries()" id="filter-form">
+						<input is="coral-textfield" placeholder="Filter by source or target" name="filter" value="">
+						<button is="coral-button" iconsize="S">
+							Filter
+						</button>
+					</form>
+					<br/>
+                    <div class="fixed-height">
+                        <table id="entry-table">
+                            <thead>
+                                <tr>
+                                    <th class="narrow-cell">ID</th>
+                                    <th>Source</th>
+                                    <th>Target</th>
+                                    <th>Status</th>
+                                    <th>Origin</th>
+                                    <th class="narrow-cell">Edit</th>
+                                </tr>
+                            </thead>
+                            <tbody >
+                                <tr ng-repeat="entry in entries" >
+                                    <td class="narrow-cell">{{$index}}</td>
+                                    <td title="{{entry.source}}">{{entry.source}}</td>
+                                    <td title="{{entry.target}}">
+                                        {{entry.target}}
+                                    </td>
+                                    <td title="{{entry.status}}">{{entry.status}}</td>
+                                    <td title="{{entry.origin}}">{{entry.origin}}</td>
+                                    <td class="narrow-cell">
+                                        <div ng-switch on="entry.origin">
+                                            <div ng-switch-when="File">
+                                                <button is="coral-button" icon="delete" iconsize="S" ng-click="removeLine($index)"></button>
+                                            </div>
+                                            <div ng-switch-default>
+                                                <button is="coral-button" icon="edit" iconsize="S" ng-click="openEditor(entry.origin)"></button>
+                                            </div>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
 				</section>
 			</coral-panel>
     	</coral-panelstack>


### PR DESCRIPTION
I added a new feature based on user feedback from the initial version of the tool. The enhancement is a new tab allowing users to edit the redirect map entries directly inside the tool:

<img width="1101" alt="screen shot 2018-04-27 at 5 01 36 pm" src="https://user-images.githubusercontent.com/2946250/39385001-aefdee4e-4a3c-11e8-8225-022aa9bb2657.png">

It also evaluates all of the entries now, so it will highlight invalid entries from the file as well as from the Page / Asset properties.