### PR TITLE
Checkstyle for Tests #task

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -25,12 +25,17 @@ plugins:
   sonar-java:
     enabled: true
     channel: "beta"
+    exclude_patterns:
+      - "**/src/test/"
     config:
       sonar.java.source: 8
   checkstyle:
     enabled: true
     config:
       file: ".codeclimate/checkstyle.xml"
+    exclude_patterns:
+      - "**/src/test/java/com/amazonaws/"
+      - "**/src/test/java/ch/randelshofer/"
 #  csslint:
 #    enabled: true
 #  duplication:
@@ -50,7 +55,6 @@ exclude_patterns:
 - ".idea/"
 - "**/vendor/"
 - "**/extensions/contentfinder/"
-- "**/src/test/"
 - "*/target/"
 
 

--- a/.codeclimate/checkstyle.xml
+++ b/.codeclimate/checkstyle.xml
@@ -100,7 +100,7 @@
         <module name="AbbreviationAsWordInName">
             <property name="ignoreFinal" value="false"/>
             <property name="allowedAbbreviationLength" value="1"/>
-            <property name="allowedAbbreviations" value="JSON,HTML,JCR,SQL,DAM,AEM,WCM,URI,SSL,ACL,UI,XML,RGB,CSV"/>
+            <property name="allowedAbbreviations" value="JSON,HTML,JCR,SQL,DAM,AEM,WCM,URI,SSL,ACL,UI,XML,RGB,CSV,GQL,IT"/>
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>

--- a/bundle/src/main/java/com/adobe/acs/commons/contentfinder/querybuilder/impl/viewhandler/GQLToQueryBuilderConverter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/contentfinder/querybuilder/impl/viewhandler/GQLToQueryBuilderConverter.java
@@ -36,7 +36,6 @@ import static com.adobe.acs.commons.contentfinder.querybuilder.impl.viewhandler.
 
 import java.util.Map;
 
-@SuppressWarnings("checkstyle:abbreviationaswordinname")
 public final class GQLToQueryBuilderConverter {
 
     private static final String SUFFIX_ORDERBY = "_orderby";

--- a/bundle/src/test/java/com/adobe/acs/commons/analysis/jcrchecksum/impl/ChecksumGeneratorImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/analysis/jcrchecksum/impl/ChecksumGeneratorImplTest.java
@@ -185,8 +185,8 @@ public class ChecksumGeneratorImplTest {
 
         final String originalJcrContentChecksum = nodeChecksum;
 
-        assertEquals(originalJcrContentChecksum, checksumGenerator.generatedNodeChecksum(asset.getPath(), asset.getNode
-                ("renditions/original/jcr:content"), opts));
+        assertEquals(originalJcrContentChecksum, checksumGenerator.generatedNodeChecksum(asset.getPath(),
+                asset.getNode("renditions/original/jcr:content"), opts));
 
         // jcr:content/renditions/original
         propertiesChecksum =
@@ -248,8 +248,8 @@ public class ChecksumGeneratorImplTest {
 
     @Test
     public void testMultiple() throws IOException, RepositoryException {
-        Node page = setupPage1();
-        Node asset = setupAsset1();
+        final Node page = setupPage1();
+        final Node asset = setupAsset1();
 
         ChecksumGeneratorOptions defaultOptions = new DefaultChecksumGeneratorOptions();
 
@@ -272,7 +272,7 @@ public class ChecksumGeneratorImplTest {
 
     @Test
     public void testGeneratedNodeChecksum() throws RepositoryException, IOException {
-        Node node = session.getRootNode().addNode("page/jcr:content");
+        final Node node = session.getRootNode().addNode("page/jcr:content");
         node.setProperty("jcr:title", "My Title");
         node.setProperty("jcr:description", "This is my test node");
         node.setProperty("long", new Long(100));
@@ -280,22 +280,22 @@ public class ChecksumGeneratorImplTest {
         node.setProperty("boolean", true);
         session.save();
 
-        String raw =
-                "jcr:content/boolean=" + DigestUtils.shaHex("true") +
-                        "jcr:content/double=" + DigestUtils.shaHex("99.99") +
-                        "jcr:content/jcr:description=" + DigestUtils.shaHex("This is my test node") +
-                        "jcr:content/jcr:primaryType=" + DigestUtils.shaHex("nt:unstructured") +
-                        "jcr:content/jcr:title=" + DigestUtils.shaHex("My Title") +
-                        "jcr:content/long=" + DigestUtils.shaHex("100");
+        final String raw =
+                "jcr:content/boolean=" + DigestUtils.shaHex("true")
+                        + "jcr:content/double=" + DigestUtils.shaHex("99.99")
+                        + "jcr:content/jcr:description=" + DigestUtils.shaHex("This is my test node")
+                        + "jcr:content/jcr:primaryType=" + DigestUtils.shaHex("nt:unstructured")
+                        + "jcr:content/jcr:title=" + DigestUtils.shaHex("My Title")
+                        + "jcr:content/long=" + DigestUtils.shaHex("100");
 
-        String propertiesChecksum = DigestUtils.shaHex(raw);
-        String expected = DigestUtils.shaHex("jcr:content=" + propertiesChecksum);
+        final String propertiesChecksum = DigestUtils.shaHex(raw);
+        final String expected = DigestUtils.shaHex("jcr:content=" + propertiesChecksum);
 
         CustomChecksumGeneratorOptions opts = new CustomChecksumGeneratorOptions();
         opts.addSortedProperties(new String[]{ "sorted" });
         opts.addIncludedNodeTypes(new String[]{ "nt:unstructured" });
 
-        Map<String, String> actual = checksumGenerator.generateChecksums(session, node.getPath(), opts);
+        final Map<String, String> actual = checksumGenerator.generateChecksums(session, node.getPath(), opts);
 
         assertEquals(expected, actual.get("/page/jcr:content"));
     }
@@ -337,7 +337,7 @@ public class ChecksumGeneratorImplTest {
         //System.out.println("jcrContentChecksum: " + jcrContentChecksum);
 
         jcrContentChecksum = DigestUtils.shaHex("jcr:content=" + jcrContentChecksum);
-        String expected = jcrContentChecksum;
+        final String expected = jcrContentChecksum;
 
         CustomChecksumGeneratorOptions opts = new CustomChecksumGeneratorOptions();
         opts.addIncludedNodeTypes(new String[]{ "nt:unstructured" });

--- a/bundle/src/test/java/com/adobe/acs/commons/audit_log_search/impl/AuditLogSearchServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/audit_log_search/impl/AuditLogSearchServletTest.java
@@ -120,8 +120,8 @@ public class AuditLogSearchServletTest {
 
     @Test
     public void testDateWindow() throws Exception {
-        MockSlingHttpServletRequest request = context.request();
-        Map<String, Object> params = new HashMap<>();
+        final MockSlingHttpServletRequest request = context.request();
+        final Map<String, Object> params = new HashMap<>();
         params.put("contentRoot", "/content");
         params.put("includeChildren", "true");
         params.put("startDate", "2017-11-01T01:00");
@@ -136,9 +136,9 @@ public class AuditLogSearchServletTest {
     }
 
     @Test
-    public void testDateWindowPM() throws Exception {
-        MockSlingHttpServletRequest request = context.request();
-        Map<String, Object> params = new HashMap<>();
+    public void testDateWindowAfterNoon() throws Exception {
+        final MockSlingHttpServletRequest request = context.request();
+        final Map<String, Object> params = new HashMap<>();
         params.put("contentRoot", "/content");
         params.put("includeChildren", "true");
         params.put("startDate", "2017-11-01T16:00");

--- a/bundle/src/test/java/com/adobe/acs/commons/auth/saml/impl/OktaLogoutHandlerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/auth/saml/impl/OktaLogoutHandlerTest.java
@@ -50,7 +50,7 @@ public class OktaLogoutHandlerTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void activateWithoutHostThrowsIAE() {
+    public void activateWithoutHostThrowsIllegalArgumentException() {
         underTest.activate(Collections.emptyMap());
     }
 

--- a/bundle/src/test/java/com/adobe/acs/commons/components/longformtext/impl/LongFormTextComponentImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/components/longformtext/impl/LongFormTextComponentImplTest.java
@@ -65,8 +65,8 @@ public class LongFormTextComponentImplTest {
     public void testGetTextParagraphs_2() throws Exception {
         final String input = "<div class=\"dog-park\"><p>ira is a dog</p><p> she barks a lot</p></div>";
 
-        final String[] expected = new String[] {"<div class=\"dog-park\"><p>ira is a dog</p><p> she barks a " +
-                "lot</p></div>"};
+        final String[] expected = new String[] {"<div class=\"dog-park\"><p>ira is a dog</p><p> she barks a "
+                + "lot</p></div>"};
         final String[] result = longFormTextComponent.getTextParagraphs(input);
 
         Assert.assertArrayEquals(expected, result);

--- a/bundle/src/test/java/com/adobe/acs/commons/contentfinder/querybuilder/impl/viewhandler/GQLToQueryBuilderConverterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/contentfinder/querybuilder/impl/viewhandler/GQLToQueryBuilderConverterTest.java
@@ -389,7 +389,6 @@ public class GQLToQueryBuilderConverterTest {
         MockSlingHttpServletRequest request = context.request();
         request.setParameterMap(ImmutableMap.<String, Object>builder().put("wcmmode", "preview").build());
         GQLToQueryBuilderConverter.addProperty(request, map, "wcmmode", 1);
-        System.out.println(map);
         assertEquals(0, map.size());
     }
 

--- a/bundle/src/test/java/com/adobe/acs/commons/dam/RenditionPatternPickerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/dam/RenditionPatternPickerTest.java
@@ -22,7 +22,8 @@ package com.adobe.acs.commons.dam;
 import com.day.cq.dam.api.Asset;
 import com.day.cq.dam.api.Rendition;
 
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,32 +45,24 @@ public class RenditionPatternPickerTest {
     public RenditionPatternPickerTest() {
     }
 
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-    }
-
     @Before
     public void setUp() {
-        originalRendition = mock(Rendition.class);
+        originalRendition = mock(Rendition.class, "original");
         when(originalRendition.getName()).thenReturn("original");
 
-        largeRendition = mock(Rendition.class);
+        largeRendition = mock(Rendition.class, "large");
         when(largeRendition.getName()).thenReturn("cq5dam.thumbnail.1000.1000");
 
-        smallRendition = mock(Rendition.class);
+        smallRendition = mock(Rendition.class, "small");
         when(smallRendition.getName()).thenReturn("cq5dam.thumbnail.100.100");
 
-        webRendition = mock(Rendition.class);
+        webRendition = mock(Rendition.class, "web");
         when(webRendition.getName()).thenReturn("cq5dam.web.1280.1280");
 
-        customRendition = mock(Rendition.class);
+        customRendition = mock(Rendition.class, "custom");
         when(customRendition.getName()).thenReturn("custom");
 
-        renditions = new ArrayList<Rendition>();
+        renditions = new ArrayList<>();
         renditions.add(originalRendition);
         renditions.add(webRendition);
         renditions.add(largeRendition);
@@ -78,10 +71,6 @@ public class RenditionPatternPickerTest {
 
         asset = mock(Asset.class);
         when(asset.getRenditions()).thenReturn(renditions);
-    }
-
-    @After
-    public void tearDown() {
     }
 
     /**
@@ -95,13 +84,15 @@ public class RenditionPatternPickerTest {
         assertEquals(expResult, result);
     }
 
+    @Test
     public void testGetRendition_MultiMatchingRegex() {
-        RenditionPatternPicker instance = new RenditionPatternPicker("^cq5dam.*");
+        RenditionPatternPicker instance = new RenditionPatternPicker("^cq5dam\\.thumb*");
         Rendition expResult = largeRendition;
         Rendition result = instance.getRendition(asset);
         assertEquals(expResult, result);
     }
 
+    @Test
     public void testGetRendition_NonMatchingRegex() {
         RenditionPatternPicker instance = new RenditionPatternPicker("nothinghere");
         Rendition expResult = originalRendition;

--- a/bundle/src/test/java/com/adobe/acs/commons/dam/impl/CustomComponentActivatorListServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/dam/impl/CustomComponentActivatorListServletTest.java
@@ -29,10 +29,10 @@ import java.util.Collections;
 
 public class CustomComponentActivatorListServletTest {
 
-    private static final String DEFAULT_RESULT = "{\"components\":[{\"propertyName\":\"xmpMM:History\",\"componentPath\":\"/apps/acs-commons/dam/content/admin/history\"}," +
-            "{\"propertyName\":\"xmpTPg:Fonts\",\"componentPath\":\"/apps/acs-commons/dam/content/admin/fonts\"}," +
-            "{\"propertyName\":\"xmpTPg:Colorants\",\"componentPath\":\"/apps/acs-commons/dam/content/admin/color-swatches\"}," +
-            "{\"propertyName\":\"location\",\"componentPath\":\"/apps/acs-commons/dam/content/admin/asset-location-map\"}]}";
+    private static final String DEFAULT_RESULT = "{\"components\":[{\"propertyName\":\"xmpMM:History\",\"componentPath\":\"/apps/acs-commons/dam/content/admin/history\"},"
+            + "{\"propertyName\":\"xmpTPg:Fonts\",\"componentPath\":\"/apps/acs-commons/dam/content/admin/fonts\"},"
+            + "{\"propertyName\":\"xmpTPg:Colorants\",\"componentPath\":\"/apps/acs-commons/dam/content/admin/color-swatches\"},"
+            + "{\"propertyName\":\"location\",\"componentPath\":\"/apps/acs-commons/dam/content/admin/asset-location-map\"}]}";
 
     @Test
     public void testDefault() throws Exception {

--- a/bundle/src/test/java/com/adobe/acs/commons/email/impl/EmailServiceImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/email/impl/EmailServiceImplTest.java
@@ -33,7 +33,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -130,7 +135,7 @@ public class EmailServiceImplTest {
                                                  };
         ArgumentCaptor<SimpleEmail> captor = ArgumentCaptor.forClass(SimpleEmail.class);
 
-        List<String> failureList = emailService.sendEmail(emailTemplatePath, params, recipients);
+        final List<String> failureList = emailService.sendEmail(emailTemplatePath, params, recipients);
 
         verify(messageGatewaySimpleEmail, times(recipients.length)).send(captor.capture());
 
@@ -164,7 +169,7 @@ public class EmailServiceImplTest {
 
         ArgumentCaptor<SimpleEmail> captor = ArgumentCaptor.forClass(SimpleEmail.class);
 
-        List<String> failureList = emailService.sendEmail(emailTemplatePath, params, recipient);
+        final List<String> failureList = emailService.sendEmail(emailTemplatePath, params, recipient);
 
         verify(messageGatewaySimpleEmail, times(1)).send(captor.capture());
 
@@ -183,8 +188,8 @@ public class EmailServiceImplTest {
         final String expectedMessage = "This is just a message";
         final String expectedSenderName = "John Smith";
         final String expectedSenderEmailAddress = "john@smith.com";
-        String attachment = "This is a attachment.";
-        String attachmentName = "attachment.txt";
+        final String attachment = "This is a attachment.";
+        final String attachmentName = "attachment.txt";
         //Subject is provided inside the HtmlTemplate directly
         final String expectedSubject = "Greetings";
 
@@ -200,7 +205,7 @@ public class EmailServiceImplTest {
 
         ArgumentCaptor<HtmlEmail> captor = ArgumentCaptor.forClass(HtmlEmail.class);
 
-        List<String> failureList = emailService.sendEmail(emailTemplateAttachmentPath, params, attachments, recipient);
+        final List<String> failureList = emailService.sendEmail(emailTemplateAttachmentPath, params, attachments, recipient);
 
         verify(messageGatewayHtmlEmail, times(1)).send(captor.capture());
 

--- a/bundle/src/test/java/com/adobe/acs/commons/email/process/impl/SendTemplatedEmailProcessTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/email/process/impl/SendTemplatedEmailProcessTest.java
@@ -88,7 +88,7 @@ public class SendTemplatedEmailProcessTest {
     private static final String WCM_PAYLOAD_PATH = "/content/mypage";
     private static final String EMAIL_TEMPLATE = "/apps/acs-commons/content/template.txt";
     private static final String GROUP_PATH = "/home/groups/samplegroup";
-    private String[] GROUP_MEMBERS;
+    private static final String[] GROUP_MEMBERS = new String[] { "user1@adobe.com", "user2@adobe.com" };
 
     @SuppressWarnings("unchecked")
     @Before
@@ -97,8 +97,6 @@ public class SendTemplatedEmailProcessTest {
 
         when(workflowSession.getSession()).thenReturn(session);
         when(resourceResolverFactory.getResourceResolver(any(Map.class))).thenReturn(resourceResolver);
-
-        GROUP_MEMBERS = new String[] { "user1@adobe.com", "user2@adobe.com" };
 
     }
 

--- a/bundle/src/test/java/com/adobe/acs/commons/email/process/impl/SendTemplatedEmailUtilsTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/email/process/impl/SendTemplatedEmailUtilsTest.java
@@ -162,8 +162,8 @@ public class SendTemplatedEmailUtilsTest {
     public void testGetEmailAddrs_Group() throws Exception {
 
         // mock group and users
-        String groupPath = "/home/users/g/group";
-        List<Authorizable> groupMembers = new ArrayList<Authorizable>();
+        final String groupPath = "/home/users/g/group";
+        final List<Authorizable> groupMembers = new ArrayList<Authorizable>();
 
         Authorizable user1 = mock(Authorizable.class);
         Authorizable user2 = mock(Authorizable.class);

--- a/bundle/src/test/java/com/adobe/acs/commons/errorpagehandler/cache/impl/ErrorPageCacheImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/errorpagehandler/cache/impl/ErrorPageCacheImplTest.java
@@ -30,6 +30,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.util.concurrent.ConcurrentHashMap;
 
 import junitx.util.PrivateAccessor;
+
 import static org.junit.Assert.assertEquals;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -118,7 +119,7 @@ public class ErrorPageCacheImplTest {
     }
 
     @Test
-    public void testGetCacheSizeInKB() throws Exception {
+    public void testGetCacheSizeInKb() throws Exception {
         final long expResult = ("hello earth".getBytes().length
                 + "hello mars".getBytes().length) / 1000L;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/errorpagehandler/impl/ErrorPageHandlerImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/errorpagehandler/impl/ErrorPageHandlerImplTest.java
@@ -37,15 +37,15 @@ public class ErrorPageHandlerImplTest {
 
     @Rule
     public final SlingContext context = new SlingContext();
-    
-	private MockSlingHttpServletRequest request;
-	private ResourceResolver resourceResolver;
+
+    private MockSlingHttpServletRequest request;
+    private ResourceResolver resourceResolver;
 
     @Before
     public void setup() {
-    	context.load().json(getClass().getResourceAsStream("ErrorPageHandlerImplTest.json"), "/content/project");
-    	resourceResolver = context.resourceResolver();
-    	request = context.request();
+        context.load().json(getClass().getResourceAsStream("ErrorPageHandlerImplTest.json"), "/content/project");
+        resourceResolver = context.resourceResolver();
+        request = context.request();
     }
     
     /**
@@ -63,7 +63,7 @@ public class ErrorPageHandlerImplTest {
      */
     @Test
     public void testFindErrorPage_withDirectConfig() {
-    	assertEquals("/content/project/test/error-pages2.html", new ErrorPageHandlerImpl().findErrorPage(request, resourceResolver.getResource("/content/project/test/page-with-config")));
+        assertEquals("/content/project/test/error-pages2.html", new ErrorPageHandlerImpl().findErrorPage(request, resourceResolver.getResource("/content/project/test/page-with-config")));
     }
     
     @Test

--- a/bundle/src/test/java/com/adobe/acs/commons/fam/ActionsTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/fam/ActionsTest.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2017 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,14 +15,17 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.fam;
 
 import com.adobe.acs.commons.fam.actions.Actions;
-import com.adobe.acs.commons.functions.*;
+import com.adobe.acs.commons.functions.CheckedBiConsumer;
+import com.adobe.acs.commons.functions.CheckedConsumer;
 import org.apache.sling.api.resource.ResourceResolver;
-import static org.junit.Assert.fail;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -41,8 +47,8 @@ public class ActionsTest {
 
     @Test
     public void retryThrowsError() throws Exception {
-        ResourceResolver rr = mock(ResourceResolver.class);
-        CheckedConsumer retry = mock(CheckedConsumer.class);
+        final ResourceResolver rr = mock(ResourceResolver.class);
+        final CheckedConsumer retry = mock(CheckedConsumer.class);
         try {
             doThrow(Exception.class)
                     .doThrow(Exception.class)

--- a/bundle/src/test/java/com/adobe/acs/commons/fam/impl/ActionManagerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/fam/impl/ActionManagerTest.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2017 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.fam.impl;
 
@@ -22,8 +26,9 @@ import java.util.logging.Logger;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.ResourceResolver;
-import static org.junit.Assert.*;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -51,10 +56,12 @@ public class ActionManagerTest {
             run((Runnable) i.getArguments()[0]);
             return null;
         }).when(taskRunner).scheduleWork(any(), any());
+
         return taskRunner;
     }
 
     static ResourceResolver mockResolver;
+
     public static ResourceResolver getFreshMockResolver() throws LoginException {
         mockResolver = null;
         return getMockResolver();
@@ -77,7 +84,7 @@ public class ActionManagerTest {
     @Test
     public void nullStatsCounterTest() throws LoginException, Exception {
         // Counters don't do tabulate in-thread actions, only deferred actions
-        ResourceResolver rr = getMockResolver();
+        final ResourceResolver rr = getMockResolver();
         ActionManager manager = getActionManager();
         assertEquals(0, manager.getAddedCount());
         manager.withResolver(resolver -> {});
@@ -93,7 +100,7 @@ public class ActionManagerTest {
 
     @Test
     public void deferredStatsCounterTest() throws LoginException, Exception {
-        ResourceResolver rr = getMockResolver();
+        final ResourceResolver rr = getMockResolver();
         ActionManager manager = getActionManager();
         assertEquals(0, manager.getAddedCount());
         manager.deferredWithResolver(resolver -> {
@@ -112,7 +119,7 @@ public class ActionManagerTest {
     
     @Test
     public void deferredStatsCounterErrorTest() throws LoginException, Exception {
-        ResourceResolver rr = getMockResolver();
+        final ResourceResolver rr = getMockResolver();
         ActionManager manager = getActionManager();
         assertEquals(0, manager.getAddedCount());
         manager.deferredWithResolver(resolver -> {
@@ -148,7 +155,7 @@ public class ActionManagerTest {
 
     @Test
     public void closeAllResolversTest() throws LoginException, Exception {
-        ResourceResolver rr = getMockResolver();
+        final ResourceResolver rr = getMockResolver();
         ActionManager manager = getActionManager();
         manager.deferredWithResolver(resolver -> {
         });

--- a/bundle/src/test/java/com/adobe/acs/commons/forms/helpers/impl/PostRedirectGetFormHelperImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/forms/helpers/impl/PostRedirectGetFormHelperImplTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.forms.helpers.impl;
 
 import com.adobe.acs.commons.forms.Form;

--- a/bundle/src/test/java/com/adobe/acs/commons/forms/helpers/impl/PostRedirectGetWithCookiesFormHelperImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/forms/helpers/impl/PostRedirectGetWithCookiesFormHelperImplTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.forms.helpers.impl;
 
 import com.adobe.acs.commons.forms.Form;

--- a/bundle/src/test/java/com/adobe/acs/commons/genericlists/impl/GenericListAdapterFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/genericlists/impl/GenericListAdapterFactoryTest.java
@@ -142,9 +142,9 @@ public class GenericListAdapterFactoryTest {
 
     @Test
     public void test_i18n_titles() {
-        Locale french = new Locale("fr");
-        Locale swissFrench = new Locale("fr", "ch");
-        Locale franceFrench = new Locale("fr", "fr");
+        final Locale french = new Locale("fr");
+        final Locale swissFrench = new Locale("fr", "ch");
+        final Locale franceFrench = new Locale("fr", "fr");
 
         GenericList list = adapterFactory.getAdapter(listPage, GenericList.class);
         assertNotNull(list);

--- a/bundle/src/test/java/com/adobe/acs/commons/http/headers/impl/AbstractDispatcherCacheHeaderFilterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/http/headers/impl/AbstractDispatcherCacheHeaderFilterTest.java
@@ -142,7 +142,7 @@ public class AbstractDispatcherCacheHeaderFilterTest {
     @Test
     public void testActivateSuccess() throws Exception {
 
-        BaseMatcher<Dictionary<String, Object>> filterPropsMatcher = new BaseMatcher<Dictionary<String, Object>>() {
+        final BaseMatcher<Dictionary<String, Object>> filterPropsMatcher = new BaseMatcher<Dictionary<String, Object>>() {
             @Override
             public void describeTo(Description description) {
                 // do nothing
@@ -152,7 +152,7 @@ public class AbstractDispatcherCacheHeaderFilterTest {
             @SuppressWarnings("unchecked")
             public boolean matches(Object item) {
                 return StringUtils.equals(pattern, ((Dictionary<String, Object>) item).get(HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_REGEX).toString());
-            };
+            }
         };
 
         filter.activate(componentContext);
@@ -167,13 +167,13 @@ public class AbstractDispatcherCacheHeaderFilterTest {
     @Test
     public void testActivateMultipleFilters() throws Exception {
 
-        ServiceRegistration secondRegistration = mock(ServiceRegistration.class);
+        final ServiceRegistration secondRegistration = mock(ServiceRegistration.class);
 
         final String secondPattern = "/content/dam/.*";
         properties.put(AbstractDispatcherCacheHeaderFilter.PROP_FILTER_PATTERN,
                 new String[] { pattern, secondPattern });
 
-        BaseMatcher<Dictionary<String, Object>> firstPropsMatcher = new BaseMatcher<Dictionary<String, Object>>() {
+        final BaseMatcher<Dictionary<String, Object>> firstPropsMatcher = new BaseMatcher<Dictionary<String, Object>>() {
             @Override
             public void describeTo(Description description) {
                 // do nothing
@@ -183,10 +183,10 @@ public class AbstractDispatcherCacheHeaderFilterTest {
             @SuppressWarnings("unchecked")
             public boolean matches(Object item) {
                 return StringUtils.equals(pattern, ((Dictionary<String, Object>) item).get(HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_REGEX).toString());
-            };
+            }
         };
 
-        BaseMatcher<Dictionary<String, Object>> secondPropsMatcher = new BaseMatcher<Dictionary<String, Object>>() {
+        final BaseMatcher<Dictionary<String, Object>> secondPropsMatcher = new BaseMatcher<Dictionary<String, Object>>() {
             @Override
             public void describeTo(Description description) {
                 // do nothing
@@ -196,7 +196,7 @@ public class AbstractDispatcherCacheHeaderFilterTest {
             @SuppressWarnings("unchecked")
             public boolean matches(Object item) {
                 return StringUtils.equals(secondPattern, ((Dictionary<String, Object>) item).get(HttpWhiteboardConstants.HTTP_WHITEBOARD_FILTER_REGEX).toString());
-            };
+            }
         };
 
         filter.activate(componentContext);

--- a/bundle/src/test/java/com/adobe/acs/commons/http/headers/impl/MonthlyExpiresHeaderFilterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/http/headers/impl/MonthlyExpiresHeaderFilterTest.java
@@ -82,7 +82,7 @@ public class MonthlyExpiresHeaderFilterTest {
 
         actual.set(Calendar.DAY_OF_MONTH, 15);
 
-        int month = expected.get(Calendar.MONTH);
+        final int month = expected.get(Calendar.MONTH);
         properties.put(MonthlyExpiresHeaderFilter.PROP_EXPIRES_DAY_OF_MONTH, expected.get(Calendar.DAY_OF_MONTH));
 
         filter.doActivate(componentContext);
@@ -103,7 +103,7 @@ public class MonthlyExpiresHeaderFilterTest {
         expected.setTime(actual.getTime());
         expected.add(Calendar.MONTH, 1);
 
-        int month = expected.get(Calendar.MONTH);
+        final int month = expected.get(Calendar.MONTH);
         properties.put(MonthlyExpiresHeaderFilter.PROP_EXPIRES_DAY_OF_MONTH, expected.get(Calendar.DAY_OF_MONTH));
 
         filter.doActivate(componentContext);
@@ -124,7 +124,7 @@ public class MonthlyExpiresHeaderFilterTest {
         Calendar expected = Calendar.getInstance();
         expected.setTime(actual.getTime());
 
-        int month = expected.get(Calendar.MONTH);
+        final int month = expected.get(Calendar.MONTH);
         properties.put(MonthlyExpiresHeaderFilter.PROP_EXPIRES_DAY_OF_MONTH, expected.get(Calendar.DAY_OF_MONTH));
 
         filter.doActivate(componentContext);
@@ -147,7 +147,7 @@ public class MonthlyExpiresHeaderFilterTest {
 
         actual.set(Calendar.DAY_OF_MONTH, 15);
 
-        int month = expected.get(Calendar.MONTH);
+        final int month = expected.get(Calendar.MONTH);
         properties.put(MonthlyExpiresHeaderFilter.PROP_EXPIRES_DAY_OF_MONTH, expected.get(Calendar.DAY_OF_MONTH));
 
         filter.doActivate(componentContext);
@@ -170,7 +170,7 @@ public class MonthlyExpiresHeaderFilterTest {
         expected.setTime(actual.getTime());
         expected.add(Calendar.MONTH, 1);
 
-        int month = expected.get(Calendar.MONTH);
+        final int month = expected.get(Calendar.MONTH);
         properties.put(MonthlyExpiresHeaderFilter.PROP_EXPIRES_DAY_OF_MONTH, "LAST");
 
         filter.doActivate(componentContext);
@@ -192,7 +192,7 @@ public class MonthlyExpiresHeaderFilterTest {
         Calendar expected = Calendar.getInstance();
         expected.setTime(actual.getTime());
 
-        int month = expected.get(Calendar.MONTH);
+        final int month = expected.get(Calendar.MONTH);
         properties.put(MonthlyExpiresHeaderFilter.PROP_EXPIRES_DAY_OF_MONTH, "LAST");
 
         filter.doActivate(componentContext);

--- a/bundle/src/test/java/com/adobe/acs/commons/http/impl/HttpClientFactoryImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/http/impl/HttpClientFactoryImplTest.java
@@ -64,7 +64,7 @@ public class HttpClientFactoryImplTest {
         config = new HashMap<String, Object>();
         username = RandomStringUtils.randomAlphabetic(5);
         password = RandomStringUtils.randomAlphabetic(6);
-        String authHeaderValue = Base64.encodeBase64String((username + ":" + password).getBytes());
+        final String authHeaderValue = Base64.encodeBase64String((username + ":" + password).getBytes());
 
         config.put("hostname", "localhost");
         config.put("port", mockServerRule.getPort().intValue());
@@ -80,8 +80,8 @@ public class HttpClientFactoryImplTest {
                 response().withStatusCode(200).withBody("{ 'foo' : 'bar' }")
         );
         mockServerClient.when(
-                request().withMethod("GET").withPath("/auth").
-                        withHeader("Authorization", "Basic " + authHeaderValue)
+                request().withMethod("GET").withPath("/auth")
+                        .withHeader("Authorization", "Basic " + authHeaderValue)
         ).respond(
                 response().withStatusCode(200).withBody("OK")
         );

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/CacheKeyMock.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/CacheKeyMock.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.store.jcr.impl;
 
 import java.io.IOException;

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/JCRHttpCacheStoreImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/JCRHttpCacheStoreImplTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.store.jcr.impl;
 
 import static org.mockito.Matchers.any;

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/mock/JCRHttpCacheStoreMocks.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/mock/JCRHttpCacheStoreMocks.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.store.jcr.impl.mock;
 
 import static org.mockito.Matchers.any;

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/visitor/AllEntryNodesCountVisitorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/visitor/AllEntryNodesCountVisitorTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.store.jcr.impl.visitor;
 
 import static org.junit.Assert.assertEquals;

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/visitor/EntryNodeByStringKeyVisitorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/visitor/EntryNodeByStringKeyVisitorTest.java
@@ -1,14 +1,30 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.store.jcr.impl.visitor;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.when;
-
-import java.util.Map;
 
 import javax.jcr.Node;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/visitor/EntryNodeMapVisitorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/visitor/EntryNodeMapVisitorTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.store.jcr.impl.visitor;
 
 import static org.junit.Assert.assertEquals;

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/visitor/ExpiredNodesVisitorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/visitor/ExpiredNodesVisitorTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.store.jcr.impl.visitor;
 
 import static org.junit.Assert.assertEquals;

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/visitor/InvalidateAllNodesVisitorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/visitor/InvalidateAllNodesVisitorTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.store.jcr.impl.visitor;
 
 import static org.junit.Assert.assertEquals;

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/visitor/InvalidateByCacheConfigVisitorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/visitor/InvalidateByCacheConfigVisitorTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.store.jcr.impl.visitor;
 
 import static org.mockito.Matchers.any;

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/visitor/TotalCacheSizeVisitorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/visitor/TotalCacheSizeVisitorTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.store.jcr.impl.visitor;
 
 import static org.junit.Assert.assertEquals;

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/visitor/mock/RootNodeMockFactory.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/visitor/mock/RootNodeMockFactory.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.store.jcr.impl.visitor.mock;
 
 import static org.mockito.Matchers.any;
@@ -45,6 +64,7 @@ public class RootNodeMockFactory
     public RootNodeMockFactory(final Settings settings){
         this.settings = settings;
     }
+
     public Node build() throws RepositoryException, IOException
     {
         final Node rootNode = mockStandardNode("rootnode");

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/writer/BucketNodeFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/writer/BucketNodeFactoryTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.store.jcr.impl.writer;
 
 import static com.adobe.acs.commons.httpcache.store.jcr.impl.writer.BucketNodeFactory.HASHCODE_LENGTH;
@@ -98,6 +117,7 @@ public class BucketNodeFactoryTest
         assertEquals("00000", bucketNode.getParent().getParent().getParent().getParent().getParent().getParent().getParent().getParent().getName());
         assertEquals("00001", bucketNode.getParent().getParent().getParent().getParent().getParent().getParent().getParent().getParent().getParent().getName());
     }
+
     private BucketNodeFactory buildNodeFactoryWithMocks(MockSettings settings)
             throws RepositoryException, BucketNodeFactoryException
     {
@@ -141,32 +161,44 @@ public class BucketNodeFactoryTest
     private CacheKey mockCacheKey(final MockSettings mockSettings){
         return new CacheKey()
         {
-            @Override public String getUri()
+            @Override
+            public String getUri()
             {
                 return mockSettings.cacheKeyURI;
             }
 
-            @Override public String getHierarchyResourcePath()
+            @Override
+            public String getHierarchyResourcePath()
             {
                 return mockSettings.cacheKeyHierarchyResourcePath;
             }
 
-            @Override public boolean isInvalidatedBy(CacheKey cacheKey)
+            @Override
+            public boolean isInvalidatedBy(CacheKey cacheKey)
             {
                 return false;
             }
 
-            @Override  public int hashCode(){
+            @Override
+            public int hashCode(){
                 return mockSettings.cacheKeyHashCode;
+            }
+
+            @Override
+            public boolean equals(Object obj) {
+                return super.equals(obj);
             }
         };
     }
 
     private static class MockSettings{
 
-        final static String VALID_ROOT_PATH = "/etc/acs-commons/jcr-cache";
-        int bucketNodeDepth,cacheKeyHashCode;
-        String cacheRootPath, cacheKeyURI, cacheKeyHierarchyResourcePath;
+        static final String VALID_ROOT_PATH = "/etc/acs-commons/jcr-cache";
+        int bucketNodeDepth;
+        int cacheKeyHashCode;
+        String cacheRootPath;
+        String cacheKeyURI;
+        String cacheKeyHierarchyResourcePath;
 
 
     }

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/writer/EntryNodeWriterMocks.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/writer/EntryNodeWriterMocks.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.store.jcr.impl.writer;
 
 import static com.adobe.acs.commons.httpcache.store.jcr.impl.JCRHttpCacheStoreConstants.OAK_UNSTRUCTURED;

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/writer/EntryNodeWriterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/store/jcr/impl/writer/EntryNodeWriterTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.store.jcr.impl.writer;
 
 import static org.mockito.Matchers.any;

--- a/bundle/src/test/java/com/adobe/acs/commons/images/impl/NamedTransformImageServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/images/impl/NamedTransformImageServletTest.java
@@ -34,7 +34,11 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -45,11 +49,11 @@ import static org.mockito.Mockito.*;
 @RunWith(MockitoJUnitRunner.class)
 public class NamedTransformImageServletTest {
 
-    final String NAMED_TRANSFORM_FEATURE = "feature";
-    final String NAMED_TRANSFORM_SMALL = "small";
+    static final String NAMED_TRANSFORM_FEATURE = "feature";
+    static final String NAMED_TRANSFORM_SMALL = "small";
 
-    final String IMAGE_TRANSFORM_RESIZE = "resize";
-    final String IMAGE_TRANSFORM_GREYSCALE = "greyscale";
+    static final String IMAGE_TRANSFORM_RESIZE = "resize";
+    static final String IMAGE_TRANSFORM_GREYSCALE = "greyscale";
 
     @Spy
     private FeaturedNamedImageTransformer featureImageTransformer = new FeaturedNamedImageTransformer();
@@ -58,7 +62,7 @@ public class NamedTransformImageServletTest {
     private SmallNamedImageTransformer smallImageTransformer = new SmallNamedImageTransformer();
 
     @Spy
-    private Map<String, NamedImageTransformer> namedImageTransformers = new HashMap<String, NamedImageTransformer>();
+    private Map<String, NamedImageTransformer> namedImageTransformers = new HashMap<>();
 
     @Spy
     private EmptyImageTransformer resizeImageTransformer = new EmptyImageTransformer();

--- a/bundle/src/test/java/com/adobe/acs/commons/images/impl/ProgressiveJpegTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/images/impl/ProgressiveJpegTest.java
@@ -25,7 +25,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.imageio.ImageIO;
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/bundle/src/test/java/com/adobe/acs/commons/images/transformers/impl/CropImageTransformerImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/images/transformers/impl/CropImageTransformerImplTest.java
@@ -20,7 +20,6 @@
 
 package com.adobe.acs.commons.images.transformers.impl;
 
-import com.adobe.acs.commons.images.transformers.impl.CropImageTransformerImpl;
 import com.day.image.Layer;
 
 import org.apache.sling.api.resource.ValueMap;
@@ -32,7 +31,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.awt.*;
+import java.awt.Rectangle;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/images/transformers/impl/LetterPillarBoxImageTransformerImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/images/transformers/impl/LetterPillarBoxImageTransformerImplTest.java
@@ -24,7 +24,8 @@ import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
 
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Dimension;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.sling.api.resource.ValueMap;
@@ -75,7 +76,7 @@ public class LetterPillarBoxImageTransformerImplTest {
         map.put("height", height);
         map.put("color", color);
         map.put("alpha", alpha);
-        ValueMap properties = new ValueMapDecorator(map);
+        final ValueMap properties = new ValueMapDecorator(map);
 
         final Layer mockLayer = mock(Layer.class);
 
@@ -107,7 +108,7 @@ public class LetterPillarBoxImageTransformerImplTest {
 
         map.put("width", width);
         map.put("height", height);
-        ValueMap properties = new ValueMapDecorator(map);
+        final ValueMap properties = new ValueMapDecorator(map);
 
         final Layer mockLayer = mock(Layer.class);
 
@@ -139,7 +140,7 @@ public class LetterPillarBoxImageTransformerImplTest {
 
         map.put("width", width);
         map.put("height", height);
-        ValueMap properties = new ValueMapDecorator(map);
+        final ValueMap properties = new ValueMapDecorator(map);
 
         final Layer mockLayer = mock(Layer.class);
 
@@ -169,7 +170,7 @@ public class LetterPillarBoxImageTransformerImplTest {
 
         map.put("width", width);
         map.put("height", height);
-        ValueMap properties = new ValueMapDecorator(map);
+        final ValueMap properties = new ValueMapDecorator(map);
 
         final Layer mockLayer = mock(Layer.class);
 
@@ -198,7 +199,7 @@ public class LetterPillarBoxImageTransformerImplTest {
         final int height = 225;
 
         map.put("width", width);
-        ValueMap properties = new ValueMapDecorator(map);
+        final ValueMap properties = new ValueMapDecorator(map);
 
         final Layer mockLayer = mock(Layer.class);
 
@@ -226,7 +227,7 @@ public class LetterPillarBoxImageTransformerImplTest {
         final int height = 225;
 
         map.put("height", height);
-        ValueMap properties = new ValueMapDecorator(map);
+        final ValueMap properties = new ValueMapDecorator(map);
 
         final Layer mockLayer = mock(Layer.class);
 
@@ -255,7 +256,7 @@ public class LetterPillarBoxImageTransformerImplTest {
 
         map.put("width", width);
         map.put("height", height);
-        ValueMap properties = new ValueMapDecorator(map);
+        final ValueMap properties = new ValueMapDecorator(map);
 
         final Layer mockLayer = mock(Layer.class);
 
@@ -287,7 +288,7 @@ public class LetterPillarBoxImageTransformerImplTest {
 
         map.put("width", width);
         map.put("height", height);
-        ValueMap properties = new ValueMapDecorator(map);
+        final ValueMap properties = new ValueMapDecorator(map);
 
         final Layer mockLayer = mock(Layer.class);
 
@@ -318,7 +319,7 @@ public class LetterPillarBoxImageTransformerImplTest {
 
         map.put("width", width);
         map.put("height", height);
-        ValueMap properties = new ValueMapDecorator(map);
+        final ValueMap properties = new ValueMapDecorator(map);
 
         final Layer mockLayer = mock(Layer.class);
 

--- a/bundle/src/test/java/com/adobe/acs/commons/logging/impl/JsonEventLoggerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/logging/impl/JsonEventLoggerTest.java
@@ -24,7 +24,10 @@ import org.apache.sling.commons.json.JSONObject;
 import org.junit.Test;
 import org.osgi.service.event.Event;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -90,7 +93,7 @@ public class JsonEventLoggerTest {
         assertEquals("complex event, map value in props", "curl/7.25.0", jMapProps.getJSONObject("headers").getString("user-agent"));
 
         Map<String, Object> stringSetProps = new LinkedHashMap<String, Object>();
-        stringSetProps.put("resourceChangedAttributes", new LinkedHashSet<String>(Arrays.asList("first", "second")));
+        stringSetProps.put("resourceChangedAttributes", new LinkedHashSet<>(Arrays.asList("first", "second")));
         Event stringSetEvent = new Event("my/simple/topic", stringSetProps);
         JSONObject jStringSet = new JSONObject(JsonEventLogger.constructMessage(stringSetEvent));
 

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/AuthorizedGroupProcessDefinitionFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/AuthorizedGroupProcessDefinitionFactoryTest.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2018 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.mcp;
 
@@ -25,6 +29,7 @@ import org.apache.jackrabbit.api.security.user.User;
 import org.apache.jackrabbit.api.security.user.Group;
 import org.junit.Before;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -106,10 +111,11 @@ public class AuthorizedGroupProcessDefinitionFactoryTest {
 
     private class AuthorizedGroupProcessDefinitionFactoryImpl extends AuthorizedGroupProcessDefinitionFactory<ProcessDefinition> {
 
+        String[] groups;
+
         AuthorizedGroupProcessDefinitionFactoryImpl(String[] groups) {
             this.groups = groups;
         }
-        String[] groups;
 
         public String[] getAuthorizedGroups() {
             return groups;

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/form/FieldComponentTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/form/FieldComponentTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.mcp.form;
 
 import org.junit.Test;

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/form/RadioComponentTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/form/RadioComponentTest.java
@@ -61,11 +61,12 @@ public class RadioComponentTest {
         RadioComponent cmp = new RadioComponent() {
             @Override
             public Map<String, String> getOptions() {
-                return new HashMap<String, String>() {{
+                return new HashMap<String, String>() { {
                     put("v1", "t1");
                     put("v2", "t2");
                     put("v3", "t3");
-                }};
+                }
+            };
             }
         };
         cmp.setup("test", null, formField, sling);

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/form/SyntheticFormResourceTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/form/SyntheticFormResourceTest.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2017 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.mcp.form;
 
@@ -23,8 +27,9 @@ import java.util.Map;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.scripting.SlingScriptHelper;
-import static org.junit.Assert.*;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 /**

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/ProcessErrorReportExcelServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/ProcessErrorReportExcelServletTest.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2018 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.mcp.impl;
 
@@ -21,10 +25,9 @@ import com.adobe.acs.commons.mcp.model.ManagedProcess;
 import com.adobe.acs.commons.mcp.model.impl.ArchivedProcessFailure;
 import java.util.Date;
 import org.apache.poi.ss.usermodel.Workbook;
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
 import org.junit.Before;
 import org.junit.Test;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.junit.Assert.*;

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/AssetFolderCreatorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/AssetFolderCreatorTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.mcp.impl.processes;
 
 import com.adobe.acs.commons.fam.ActionManager;

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/AssetFolderDefinitionTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/AssetFolderDefinitionTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.mcp.impl.processes;
 
 import com.adobe.acs.commons.util.datadefinitions.ResourceDefinition;

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/BrokenLinksTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/BrokenLinksTest.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2017 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.mcp.impl.processes;
 
@@ -21,12 +25,12 @@ import com.adobe.acs.commons.fam.impl.ActionManagerFactoryImpl;
 import com.adobe.acs.commons.mcp.ControlledProcessManager;
 import com.adobe.acs.commons.mcp.impl.AbstractResourceImpl;
 import com.adobe.acs.commons.mcp.impl.ProcessInstanceImpl;
-import org.apache.sling.api.resource.*;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.NonExistingResource;
+import org.apache.sling.api.resource.ResourceMetadata;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.junit.SlingContext;
-import static com.adobe.acs.commons.mcp.impl.processes.BrokenLinksReport.Report;
-import static com.adobe.acs.commons.mcp.impl.processes.BrokenLinksReport.collectBrokenReferences;
-import static com.adobe.acs.commons.mcp.impl.processes.BrokenLinksReport.collectPaths;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,7 +39,13 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.Privilege;
-import java.util.*;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -46,6 +56,9 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static com.adobe.acs.commons.mcp.impl.processes.BrokenLinksReport.Report;
+import static com.adobe.acs.commons.mcp.impl.processes.BrokenLinksReport.collectBrokenReferences;
+import static com.adobe.acs.commons.mcp.impl.processes.BrokenLinksReport.collectPaths;
 
 /**
  *
@@ -63,25 +76,27 @@ public class BrokenLinksTest {
 
     @Test
     public void reportBrokenReferences() throws Exception {
-        ResourceResolver rr = getEnhancedMockResolver();
+        final ResourceResolver rr = getEnhancedMockResolver();
 
         AbstractResourceImpl content = new AbstractResourceImpl("/content", "cq:Page", "cq:Page", new ResourceMetadata());
 
         AbstractResourceImpl pageA = new AbstractResourceImpl("/content/pageA", "cq:Page", "cq:Page", new ResourceMetadata());
         content.addChild(pageA);
         AbstractResourceImpl pageAcontent = new AbstractResourceImpl("/content/pageA/jcr:content", "cq:PageContent", "cq:PageContent", new ResourceMetadata() {{
-            put("ref1", "/content/pageA");
-            put("ref2", "/content/pageB");
-            put("ref3", "/content/pageC");
-        }});
+                put("ref1", "/content/pageA");
+                put("ref2", "/content/pageB");
+                put("ref3", "/content/pageC");
+            }
+        });
         pageA.addChild(pageAcontent);
         AbstractResourceImpl pageB = new AbstractResourceImpl("/content/pageB", "cq:Page", "cq:Page", new ResourceMetadata());
         content.addChild(pageB);
         AbstractResourceImpl pageBcontent = new AbstractResourceImpl("/content/pageB/jcr:content", "cq:PageContent", "cq:PageContent", new ResourceMetadata() {{
-            put("ignoredRef", "/content/pageC");
-            put("ref2", "/content/pageD");
-            put("ref3", "/content/pageE");
-        }});
+                put("ignoredRef", "/content/pageC");
+                put("ref2", "/content/pageD");
+                put("ref3", "/content/pageE");
+            }
+        });
         pageB.addChild(pageBcontent);
         when(rr.getResource("/content")).thenReturn(content);
 
@@ -123,7 +138,7 @@ public class BrokenLinksTest {
     }
 
     private ResourceResolver getEnhancedMockResolver() throws RepositoryException, LoginException {
-        ResourceResolver rr = getFreshMockResolver();
+        final ResourceResolver rr = getFreshMockResolver();
 
         AbstractResourceImpl processes = new AbstractResourceImpl(ProcessInstanceImpl.BASE_PATH, null, null, new ResourceMetadata());
         when(rr.getResource(ProcessInstanceImpl.BASE_PATH)).thenReturn(processes);

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/FolderRelocatorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/FolderRelocatorTest.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2017 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.mcp.impl.processes;
 
@@ -21,7 +25,6 @@ import com.adobe.acs.commons.fam.impl.ActionManagerFactoryImpl;
 import com.adobe.acs.commons.mcp.ControlledProcessManager;
 import com.adobe.acs.commons.mcp.ProcessInstance;
 import com.adobe.acs.commons.mcp.impl.ProcessInstanceImpl;
-import static com.adobe.acs.commons.fam.impl.ActionManagerTest.*;
 import com.adobe.acs.commons.mcp.impl.AbstractResourceImpl;
 import com.adobe.acs.commons.mcp.util.DeserializeException;
 import java.util.Collections;
@@ -37,8 +40,10 @@ import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.ResourceMetadata;
 import org.apache.sling.api.resource.ResourceResolver;
-import static org.junit.Assert.*;
 import org.junit.Test;
+
+import static com.adobe.acs.commons.fam.impl.ActionManagerTest.*;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -62,7 +67,7 @@ public class FolderRelocatorTest {
     
     @Test
     public void barebonesRun() throws LoginException, DeserializeException, RepositoryException, PersistenceException {
-        ResourceResolver rr = getEnhancedMockResolver();
+        final ResourceResolver rr = getEnhancedMockResolver();
         FolderRelocator tool = new FolderRelocatorFactory().createProcessDefinition();
         ProcessInstance instance = new ProcessInstanceImpl(getControlledProcessManager(), tool, "relocator test");
 
@@ -80,7 +85,7 @@ public class FolderRelocatorTest {
     
     @Test
     public void testHaltingScenario() throws DeserializeException, LoginException, RepositoryException, InterruptedException, ExecutionException, PersistenceException {
-        ResourceResolver rr = getEnhancedMockResolver();
+        final ResourceResolver rr = getEnhancedMockResolver();
         FolderRelocator tool = new FolderRelocatorFactory().createProcessDefinition();
         ProcessInstance instance = new ProcessInstanceImpl(getControlledProcessManager(), tool, "relocator test");
 
@@ -109,7 +114,7 @@ public class FolderRelocatorTest {
     }
 
     private ResourceResolver getEnhancedMockResolver() throws RepositoryException, LoginException {
-        ResourceResolver rr = getFreshMockResolver();
+        final ResourceResolver rr = getFreshMockResolver();
         
         when(rr.hasChanges()).thenReturn(true);
 

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/MockPageManager.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/MockPageManager.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2017 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.mcp.impl.processes;
 
@@ -41,27 +45,6 @@ public class MockPageManager implements PageManager {
     public MockPageManager(ResourceResolver rr) {
         this.rr = rr;
     }
-    
-    @Override
-    public Page move(final Page page, final String destination, final String beforeName, final boolean shallow,
-            final boolean resolveConflict, final String[] adjustRefs) throws WCMException {
-        try {
-            if (rr == null) {
-                throw new RuntimeException("Resource resolver was null");
-            }
-            
-            if (replicator == null) {
-                throw new RuntimeException("Replicator was not changed out -- will not work properly");
-            }
-            
-            replicator.replicate(null, ReplicationActionType.DEACTIVATE, page.getPath());
-            replicator.replicate(null, ReplicationActionType.ACTIVATE, destination + "/" + page.getName());
-            
-            return page;
-        } catch (ReplicationException ex) {
-            throw new RuntimeException(ex);
-        }
-    }    
 
     @Override
     public Page getPage(String string) {
@@ -86,6 +69,27 @@ public class MockPageManager implements PageManager {
     @Override
     public Page create(String string, String string1, String string2, String string3, boolean bln) throws WCMException {
         throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public Page move(final Page page, final String destination, final String beforeName, final boolean shallow,
+                     final boolean resolveConflict, final String[] adjustRefs) throws WCMException {
+        try {
+            if (rr == null) {
+                throw new RuntimeException("Resource resolver was null");
+            }
+
+            if (replicator == null) {
+                throw new RuntimeException("Replicator was not changed out -- will not work properly");
+            }
+
+            replicator.replicate(null, ReplicationActionType.DEACTIVATE, page.getPath());
+            replicator.replicate(null, ReplicationActionType.ACTIVATE, destination + "/" + page.getName());
+
+            return page;
+        } catch (ReplicationException ex) {
+            throw new RuntimeException(ex);
+        }
     }
 
     @Override

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/PageRelocatorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/PageRelocatorTest.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2017 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,13 +15,13 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.mcp.impl.processes;
 
 import com.adobe.acs.commons.fam.ActionManager;
 import com.adobe.acs.commons.fam.ActionManagerFactory;
 import com.adobe.acs.commons.fam.impl.ActionManagerFactoryImpl;
-import static com.adobe.acs.commons.fam.impl.ActionManagerTest.*;
 import com.adobe.acs.commons.mcp.ControlledProcessManager;
 import com.adobe.acs.commons.mcp.ProcessInstance;
 import com.adobe.acs.commons.mcp.impl.AbstractResourceImpl;
@@ -39,14 +42,16 @@ import org.apache.sling.api.resource.ResourceMetadata;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.junit.SlingContext;
-import static org.junit.Assert.*;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.*;
+import static com.adobe.acs.commons.fam.impl.ActionManagerTest.*;
+import static org.junit.Assert.*;
 
 /**
  *

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorTest.java
@@ -143,8 +143,6 @@ public class FileAssetIngestorTest {
         File folder3 = mkdir(folder2, "folder3");
         addFile(folder3, "image.png", "/img/test.png");
 
-        java.nio.file.Files.walk(tempDirectory.toPath()).forEach(p -> System.out.println(p.toString()));
-
         ingestor.createFolders(actionManager);
 
         assertFalse(context.resourceResolver().hasChanges());
@@ -193,12 +191,12 @@ public class FileAssetIngestorTest {
     @Test
     public void testImportAssets() throws Exception {
         ingestor.init();
-        File rootImage = addFile(tempDirectory, "image.png", "/img/test.png");
-        File folder1 = mkdir(tempDirectory, "folder1");
-        File folder1Image = addFile(folder1, "image.png", "/img/test.png");
-        File folder2 = mkdir(tempDirectory, "folder2");
-        File folder3 = mkdir(folder2, "folder3");
-        File folder3Image = addFile(folder3, "image.png", "/img/test.png");
+        final File rootImage = addFile(tempDirectory, "image.png", "/img/test.png");
+        final File folder1 = mkdir(tempDirectory, "folder1");
+        final File folder1Image = addFile(folder1, "image.png", "/img/test.png");
+        final File folder2 = mkdir(tempDirectory, "folder2");
+        final File folder3 = mkdir(folder2, "folder3");
+        final File folder3Image = addFile(folder3, "image.png", "/img/test.png");
 
         ingestor.importAssets(actionManager);
 
@@ -220,7 +218,7 @@ public class FileAssetIngestorTest {
     public void testImportAssetsToNewRootFolder() throws Exception {
         ingestor.jcrBasePath = "/content/dam/test";
         ingestor.init();
-        File rootImage = addFile(tempDirectory, "image.png", "/img/test.png");
+        final File rootImage = addFile(tempDirectory, "image.png", "/img/test.png");
 
         ingestor.importAssets(actionManager);
 
@@ -244,7 +242,7 @@ public class FileAssetIngestorTest {
         ingestor.jcrBasePath = "/content/dam/test";
         ingestor.init();
         context.create().resource("/content/dam/test", "jcr:primaryType", "sling:Folder", "jcr:title", "testTitle");
-        File rootImage = addFile(tempDirectory, "image.png", "/img/test.png");
+        final File rootImage = addFile(tempDirectory, "image.png", "/img/test.png");
 
         ingestor.importAssets(actionManager);
 

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorUtilitiesTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorUtilitiesTest.java
@@ -19,8 +19,6 @@
  */
 package com.adobe.acs.commons.mcp.impl.processes.asset;
 
-import com.adobe.acs.commons.mcp.impl.processes.asset.FileAssetIngestor;
-import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
@@ -109,6 +107,7 @@ public class FileAssetIngestorUtilitiesTest {
 
         assertNull(parent.getParent());
     }
+
     @Test
     public void testHierarchialElementForFileInRoot() throws Exception {
         File image = new File(tempDirectory, "image.png");

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileOrRenditionTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileOrRenditionTest.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2018 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.mcp.impl.processes.asset;
 
@@ -20,14 +24,13 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.Collections;
-import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 /**
  *
- * @author brobert
  */
 public class FileOrRenditionTest {
     

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/UrlAssetImportTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/UrlAssetImportTest.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2018 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.mcp.impl.processes.asset;
 
@@ -35,16 +39,17 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.commons.mime.MimeTypeService;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.junit.SlingContext;
-import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
-import static org.mockito.Matchers.any;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
 /**
  * Provide code coverage for URL Asset Import

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/model/ValueFormatTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/model/ValueFormatTest.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2017 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,10 +15,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.mcp.model;
 
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 /**
@@ -25,7 +30,7 @@ public class ValueFormatTest {
 
     private static String ONE = String.format("%.1f", 1f);
 
-    enum fieldEnum {
+    enum FieldEnum {
         @FieldFormat(ValueFormat.plain)
         somePlainField,
         @FieldFormat(ValueFormat.storageSize)
@@ -35,13 +40,13 @@ public class ValueFormatTest {
     
     @Test
     public void testDefinedAnnotations() {
-        assertEquals(ValueFormat.plain, ValueFormat.forField(fieldEnum.somePlainField));
-        assertEquals(ValueFormat.storageSize, ValueFormat.forField(fieldEnum.someStorageSizeField));
+        assertEquals(ValueFormat.plain, ValueFormat.forField(FieldEnum.somePlainField));
+        assertEquals(ValueFormat.storageSize, ValueFormat.forField(FieldEnum.someStorageSizeField));
     }
     
     @Test
     public void testUndefinedAnnotations() {
-        assertEquals(ValueFormat.plain, ValueFormat.forField(fieldEnum.someUnannotatedField));
+        assertEquals(ValueFormat.plain, ValueFormat.forField(FieldEnum.someUnannotatedField));
     }
     
     @Test

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/util/AnnotatedFieldDeserializerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/util/AnnotatedFieldDeserializerTest.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2017 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.mcp.util;
 
@@ -20,14 +24,12 @@ import com.adobe.acs.commons.mcp.form.FormField;
 import java.text.NumberFormat;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import org.apache.sling.api.wrappers.ModifiableValueMapDecorator;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.*;
 
+import static org.junit.Assert.*;
 
 public class AnnotatedFieldDeserializerTest {
 
@@ -60,8 +62,7 @@ public class AnnotatedFieldDeserializerTest {
     @Test
     public void testPrimitiveInputs() throws Exception {
 
-        System.out.println("processInput");
-        PrimitivesTest target = new PrimitivesTest();
+        final PrimitivesTest target = new PrimitivesTest();
         Map<String, Object> params = new HashMap<>();
         params.put("intValue", "123");
         params.put("doubleValue", numberFormat.format(123.456));
@@ -93,8 +94,7 @@ public class AnnotatedFieldDeserializerTest {
      */
     @Test
     public void testPrimitiveArrayInputs() throws Exception {
-        System.out.println("processInput");
-        PrimitiveArrayTest target = new PrimitiveArrayTest();
+        final PrimitiveArrayTest target = new PrimitiveArrayTest();
         Map<String, Object> params = new HashMap<>();
         params.put("intValue", new String[]{"123", "456", "789"});
         params.put("doubleValue",  numberFormat.format(123.456));
@@ -121,9 +121,7 @@ public class AnnotatedFieldDeserializerTest {
      */
     @Test
     public void testBooleanFalseByDefault() throws Exception {
-
-        System.out.println("processInput");
-        PrimitivesTest target = new PrimitivesTest();
+        final PrimitivesTest target = new PrimitivesTest();
         Map<String, Object> params = new HashMap<>();
         params.put("intValue", "123");
         params.put("doubleValue", numberFormat.format(123.456));

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/util/SpreadsheetTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/util/SpreadsheetTest.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2018 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.mcp.util;
 
@@ -26,6 +30,7 @@ import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 /**
@@ -41,7 +46,7 @@ public class SpreadsheetTest {
     static ByteArrayOutputStream workbookData = new ByteArrayOutputStream();
     
     @BeforeClass
-    static public void setUp() throws IOException {
+    public static void setUp() throws IOException {
         testWorkbook = new XSSFWorkbook();
         XSSFSheet sheet = testWorkbook.createSheet("sheet 1");
         createRow(sheet, header);
@@ -58,7 +63,6 @@ public class SpreadsheetTest {
      */
     @Test
     public void testGetFileName() throws IOException {
-        System.out.println("getFileName");
         Spreadsheet instance = new Spreadsheet(new ByteArrayInputStream(workbookData.toByteArray()));
         String expResult = "unknown";
         String result = instance.getFileName();
@@ -70,7 +74,6 @@ public class SpreadsheetTest {
      */
     @Test
     public void testGetRowCount() throws IOException {
-        System.out.println("getRowCount");
         Spreadsheet instance = new Spreadsheet(new ByteArrayInputStream(workbookData.toByteArray()));
         int expResult = 4;
         int result = instance.getRowCount();
@@ -82,7 +85,6 @@ public class SpreadsheetTest {
      */
     @Test
     public void testGetHeaderRow() throws IOException {
-        System.out.println("getHeaderRow");
         Spreadsheet instance = new Spreadsheet(false, new ByteArrayInputStream(workbookData.toByteArray()));
         List<String> expResult = Arrays.asList(header);
         List<String> result = instance.getHeaderRow();
@@ -94,7 +96,6 @@ public class SpreadsheetTest {
      */
     @Test
     public void testGetDataRows() throws IOException {
-        System.out.println("getDataRows");
         Spreadsheet instance = new Spreadsheet(new ByteArrayInputStream(workbookData.toByteArray()));
         List<Map<String, String>> result = instance.getDataRows();
         assertEquals(result.get(0).get("path"), "/test/a1");
@@ -106,7 +107,6 @@ public class SpreadsheetTest {
      */
     @Test
     public void testRequiredColumnsNoConversion() throws IOException {
-        System.out.println("getRequiredColumns");
         Spreadsheet instance = new Spreadsheet(false, new ByteArrayInputStream(workbookData.toByteArray()), "someOtherCol");
         List<String> required = instance.getRequiredColumns();
         assertEquals("someOtherCol", required.get(0));
@@ -119,7 +119,6 @@ public class SpreadsheetTest {
      */
     @Test
     public void testRequiredColumnsWithConversion() throws IOException {
-        System.out.println("getRequiredColumns");
         Spreadsheet instance = new Spreadsheet(true, new ByteArrayInputStream(workbookData.toByteArray()), "someOtherCol");
         List<String> required = instance.getRequiredColumns();
         assertEquals("someothercol", required.get(0));
@@ -127,7 +126,7 @@ public class SpreadsheetTest {
         assertEquals("/test/a2", result.get(0).get("path"));
     }
     
-    static private XSSFRow createRow(XSSFSheet sheet, String... values) {
+    private static XSSFRow createRow(XSSFSheet sheet, String... values) {
         int rowNum = sheet.getPhysicalNumberOfRows();
         XSSFRow row = sheet.createRow(rowNum);
         for (int i=0; i < values.length; i++) {

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/util/ValueMapSerializerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/util/ValueMapSerializerTest.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2017 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,15 +15,13 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.mcp.util;
 
 import java.util.Arrays;
-import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import org.apache.sling.api.resource.Resource;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 /**
@@ -36,7 +37,6 @@ public class ValueMapSerializerTest {
      */
     @Test
     public void testSerializeToStringArray() {
-        System.out.println("serializeToStringArray");
         Object value = Arrays.asList("one", "two", "three", 4, 5.0D, 6L, new Integer(7), new Long(8));
         String[] expResult = new String[]{"one", "two", "three", "4", "5.0", "6", "7", "8"};
         String[] result = ValueMapSerializer.serializeToStringArray(value);

--- a/bundle/src/test/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexJobHandlerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexJobHandlerTest.java
@@ -242,12 +242,12 @@ public class EnsureOakIndexJobHandlerTest {
 
     @Ignore("This test passes locally but fails on TravisCI; Figure out how to make this test pass on TravisCI")
     public void testUpdateOperation() throws RepositoryException, IOException {
-        String PN_IGNORE_ME = "ignoreMe";
+        String pnIgnoreMe = "ignoreMe";
 
         ChecksumGenerator checksumGenerator = mock(ChecksumGenerator.class);
 
         List<String> ignoreProperties = new ArrayList<String>();
-        ignoreProperties.add(PN_IGNORE_ME);
+        ignoreProperties.add(pnIgnoreMe);
         EnsureOakIndex eoi = mock(EnsureOakIndex.class);
         when(eoi.getIgnoreProperties()).thenReturn(ignoreProperties);
         when(eoi.getChecksumGenerator()).thenReturn(checksumGenerator);
@@ -258,7 +258,7 @@ public class EnsureOakIndexJobHandlerTest {
 
         Map<String, Object> oakProps = spy(new HashMap<String, Object>());
         oakProps.put(EnsureOakIndexJobHandler.PN_RECREATE_ON_UPDATE, true);
-        oakProps.put(PN_IGNORE_ME, "true");
+        oakProps.put(pnIgnoreMe, "true");
         Resource oak = getOakDefinition(oakProps);
 
         Map<String,String> defChecksum = new HashMap<String, String>();
@@ -273,6 +273,6 @@ public class EnsureOakIndexJobHandlerTest {
 
         handler.update(def, oakIndexResource, false);
 
-        verify(oakProps, never()).remove(PN_IGNORE_ME);
+        verify(oakProps, never()).remove(pnIgnoreMe);
     }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutorImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutorImplTest.java
@@ -211,8 +211,8 @@ public class OnDeployExecutorImplTest {
 
         Resource status2 = resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccessWithPause.class.getName());
         assertNotNull(status2);
-        Calendar start = status2.getValueMap().get("startDate", Calendar.class);
-        Calendar end = status2.getValueMap().get("endDate", Calendar.class);
+        final Calendar start = status2.getValueMap().get("startDate", Calendar.class);
+        final Calendar end = status2.getValueMap().get("endDate", Calendar.class);
         assertEquals("success", status2.getValueMap().get("status", ""));
         assertTrue(start.getTimeInMillis() <= System.currentTimeMillis());
         assertTrue(System.currentTimeMillis() - start.getTimeInMillis() < 10000);
@@ -256,11 +256,11 @@ public class OnDeployExecutorImplTest {
 
     @Test
     public void testExecuteTerminatesWhenScriptAlreadyRunning() throws RepositoryException {
-        OnDeployExecutorImpl impl = new OnDeployExecutorImpl();
+        final OnDeployExecutorImpl impl = new OnDeployExecutorImpl();
 
         // Mimic the situation where a script initiated in the past is still running
-        Resource statusResource = impl.getOrCreateStatusTrackingResource(context.resourceResolver(), OnDeployScriptTestExampleSuccess1.class);
-        String status1ResourcePath = statusResource.getPath();
+        final Resource statusResource = impl.getOrCreateStatusTrackingResource(context.resourceResolver(), OnDeployScriptTestExampleSuccess1.class);
+        final String status1ResourcePath = statusResource.getPath();
         impl.trackScriptStart(statusResource);
         LogTester.reset();
 

--- a/bundle/src/test/java/com/adobe/acs/commons/ondeploy/scripts/OnDeployScriptBaseTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/ondeploy/scripts/OnDeployScriptBaseTest.java
@@ -171,8 +171,8 @@ public class OnDeployScriptBaseTest {
 
     @Test
     public void testRenameProperty() throws RepositoryException {
-        Resource resource = resourceResolver.getResource("/content/resource-type-update1");
-        Node node = resource.adaptTo(Node.class);
+        final Resource resource = resourceResolver.getResource("/content/resource-type-update1");
+        final Node node = resource.adaptTo(Node.class);
 
         assertTrue(resource.getValueMap().containsKey("text"));
         assertFalse(resource.getValueMap().containsKey("label"));
@@ -187,8 +187,8 @@ public class OnDeployScriptBaseTest {
 
     @Test
     public void testRenamePropertyWhenPropertyDoesNotExist() throws RepositoryException {
-        Resource resource = resourceResolver.getResource("/content/resource-type-update1");
-        Node node = resource.adaptTo(Node.class);
+        final Resource resource = resourceResolver.getResource("/content/resource-type-update1");
+        final Node node = resource.adaptTo(Node.class);
 
         onDeployScript.renameProperty(node, "bogus", "label");
 
@@ -197,7 +197,7 @@ public class OnDeployScriptBaseTest {
 
     @Test
     public void testRemoveResourceWhenDoesNotExist() throws RepositoryException {
-        Resource resourceToDelete = resourceResolver.getResource("/content/bogus");
+        final Resource resourceToDelete = resourceResolver.getResource("/content/bogus");
         assertNull(resourceToDelete);
 
         onDeployScript.removeResource("/content/bogus");

--- a/bundle/src/test/java/com/adobe/acs/commons/ondeploy/scripts/OnDeployScriptTestExampleFailExecute.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/ondeploy/scripts/OnDeployScriptTestExampleFailExecute.java
@@ -1,6 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.ondeploy.scripts;
-
-import com.adobe.acs.commons.ondeploy.scripts.OnDeployScriptBase;
 
 public class OnDeployScriptTestExampleFailExecute extends OnDeployScriptBase {
     @Override

--- a/bundle/src/test/java/com/adobe/acs/commons/ondeploy/scripts/OnDeployScriptTestExampleSuccess1.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/ondeploy/scripts/OnDeployScriptTestExampleSuccess1.java
@@ -1,6 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.ondeploy.scripts;
-
-import com.adobe.acs.commons.ondeploy.scripts.OnDeployScriptBase;
 
 public class OnDeployScriptTestExampleSuccess1 extends OnDeployScriptBase {
     @Override

--- a/bundle/src/test/java/com/adobe/acs/commons/ondeploy/scripts/OnDeployScriptTestExampleSuccess2.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/ondeploy/scripts/OnDeployScriptTestExampleSuccess2.java
@@ -1,6 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.ondeploy.scripts;
-
-import com.adobe.acs.commons.ondeploy.scripts.OnDeployScriptBase;
 
 public class OnDeployScriptTestExampleSuccess2 extends OnDeployScriptBase {
     @Override

--- a/bundle/src/test/java/com/adobe/acs/commons/ondeploy/scripts/OnDeployScriptTestExampleSuccessWithPause.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/ondeploy/scripts/OnDeployScriptTestExampleSuccessWithPause.java
@@ -1,6 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.ondeploy.scripts;
-
-import com.adobe.acs.commons.ondeploy.scripts.OnDeployScriptBase;
 
 public class OnDeployScriptTestExampleSuccessWithPause extends OnDeployScriptBase {
     @Override

--- a/bundle/src/test/java/com/adobe/acs/commons/packaging/impl/PackageHelperImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/packaging/impl/PackageHelperImplTest.java
@@ -21,7 +21,6 @@
 package com.adobe.acs.commons.packaging.impl;
 
 import com.adobe.acs.commons.packaging.PackageHelper;
-import com.day.cq.commons.jcr.JcrUtil;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.jackrabbit.commons.iterator.NodeIteratorAdapter;
 import org.apache.jackrabbit.commons.iterator.PropertyIteratorAdapter;
@@ -130,10 +129,10 @@ public class PackageHelperImplTest {
     WorkspaceFilter packageTwoFilter;
 
     @Mock
-    PackageId packageOneID;
+    PackageId packageOneId;
 
     @Mock
-    PackageId packageTwoID;
+    PackageId packageTwoId;
 
     @InjectMocks
     final PackageHelperImpl packageHelper = new PackageHelperImpl();
@@ -178,8 +177,8 @@ public class PackageHelperImplTest {
         when(packageOne.getDefinition()).thenReturn(packageOneDef);
         when(packageTwo.getDefinition()).thenReturn(packageTwoDef);
 
-        when(packageOneDef.getId()).thenReturn(packageOneID);
-        when(packageTwoDef.getId()).thenReturn(packageTwoID);
+        when(packageOneDef.getId()).thenReturn(packageOneId);
+        when(packageTwoDef.getId()).thenReturn(packageTwoId);
 
         when(packageOneDef.getNode()).thenReturn(packageOneDefNode);
         when(packageTwoDef.getNode()).thenReturn(packageTwoDefNode);
@@ -196,16 +195,16 @@ public class PackageHelperImplTest {
         when(packageOne.getNode()).thenReturn(packageOneNode);
         when(packageTwo.getNode()).thenReturn(packageTwoNode);
 
-        when(packageOneNode.getPath()).thenReturn("/etc/packages/" + packageGroup + "/" + packageName + "-" +
-                packageOneVersion + ".zip");
-        when(packageTwoNode.getPath()).thenReturn("/etc/packages/" + packageGroup + "/" + packageName + "-" +
-                packageTwoVersion + ".zip");
+        when(packageOneNode.getPath()).thenReturn("/etc/packages/" + packageGroup + "/" + packageName + "-"
+                + packageOneVersion + ".zip");
+        when(packageTwoNode.getPath()).thenReturn("/etc/packages/" + packageGroup + "/" + packageName + "-"
+                + packageTwoVersion + ".zip");
 
-        when(packageOneID.getName()).thenReturn(packageName);
-        when(packageTwoID.getName()).thenReturn(packageName);
+        when(packageOneId.getName()).thenReturn(packageName);
+        when(packageTwoId.getName()).thenReturn(packageName);
 
-        when(packageOneID.getVersion()).thenReturn(Version.create(packageOneVersion));
-        when(packageTwoID.getVersion()).thenReturn(Version.create(packageTwoVersion));
+        when(packageOneId.getVersion()).thenReturn(Version.create(packageOneVersion));
+        when(packageTwoId.getVersion()).thenReturn(Version.create(packageTwoVersion));
     }
 
 
@@ -229,8 +228,8 @@ public class PackageHelperImplTest {
                 packageTwoMetaInf,
                 packageOneFilter,
                 packageTwoFilter,
-                packageOneID,
-                packageTwoID);
+                packageOneId,
+                packageTwoId);
     }
 
     @Test
@@ -304,7 +303,7 @@ public class PackageHelperImplTest {
 
     @Test
     public void testCreatePackageFromPathFilterSets() throws Exception {
-        Map<String, String> properties = new HashMap<String, String>();
+        final Map<String, String> properties = new HashMap<String, String>();
 
         final List<PathFilterSet> pathFilterSets = new ArrayList<PathFilterSet>();
         pathFilterSets.add(new PathFilterSet("/a/b/c"));

--- a/bundle/src/test/java/com/adobe/acs/commons/redirectmaps/impl/FakeSlingHttpSerlvetRequestTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirectmaps/impl/FakeSlingHttpSerlvetRequestTest.java
@@ -35,31 +35,31 @@ import com.adobe.acs.commons.redirectmaps.models.RedirectMapModelTest;
 @RunWith(MockitoJUnitRunner.class)
 public class FakeSlingHttpSerlvetRequestTest {
 
-	private FakeSlingHttpServletRequest test;
+    private FakeSlingHttpServletRequest test;
 
-	@Mock
-	private ResourceResolver resolver;
+    @Mock
+    private ResourceResolver resolver;
 
-	private static final Logger log = LoggerFactory.getLogger(RedirectMapModelTest.class);
+    private static final Logger log = LoggerFactory.getLogger(RedirectMapModelTest.class);
 
-	@Before
-	public void init() {
-		log.info("init");
-		test = new FakeSlingHttpServletRequest(resolver, "http", "www.adobe.com", 80);
-	}
+    @Before
+    public void init() {
+        log.info("init");
+        test = new FakeSlingHttpServletRequest(resolver, "http", "www.adobe.com", 80);
+    }
 
-	@Test
-	public void getScheme() {
-		assertEquals("http", test.getScheme());
-	}
-	
-	@Test
-	public void testPort() {
-		assertEquals(80, test.getServerPort());
-	}
-	
-	@Test
-	public void testServerName() {
-		assertEquals("www.adobe.com", test.getServerName());
-	}
+    @Test
+    public void getScheme() {
+        assertEquals("http", test.getScheme());
+    }
+
+    @Test
+    public void testPort() {
+        assertEquals(80, test.getServerPort());
+    }
+
+    @Test
+    public void testServerName() {
+        assertEquals("www.adobe.com", test.getServerName());
+    }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/redirectmaps/impl/TestServlets.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirectmaps/impl/TestServlets.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.redirectmaps.impl;
 
 import static org.junit.Assert.assertFalse;
@@ -73,6 +92,12 @@ public class TestServlets {
         }
 
         @Override
+        public Object get(Object key) {
+
+            return null;
+        }
+
+        @Override
         public int size() {
     
             return 0;
@@ -94,12 +119,6 @@ public class TestServlets {
         public boolean containsValue(Object value) {
     
             return false;
-        }
-
-        @Override
-        public Object get(Object key) {
-    
-            return null;
         }
 
         @Override
@@ -199,7 +218,7 @@ public class TestServlets {
 
         MockitoAnnotations.initMocks(this);
 
-        MockResourceResolver mockResolver =     new MockResourceResolver() {
+        final MockResourceResolver mockResolver =     new MockResourceResolver() {
             public Iterator<Resource> findResources(String query, String language) {
                 return new ArrayList<Resource>().iterator();
 

--- a/bundle/src/test/java/com/adobe/acs/commons/redirectmaps/models/MapEntryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirectmaps/models/MapEntryTest.java
@@ -37,58 +37,58 @@ import org.slf4j.LoggerFactory;
 @RunWith(MockitoJUnitRunner.class)
 public class MapEntryTest {
 
-	private Resource mockResource = null;
+    private Resource mockResource = null;
 
-	private static final Logger log = LoggerFactory.getLogger(MapEntryTest.class);
+    private static final Logger log = LoggerFactory.getLogger(MapEntryTest.class);
 
-	@Before
-	public void init() {
-		log.info("init");
-		MockResourceResolver mockResourceResolver = new MockResourceResolver();
-		mockResource = new MockResource(mockResourceResolver,
-				"/etc/acs-commons/redirect-maps/redirectmap1/jcr:content/redirects/2_123",
-				"acs-commons/components/utilities/redirects");
-	}
+    @Before
+    public void init() {
+        log.info("init");
+        MockResourceResolver mockResourceResolver = new MockResourceResolver();
+        mockResource = new MockResource(mockResourceResolver,
+                "/etc/acs-commons/redirect-maps/redirectmap1/jcr:content/redirects/2_123",
+                "acs-commons/components/utilities/redirects");
+    }
 
-	@Test
-	public void testInvalidMapEntry() {
+    @Test
+    public void testInvalidMapEntry() {
 
-		log.info("testInvalidMapEntry");
-		String source = "/vanity 2";
-		MapEntry invalid = new MapEntry(source, mockResource.getPath(), "File");
+        log.info("testInvalidMapEntry");
+        String source = "/vanity 2";
+        MapEntry invalid = new MapEntry(source, mockResource.getPath(), "File");
 
-		invalid.setValid(false);
-		invalid.setStatus("Invalid!");
-		
-		log.info("Asserting that entry is invalid");
-		assertFalse(invalid.isValid());
-		assertNotNull(invalid.getStatus());
+        invalid.setValid(false);
+        invalid.setStatus("Invalid!");
 
-		log.info("Asserting that matches expected values");
-		assertEquals(invalid.getOrigin(), "File");
-		assertEquals(invalid.getSource(), source);
-		assertEquals(invalid.getTarget(), mockResource.getPath());
-		log.debug(invalid.toString());
+        log.info("Asserting that entry is invalid");
+        assertFalse(invalid.isValid());
+        assertNotNull(invalid.getStatus());
 
-		log.info("Test successful!");
-	}
+        log.info("Asserting that matches expected values");
+        assertEquals(invalid.getOrigin(), "File");
+        assertEquals(invalid.getSource(), source);
+        assertEquals(invalid.getTarget(), mockResource.getPath());
+        log.debug(invalid.toString());
 
-	@Test
-	public void testValidMapEntry() {
+        log.info("Test successful!");
+    }
 
-		log.info("testValidMapEntry");
-		String source = "/vanity-2";
-		MapEntry valid = new MapEntry(source, mockResource.getPath(), mockResource.getPath());
+    @Test
+    public void testValidMapEntry() {
 
-		log.info("Asserting that entry is valid");
-		assertTrue(valid.isValid());
+        log.info("testValidMapEntry");
+        String source = "/vanity-2";
+        MapEntry valid = new MapEntry(source, mockResource.getPath(), mockResource.getPath());
 
-		log.info("Asserting that matches expected values");
-		assertEquals(valid.getOrigin(), mockResource.getPath());
-		assertEquals(valid.getSource(), source);
-		assertEquals(valid.getTarget(), mockResource.getPath());
-		log.debug(valid.toString());
+        log.info("Asserting that entry is valid");
+        assertTrue(valid.isValid());
 
-		log.info("Test successful!");
-	}
+        log.info("Asserting that matches expected values");
+        assertEquals(valid.getOrigin(), mockResource.getPath());
+        assertEquals(valid.getSource(), source);
+        assertEquals(valid.getTarget(), mockResource.getPath());
+        log.debug(valid.toString());
+
+        log.info("Test successful!");
+    }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/replication/dispatcher/DispatcherFlushFilterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/replication/dispatcher/DispatcherFlushFilterTest.java
@@ -126,7 +126,7 @@ public class DispatcherFlushFilterTest {
     }
 
     @Test
-    public void testIsIncluded_enabled_invalidHTTPHeaders() throws Exception {
+    public void testIsIncluded_enabled_invalidHttpHeaders() throws Exception {
         final DispatcherFlushFilter filter = new DispatcherFlushFilter();
 
         when(agent.isEnabled()).thenReturn(true);

--- a/bundle/src/test/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlushRulesImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlushRulesImplTest.java
@@ -79,7 +79,7 @@ public class DispatcherFlushRulesImplTest {
     }
 
     @Test
-    public void testConfigureReplicationActionType_ACTIVATE() throws Exception {
+    public void testConfigureReplicationActionType_Activate() throws Exception {
         final ReplicationActionType expected = ReplicationActionType.ACTIVATE;
         final ReplicationActionType actual = dispatcherFlushRules.configureReplicationActionType("ACTIVATE");
 
@@ -87,7 +87,7 @@ public class DispatcherFlushRulesImplTest {
     }
 
     @Test
-    public void testConfigureReplicationActionType_DELETE() throws Exception {
+    public void testConfigureReplicationActionType_Delete() throws Exception {
         final ReplicationActionType expected = ReplicationActionType.DELETE;
         final ReplicationActionType actual = dispatcherFlushRules.configureReplicationActionType("DELETE");
 
@@ -95,7 +95,7 @@ public class DispatcherFlushRulesImplTest {
     }
 
     @Test
-    public void testConfigureReplicationActionType_DEACTIVATE() throws Exception {
+    public void testConfigureReplicationActionType_Deactivate() throws Exception {
         final ReplicationActionType expected = ReplicationActionType.DEACTIVATE;
         final ReplicationActionType actual = dispatcherFlushRules.configureReplicationActionType("DEACTIVATE");
 
@@ -103,7 +103,7 @@ public class DispatcherFlushRulesImplTest {
     }
 
     @Test
-    public void testConfigureReplicationActionType_INHERIT() throws Exception {
+    public void testConfigureReplicationActionType_Inherit() throws Exception {
         final ReplicationActionType expected = null;
         final ReplicationActionType actual = dispatcherFlushRules.configureReplicationActionType("INHERIT");
 

--- a/bundle/src/test/java/com/adobe/acs/commons/replication/impl/ReplicateVersionImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/replication/impl/ReplicateVersionImplTest.java
@@ -138,6 +138,7 @@ public class ReplicateVersionImplTest {
         Assert.assertEquals(Status.replicated, list.get(0).getStatus());
         Assert.assertEquals("version1", list.get(0).getVersion());
     }
+
     private Date getDate(String datetime) throws Exception {
 
             SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss");

--- a/bundle/src/test/java/com/adobe/acs/commons/replication/status/impl/JcrPackageReplicationStatusEventHandlerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/replication/status/impl/JcrPackageReplicationStatusEventHandlerTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.replication.status.impl;
 
 import com.adobe.acs.commons.packaging.PackageHelper;
@@ -45,7 +64,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class JcrPackageReplicationStatusEventHandlerTest {
-    final String PACKAGE_PATH = "/etc/packages/acs-commons/test.zip";
+    static final String PACKAGE_PATH = "/etc/packages/acs-commons/test.zip";
 
     Calendar calendar;
 
@@ -186,7 +205,7 @@ public class JcrPackageReplicationStatusEventHandlerTest {
     }
 
     @Test
-    public void testGetInfoFromEvent_CQEvent() {
+    public void testGetInfoFromEvent_CqEvent() {
         final String[] expectedPaths = new String[]{PACKAGE_PATH};
         final String expectedUserId = "replication-user";
 
@@ -210,7 +229,7 @@ public class JcrPackageReplicationStatusEventHandlerTest {
         modification.put("paths", expectedPaths);
         modification.put("userId", expectedUserId);
         modification.put("type", ReplicationActionType.ACTIVATE);
-        modification.put("time", 0l);
+        modification.put("time", 0L);
         modification.put("revision", "1");
 
         final List<Map<String, Object>> modifications = new ArrayList<>();

--- a/bundle/src/test/java/com/adobe/acs/commons/replication/status/impl/SetReplicationStatusProcessTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/replication/status/impl/SetReplicationStatusProcessTest.java
@@ -82,10 +82,10 @@ public class SetReplicationStatusProcessTest {
     String workflowPayload = "/content/workflow-payload";
 
     @Spy
-    SetReplicationStatusProcess setReplicationStatusProcess = new SetReplicationStatusProcess();;
+    SetReplicationStatusProcess setReplicationStatusProcess = new SetReplicationStatusProcess();
 
     @Before
-    public void setUp() throws Exception {		
+    public void setUp() throws Exception {
         when(workflowHelper.getResourceResolver(workflowSession)).thenReturn(resourceResolver);
 
         when(workItem.getWorkflowData()).thenReturn(workflowData);
@@ -137,35 +137,37 @@ public class SetReplicationStatusProcessTest {
         verify(replicationStatusManager).setReplicationStatus(any(), eq("migration"), argThat(calMatch), any(), anyString());
     }
 
-}
+    private static class CalendarMatcher extends ArgumentMatcher<Calendar> {
 
-class CalendarMatcher extends ArgumentMatcher<Calendar> {
+        private Calendar leftCal;
 
-    private Calendar leftCal;
-
-    public CalendarMatcher(String date) throws ParseException {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm", Locale.ENGLISH);
-        Calendar cal = Calendar.getInstance();
-        cal.setTime(sdf.parse(date));
-        this.leftCal = cal;
-    }
-
-    public CalendarMatcher(Calendar cal) throws ParseException {
-        this.leftCal = cal;
-    }
-
-    @Override
-    public boolean matches(Object argument) {
-        if (argument instanceof Calendar) {
-            Calendar rightCal = (Calendar)argument;
-            return (leftCal.get(Calendar.YEAR) == rightCal.get(Calendar.YEAR) &&
-                    leftCal.get(Calendar.MONTH) == rightCal.get(Calendar.MONTH) &&
-                    leftCal.get(Calendar.DATE) == rightCal.get(Calendar.DATE) &&
-                    leftCal.get(Calendar.HOUR) == rightCal.get(Calendar.HOUR) &&
-                    leftCal.get(Calendar.MINUTE) == rightCal.get(Calendar.MINUTE));
-        } else {
-            return false;
+        public CalendarMatcher(String date) throws ParseException {
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm", Locale.ENGLISH);
+            Calendar cal = Calendar.getInstance();
+            cal.setTime(sdf.parse(date));
+            this.leftCal = cal;
         }
+
+        public CalendarMatcher(Calendar cal) throws ParseException {
+            this.leftCal = cal;
+        }
+
+        @Override
+        public boolean matches(Object argument) {
+            if (argument instanceof Calendar) {
+                Calendar rightCal = (Calendar)argument;
+                return (leftCal.get(Calendar.YEAR) == rightCal.get(Calendar.YEAR)
+                        && leftCal.get(Calendar.MONTH) == rightCal.get(Calendar.MONTH)
+                        && leftCal.get(Calendar.DATE) == rightCal.get(Calendar.DATE)
+                        && leftCal.get(Calendar.HOUR) == rightCal.get(Calendar.HOUR)
+                        && leftCal.get(Calendar.MINUTE) == rightCal.get(Calendar.MINUTE));
+            } else {
+                return false;
+            }
+        }
+
     }
 
 }
+
+

--- a/bundle/src/test/java/com/adobe/acs/commons/reports/models/ContainingPageReportCellCSVExporterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/reports/models/ContainingPageReportCellCSVExporterTest.java
@@ -36,58 +36,58 @@ import com.day.cq.wcm.api.PageManager;
 
 public class ContainingPageReportCellCSVExporterTest {
 
-	private static final Logger log = LoggerFactory.getLogger(ContainingPageReportCellCSVExporterTest.class);
+    private static final Logger log = LoggerFactory.getLogger(ContainingPageReportCellCSVExporterTest.class);
 
-	@Mock
-	private Resource validResource;
-	@Mock
-	private Resource invalidResource;
+    @Mock
+    private Resource validResource;
+    @Mock
+    private Resource invalidResource;
 
-	@Mock
-	private PageManager pageManager;
+    @Mock
+    private PageManager pageManager;
 
-	@Mock
-	private ResourceResolver resolver;
+    @Mock
+    private ResourceResolver resolver;
 
-	@Mock
-	private Page page;
+    @Mock
+    private Page page;
 
-	private final String VALID_PATH = "/content/test";
+    private static final String VALID_PATH = "/content/test";
 
-	@Before
-	public void init() {
-		log.info("init");
+    @Before
+    public void init() {
+        log.info("init");
 
-		MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.initMocks(this);
 
-		when(validResource.getResourceResolver()).thenReturn(resolver);
-		when(invalidResource.getResourceResolver()).thenReturn(resolver);
-		when(resolver.adaptTo(PageManager.class)).thenReturn(pageManager);
-		when(pageManager.getContainingPage(validResource)).thenReturn(page);
-		when(page.getPath()).thenReturn(VALID_PATH);
+        when(validResource.getResourceResolver()).thenReturn(resolver);
+        when(invalidResource.getResourceResolver()).thenReturn(resolver);
+        when(resolver.adaptTo(PageManager.class)).thenReturn(pageManager);
+        when(pageManager.getContainingPage(validResource)).thenReturn(page);
+        when(page.getPath()).thenReturn(VALID_PATH);
 
-	}
+    }
 
-	@Test
-	public void testExporter() {
-		log.info("testExporter");
+    @Test
+    public void testExporter() {
+        log.info("testExporter");
 
-		ContainingPageReportCellCSVExporter valid = new ContainingPageReportCellCSVExporter();
-		String value = valid.getValue(validResource);
-		assertEquals(VALID_PATH, value);
+        ContainingPageReportCellCSVExporter valid = new ContainingPageReportCellCSVExporter();
+        String value = valid.getValue(validResource);
+        assertEquals(VALID_PATH, value);
 
-		log.info("Test successful!");
-	}
+        log.info("Test successful!");
+    }
 
-	@Test
-	public void testInvalidPage() {
-		log.info("testInvalidPage");
+    @Test
+    public void testInvalidPage() {
+        log.info("testInvalidPage");
 
-		ContainingPageReportCellCSVExporter invalid = new ContainingPageReportCellCSVExporter();
-		String value = invalid.getValue(invalidResource);
-		assertEquals("", value);
+        ContainingPageReportCellCSVExporter invalid = new ContainingPageReportCellCSVExporter();
+        String value = invalid.getValue(invalidResource);
+        assertEquals("", value);
 
-		log.info("Test successful!");
-	}
+        log.info("Test successful!");
+    }
 
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/reports/models/ReportRunnerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/reports/models/ReportRunnerTest.java
@@ -44,103 +44,103 @@ import org.slf4j.LoggerFactory;
 
 public class ReportRunnerTest {
 
-	private static final Logger log = LoggerFactory.getLogger(ReportRunnerTest.class);
+    private static final Logger log = LoggerFactory.getLogger(ReportRunnerTest.class);
 
-	@Mock
-	private Resource configParentResource;
+    @Mock
+    private Resource configParentResource;
 
-	@Mock
-	private Resource contentResource;
+    @Mock
+    private Resource contentResource;
 
-	@Mock
-	Resource oldMaid;
+    @Mock
+    Resource oldMaid;
 
-	@Mock
-	private Resource configResource;
+    @Mock
+    private Resource configResource;
 
-	@Mock
-	private Resource noClassConfigResource;
+    @Mock
+    private Resource noClassConfigResource;
 
-	@Mock
-	private Resource invalidClassConfigResource;
+    @Mock
+    private Resource invalidClassConfigResource;
 
-	@Mock
-	private Resource incorrectClassConfigResource;
+    @Mock
+    private Resource incorrectClassConfigResource;
 
-	@Mock
-	private SlingHttpServletRequest validRequest;
+    @Mock
+    private SlingHttpServletRequest validRequest;
 
-	@Mock
-	private SlingHttpServletRequest invalidRequest;
+    @Mock
+    private SlingHttpServletRequest invalidRequest;
 
-	private MockReportExecutor exec = new MockReportExecutor();
+    private MockReportExecutor exec = new MockReportExecutor();
 
-	@Before
-	public void init() {
-		log.info("init");
+    @Before
+    public void init() {
+        log.info("init");
 
-		MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.initMocks(this);
 
-		when(invalidRequest.getParameter("page")).thenReturn("alpha");
-		when(invalidRequest.getResource()).thenReturn(oldMaid);
+        when(invalidRequest.getParameter("page")).thenReturn("alpha");
+        when(invalidRequest.getResource()).thenReturn(oldMaid);
 
-		when(validRequest.getResource()).thenReturn(contentResource);
-		when(validRequest.getParameter("page")).thenReturn("1");
-		when(validRequest.adaptTo(MockReportExecutor.class)).thenReturn(exec);
-		when(contentResource.getChild("config")).thenReturn(configParentResource);
+        when(validRequest.getResource()).thenReturn(contentResource);
+        when(validRequest.getParameter("page")).thenReturn("1");
+        when(validRequest.adaptTo(MockReportExecutor.class)).thenReturn(exec);
+        when(contentResource.getChild("config")).thenReturn(configParentResource);
 
-		Iterator<Resource> it = Arrays.asList(new Resource[] { noClassConfigResource, invalidClassConfigResource,
-				incorrectClassConfigResource, configResource }).iterator();
-		when(configParentResource.listChildren()).thenReturn(it);
+        Iterator<Resource> it = Arrays.asList(new Resource[] { noClassConfigResource, invalidClassConfigResource,
+                incorrectClassConfigResource, configResource }).iterator();
+        when(configParentResource.listChildren()).thenReturn(it);
 
-		when(configResource.getValueMap()).thenReturn(new ValueMapDecorator(new HashMap<String, Object>() {
-			private static final long serialVersionUID = 1L;
-			{
-				put(ReportRunner.PN_EXECUTOR, MockReportExecutor.class.getName());
-			}
-		}));
+        when(configResource.getValueMap()).thenReturn(new ValueMapDecorator(new HashMap<String, Object>() {
+            private static final long serialVersionUID = 1L;
+            {
+                put(ReportRunner.PN_EXECUTOR, MockReportExecutor.class.getName());
+            }
+        }));
 
-		when(noClassConfigResource.getValueMap()).thenReturn(new ValueMapDecorator(new HashMap<String, Object>()));
+        when(noClassConfigResource.getValueMap()).thenReturn(new ValueMapDecorator(new HashMap<String, Object>()));
 
-		when(invalidClassConfigResource.getValueMap()).thenReturn(new ValueMapDecorator(new HashMap<String, Object>() {
-			private static final long serialVersionUID = 1L;
-			{
-				put(ReportRunner.PN_EXECUTOR, "not.a.class.CLAZZ");
-			}
-		}));
+        when(invalidClassConfigResource.getValueMap()).thenReturn(new ValueMapDecorator(new HashMap<String, Object>() {
+            private static final long serialVersionUID = 1L;
+            {
+                put(ReportRunner.PN_EXECUTOR, "not.a.class.CLAZZ");
+            }
+        }));
 
-		when(incorrectClassConfigResource.getValueMap())
-				.thenReturn(new ValueMapDecorator(new HashMap<String, Object>() {
-					private static final long serialVersionUID = 1L;
-					{
-						put(ReportRunner.PN_EXECUTOR, "java.lang.String");
-					}
-				}));
+        when(incorrectClassConfigResource.getValueMap())
+                .thenReturn(new ValueMapDecorator(new HashMap<String, Object>() {
+                    private static final long serialVersionUID = 1L;
+                    {
+                        put(ReportRunner.PN_EXECUTOR, "java.lang.String");
+                    }
+                }));
 
-	}
+    }
 
-	@Test
-	public void testInvalid() throws RepositoryException {
-		log.info("testInvalid");
-		ReportRunner reportRunner = new ReportRunner(invalidRequest);
-		reportRunner.init();
-		assertEquals("No configurations found!", reportRunner.getFailureMessage());
-		assertFalse(reportRunner.isSuccessful());
-		log.info("Test Succeeded!");
-	}
+    @Test
+    public void testInvalid() throws RepositoryException {
+        log.info("testInvalid");
+        ReportRunner reportRunner = new ReportRunner(invalidRequest);
+        reportRunner.init();
+        assertEquals("No configurations found!", reportRunner.getFailureMessage());
+        assertFalse(reportRunner.isSuccessful());
+        log.info("Test Succeeded!");
+    }
 
-	@Test
-	public void testReportRunner() throws RepositoryException {
-		log.info("testReportRunner");
-		ReportRunner reportRunner = new ReportRunner(validRequest);
-		reportRunner.init();
-		assertTrue(reportRunner.isSuccessful());
-		assertNull(reportRunner.getFailureMessage());
+    @Test
+    public void testReportRunner() throws RepositoryException {
+        log.info("testReportRunner");
+        ReportRunner reportRunner = new ReportRunner(validRequest);
+        reportRunner.init();
+        assertTrue(reportRunner.isSuccessful());
+        assertNull(reportRunner.getFailureMessage());
 
-		assertNotNull(reportRunner.getReportExecutor());
-		assertEquals(exec, reportRunner.getReportExecutor());
+        assertNotNull(reportRunner.getReportExecutor());
+        assertEquals(exec, reportRunner.getReportExecutor());
 
-		log.info("Test Succeeded!");
-	}
+        log.info("Test Succeeded!");
+    }
 
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/SaxElementUtilsTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/SaxElementUtilsTest.java
@@ -32,7 +32,7 @@ import org.xml.sax.helpers.AttributesImpl;
 public class SaxElementUtilsTest {
 
     @Test
-    public void testIsCSS() throws Exception {
+    public void testIsCss() throws Exception {
         assertTrue("CSS Happy Path", 
                 SaxElementUtils.isCss("link",
                         makeAtts(

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/StylesheetInlinerTransformerFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/StylesheetInlinerTransformerFactoryTest.java
@@ -85,9 +85,9 @@ public class StylesheetInlinerTransformerFactoryTest {
 
     private Attributes empty = new AttributesImpl();
     
-    private final String CLIENTLIB_PATH = "/etc/clientlibs/test";
-    private final String CSS_RESOURCE_PATH = "/etc/assets/somecss";
-    private final String NON_EXISTING_PATH = "/etc/assets/doesntexist";
+    private static final String CLIENTLIB_PATH = "/etc/clientlibs/test";
+    private static final String CSS_RESOURCE_PATH = "/etc/assets/somecss";
+    private static final String NON_EXISTING_PATH = "/etc/assets/doesntexist";
     
     private static final String CSS_CONTENTS = "div {display:block;}";
     private static final String NEWLINE = "\n";
@@ -246,6 +246,7 @@ public class StylesheetInlinerTransformerFactoryTest {
         transformer.characters( TEST_DATA.toCharArray(), 0, TEST_DATA.length());
         transformer.endElement(null, "div", null);
     }
+
     private void verifyDiv() throws SAXException {
         verify(handler).startElement(isNull(String.class), eq("div"), isNull(String.class), eq(empty));
         verify(handler).characters(TEST_DATA.toCharArray(), 0, TEST_DATA.length());

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactoryTest.java
@@ -56,6 +56,7 @@ import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
@@ -100,20 +101,23 @@ public class VersionedClientlibsTransformerFactoryTest {
     @Mock
     private ResourceResolver resourceResolver;
 
-    private final String PATH = "/etc/clientlibs/test";
-    private final String FAKE_STREAM_CHECKSUM="fcadcfb01c1367e9e5b7f2e6d455ba8f"; // md5 of "I love strings"
-    private final String PROXIED_FAKE_STREAM_CHECKSUM="669a712c318596cd7e7520e3e2000cfb"; // md5 of "I love strings when they are proxied"
-    private final byte[] BYTES;
-    private final java.io.InputStream INPUTSTREAM;
-    private final String INPUTSTREAM_MD5;
-    private final String PROXIED_PATH = "/apps/myco/test";
-    private final String PROXY_PATH = "/etc.clientlibs/myco/test";
+    private static final String PATH = "/etc/clientlibs/test";
+    private static final String FAKE_STREAM_CHECKSUM="fcadcfb01c1367e9e5b7f2e6d455ba8f"; // md5 of "I love strings"
+    private static final String PROXIED_FAKE_STREAM_CHECKSUM="669a712c318596cd7e7520e3e2000cfb"; // md5 of "I love strings when they are proxied"
+    private static final byte[] BYTES;
+    private static final java.io.InputStream INPUTSTREAM;
+    private static final String INPUTSTREAM_MD5;
+    private static final String PROXIED_PATH = "/apps/myco/test";
+    private static final String PROXY_PATH = "/etc.clientlibs/myco/test";
 
-
-    public VersionedClientlibsTransformerFactoryTest() throws Exception {
-        BYTES = "test".getBytes("UTF-8");
-        INPUTSTREAM = new ByteArrayInputStream(BYTES);
-        INPUTSTREAM_MD5 = DigestUtils.md5Hex(BYTES);
+    static {
+        try {
+            BYTES = "test".getBytes("UTF-8");
+            INPUTSTREAM = new ByteArrayInputStream(BYTES);
+            INPUTSTREAM_MD5 = DigestUtils.md5Hex(BYTES);
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Before
@@ -177,7 +181,7 @@ public class VersionedClientlibsTransformerFactoryTest {
     }
 
     @Test
-    public void testCSSClientLibrary() throws Exception {
+    public void testCssClientLibrary() throws Exception {
 
         when(htmlLibraryManager.getLibrary(eq(LibraryType.CSS), eq(PATH))).thenReturn(htmlLibrary);
 
@@ -197,7 +201,7 @@ public class VersionedClientlibsTransformerFactoryTest {
     }
 
     @Test
-    public void testCSSClientLibraryWithMd5Enforce() throws Exception {
+    public void testCssClientLibraryWithMd5Enforce() throws Exception {
         PrivateAccessor.setField(factory, "enforceMd5", true);
 
         when(htmlLibraryManager.getLibrary(eq(LibraryType.CSS), eq(PATH))).thenReturn(htmlLibrary);
@@ -218,7 +222,7 @@ public class VersionedClientlibsTransformerFactoryTest {
     }
 
     @Test
-    public void testCSSClientLibraryWithDot() throws Exception {
+    public void testCssClientLibraryWithDot() throws Exception {
         final String path = PATH + ".foo";
 
         when(htmlLibraryManager.getLibrary(eq(LibraryType.CSS), eq(path))).thenReturn(htmlLibrary);
@@ -240,7 +244,7 @@ public class VersionedClientlibsTransformerFactoryTest {
     }
 
     @Test
-    public void testMinifiedCSSClientLibrary() throws Exception {
+    public void testMinifiedCssClientLibrary() throws Exception {
 
         when(htmlLibraryManager.getLibrary(eq(LibraryType.CSS), eq(PATH))).thenReturn(htmlLibrary);
 
@@ -260,7 +264,7 @@ public class VersionedClientlibsTransformerFactoryTest {
     }
 
     @Test
-    public void testMinifiedCSSClientLibraryWithEnforceMd5() throws Exception {
+    public void testMinifiedCssClientLibraryWithEnforceMd5() throws Exception {
         PrivateAccessor.setField(factory, "enforceMd5", true);
 
         when(htmlLibraryManager.getLibrary(eq(LibraryType.CSS), eq(PATH))).thenReturn(htmlLibrary);
@@ -361,7 +365,7 @@ public class VersionedClientlibsTransformerFactoryTest {
     }
 
     @Test
-    public void testCSSClientLibraryWithInvalidExtension() throws Exception {
+    public void testCssClientLibraryWithInvalidExtension() throws Exception {
 
         when(htmlLibraryManager.getLibrary(eq(LibraryType.CSS), eq(PATH))).thenReturn(htmlLibrary);
 
@@ -381,7 +385,7 @@ public class VersionedClientlibsTransformerFactoryTest {
     }
 
      @Test
-    public void testCSSClientLibraryWithRelAttributeValueDiffersFromStylesheet() throws Exception {
+    public void testCssClientLibraryWithRelAttributeValueDiffersFromStylesheet() throws Exception {
 
         when(htmlLibraryManager.getLibrary(eq(LibraryType.CSS), eq(PATH))).thenReturn(htmlLibrary);
 
@@ -459,7 +463,7 @@ public class VersionedClientlibsTransformerFactoryTest {
     }
 
     @Test
-    public void testCSSClientLibraryWithSameSchemePath() throws Exception {
+    public void testCssClientLibraryWithSameSchemePath() throws Exception {
 
         when(htmlLibraryManager.getLibrary(eq(LibraryType.CSS), eq(PATH))).thenReturn(htmlLibrary);
 
@@ -498,7 +502,7 @@ public class VersionedClientlibsTransformerFactoryTest {
     }
 
     @Test
-    public void testCSSClientLibraryWithSameDomainedPath() throws Exception {
+    public void testCssClientLibraryWithSameDomainedPath() throws Exception {
 
         when(htmlLibraryManager.getLibrary(eq(LibraryType.CSS), eq(PATH))).thenReturn(htmlLibrary);
 
@@ -518,7 +522,7 @@ public class VersionedClientlibsTransformerFactoryTest {
     }
 
     @Test
-    public void doFilter_nonJSCSS() throws Exception {
+    public void doFilter_nonJsCss() throws Exception {
         when(slingRequest.getRequestURI()).thenReturn("/some_other/uri.html");
         filter.doFilter(slingRequest, slingResponse, filterChain);
         verifyNothingHappened();

--- a/bundle/src/test/java/com/adobe/acs/commons/scripting/impl/QueryBuilderBindingsValuesProviderTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/scripting/impl/QueryBuilderBindingsValuesProviderTest.java
@@ -1,15 +1,15 @@
 /*
  * #%L
- * ACS AEM Tools Content
+ * ACS AEM Commons Bundle
  * %%
  * Copyright (C) 2014 Adobe
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/bundle/src/test/java/com/adobe/acs/commons/synth/children/ChildrenAsPropertyResourceTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/synth/children/ChildrenAsPropertyResourceTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.synth.children;
 
 import org.apache.commons.collections.IteratorUtils;

--- a/bundle/src/test/java/com/adobe/acs/commons/users/impl/AbstractAuthorizableTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/users/impl/AbstractAuthorizableTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.users.impl;
 
 import org.junit.Test;

--- a/bundle/src/test/java/com/adobe/acs/commons/users/impl/GroupTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/users/impl/GroupTest.java
@@ -1,4 +1,22 @@
-
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.users.impl;
 
 import static org.junit.Assert.assertEquals;

--- a/bundle/src/test/java/com/adobe/acs/commons/util/BufferingResponseTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/BufferingResponseTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
 import static org.junit.Assert.*;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/bundle/src/test/java/com/adobe/acs/commons/util/CookieUtilTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/CookieUtilTest.java
@@ -19,7 +19,8 @@
  */
 package com.adobe.acs.commons.util;
 
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import javax.servlet.http.Cookie;
@@ -44,18 +45,6 @@ public class CookieUtilTest {
 
     private static Cookie[] cookies;
 
-    public CookieUtilTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-    }
-
     @Before
     public void setUp() {
         request = mock(HttpServletRequest.class);
@@ -71,10 +60,6 @@ public class CookieUtilTest {
 
         when(request.getCookies()).thenReturn(cookies);
 
-    }
-
-    @After
-    public void tearDown() {
     }
 
     /**

--- a/bundle/src/test/java/com/adobe/acs/commons/util/InfoWriterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/InfoWriterTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.util;
 
 import org.apache.commons.lang.StringUtils;
@@ -10,7 +29,7 @@ import static org.junit.Assert.assertEquals;
 public class InfoWriterTest {
     InfoWriter iw = new InfoWriter();
 
-    final String LS = System.getProperty("line.separator");
+    static final String LS = System.getProperty("line.separator");
 
     @Test
     public void testPrint_OnlyMessage() throws Exception {
@@ -113,7 +132,7 @@ public class InfoWriterTest {
 
     @Test
     public void testGetInfo() throws Exception {
-        String expected = LS
+        final String expected = LS
                 +  StringUtils.repeat("-", 80) + LS
                 + "Info Title" + LS
                 +  StringUtils.repeat("=", 80) + LS

--- a/bundle/src/test/java/com/adobe/acs/commons/util/ParameterUtilTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/ParameterUtilTest.java
@@ -19,7 +19,7 @@
  */
 package com.adobe.acs.commons.util;
 
-import org.junit.*;
+import org.junit.Test;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.HashMap;
@@ -28,25 +28,6 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 
 public class ParameterUtilTest {
-
-    public ParameterUtilTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
-    }
 
     /**
      * Test of toSimpleEntry method, of class OsgiPropertyUtil.

--- a/bundle/src/test/java/com/adobe/acs/commons/util/RunnableOnMasterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/RunnableOnMasterTest.java
@@ -21,6 +21,7 @@ package com.adobe.acs.commons.util;
 
 import org.apache.commons.lang.mutable.MutableInt;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 public class RunnableOnMasterTest {

--- a/bundle/src/test/java/com/adobe/acs/commons/util/datadefinitions/impl/JcrValidNameDefinitionBuilderImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/datadefinitions/impl/JcrValidNameDefinitionBuilderImplTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.util.datadefinitions.impl;
 
 import com.adobe.acs.commons.util.datadefinitions.ResourceDefinition;

--- a/bundle/src/test/java/com/adobe/acs/commons/util/datadefinitions/impl/LocalizedTitleDefinitionBuilderImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/datadefinitions/impl/LocalizedTitleDefinitionBuilderImplTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.util.datadefinitions.impl;
 
 import com.adobe.acs.commons.util.datadefinitions.ResourceDefinition;

--- a/bundle/src/test/java/com/adobe/acs/commons/util/datadefinitions/impl/LowercaseWithDashesDefinitionBuilderImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/datadefinitions/impl/LowercaseWithDashesDefinitionBuilderImplTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.util.datadefinitions.impl;
 
 import com.adobe.acs.commons.util.datadefinitions.ResourceDefinition;

--- a/bundle/src/test/java/com/adobe/acs/commons/util/datadefinitions/impl/TitleAndNodeNameDefinitionBuilderImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/datadefinitions/impl/TitleAndNodeNameDefinitionBuilderImplTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.util.datadefinitions.impl;
 
 import com.adobe.acs.commons.util.datadefinitions.ResourceDefinition;

--- a/bundle/src/test/java/com/adobe/acs/commons/util/visitors/SimpleFilteringResourceVisitorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/visitors/SimpleFilteringResourceVisitorTest.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2017 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.util.visitors;
 
@@ -26,6 +30,7 @@ import org.apache.sling.commons.testing.sling.MockResource;
 import org.apache.sling.commons.testing.sling.MockResourceResolver;
 import org.junit.Before;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 public class SimpleFilteringResourceVisitorTest {

--- a/bundle/src/test/java/com/adobe/acs/commons/util/visitors/TreeFilteringResourceVisitorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/visitors/TreeFilteringResourceVisitorTest.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2017 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.util.visitors;
 
@@ -22,6 +26,7 @@ import org.apache.sling.commons.testing.sling.MockResource;
 import org.apache.sling.commons.testing.sling.MockResourceResolver;
 import org.junit.Before;
 import org.junit.Test;
+
 import static org.junit.Assert.*;
 
 public class TreeFilteringResourceVisitorTest {

--- a/bundle/src/test/java/com/adobe/acs/commons/version/impl/EvolutionConfigTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/version/impl/EvolutionConfigTest.java
@@ -1,23 +1,21 @@
 /*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * #%L
- *  * ACS AEM Commons Bundle
- *  * %%
- *  * Copyright (C) 2016 Adobe
- *  * %%
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
- *  * #L%
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.version.impl;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/version/impl/EvolutionContextImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/version/impl/EvolutionContextImplTest.java
@@ -1,23 +1,21 @@
 /*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * #%L
- *  * ACS AEM Commons Bundle
- *  * %%
- *  * Copyright (C) 2018 Adobe
- *  * %%
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
- *  * #L%
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.version.impl;
 
@@ -32,7 +30,12 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import javax.jcr.*;
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.PropertyType;
+import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.Workspace;
 import javax.jcr.version.Version;
 import javax.jcr.version.VersionHistory;
 import javax.jcr.version.VersionIterator;

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/PageCompareDataImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/PageCompareDataImplTest.java
@@ -1,23 +1,21 @@
 /*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * #%L
- *  * ACS AEM Commons Bundle
- *  * %%
- *  * Copyright (C) 2016 Adobe
- *  * %%
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
- *  * #L%
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.wcm.comparisons.impl;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/PageCompareDataLineImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/PageCompareDataLineImplTest.java
@@ -1,23 +1,21 @@
 /*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * #%L
- *  * ACS AEM Commons Bundle
- *  * %%
- *  * Copyright (C) 2016 Adobe
- *  * %%
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
- *  * #L%
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.wcm.comparisons.impl;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/PageCompareDataLinesTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/PageCompareDataLinesTest.java
@@ -1,25 +1,22 @@
 /*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * #%L
- *  * ACS AEM Commons Bundle
- *  * %%
- *  * Copyright (C) 2016 Adobe
- *  * %%
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
- *  * #L%
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
  */
-
 package com.adobe.acs.commons.wcm.comparisons.impl;
 
 import com.adobe.acs.commons.wcm.comparisons.PageCompareDataLine;

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/PageCompareDataLoaderImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/PageCompareDataLoaderImplTest.java
@@ -1,23 +1,21 @@
 /*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * #%L
- *  * ACS AEM Commons Bundle
- *  * %%
- *  * Copyright (C) 2016 Adobe
- *  * %%
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
- *  * #L%
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.wcm.comparisons.impl;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/PropertiesTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/PropertiesTest.java
@@ -1,23 +1,21 @@
 /*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * #%L
- *  * ACS AEM Commons Bundle
- *  * %%
- *  * Copyright (C) 2016 Adobe
- *  * %%
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
- *  * #L%
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.wcm.comparisons.impl;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/VersionSelectionTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/VersionSelectionTest.java
@@ -1,23 +1,21 @@
 /*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * #%L
- *  * ACS AEM Commons Bundle
- *  * %%
- *  * Copyright (C) 2016 Adobe
- *  * %%
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
- *  * #L%
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.wcm.comparisons.impl;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/VersionServiceImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/VersionServiceImplTest.java
@@ -1,23 +1,21 @@
 /*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * #%L
- *  * ACS AEM Commons Bundle
- *  * %%
- *  * Copyright (C) 2016 Adobe
- *  * %%
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
- *  * #L%
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
  */
 
 package com.adobe.acs.commons.wcm.comparisons.impl;

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/lines/LineImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/lines/LineImplTest.java
@@ -1,23 +1,21 @@
 /*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * #%L
- *  * ACS AEM Commons Bundle
- *  * %%
- *  * Copyright (C) 2016 Adobe
- *  * %%
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
- *  * #L%
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.wcm.comparisons.impl.lines;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/lines/LinesTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/lines/LinesTest.java
@@ -1,23 +1,21 @@
 /*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * #%L
- *  * ACS AEM Commons Bundle
- *  * %%
- *  * Copyright (C) 2016 Adobe
- *  * %%
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
- *  * #L%
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.wcm.comparisons.impl.lines;
 
@@ -205,8 +203,8 @@ public class LinesTest {
         return new TypeSafeMatcher<Line<String>>() {
             @Override
             protected boolean matchesSafely(Line<String> stringLine) {
-                return left.equals(Optional.fromNullable(stringLine.getLeft())) &&
-                        right.equals(Optional.fromNullable(stringLine.getRight()));
+                return left.equals(Optional.fromNullable(stringLine.getLeft()))
+                        && right.equals(Optional.fromNullable(stringLine.getRight()));
             }
 
             @Override

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/lines/StepperTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/lines/StepperTest.java
@@ -1,23 +1,21 @@
 /*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * #%L
- *  * ACS AEM Commons Bundle
- *  * %%
- *  * Copyright (C) 2016 Adobe
- *  * %%
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
- *  * #L%
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.wcm.comparisons.impl.lines;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/model/PageCompareModelTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/model/PageCompareModelTest.java
@@ -1,23 +1,21 @@
 /*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * #%L
- *  * ACS AEM Commons Bundle
- *  * %%
- *  * Copyright (C) 2016 Adobe
- *  * %%
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
- *  * #L%
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.wcm.comparisons.model;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/AuthorUIHelperImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/AuthorUIHelperImplTest.java
@@ -72,46 +72,46 @@ public class AuthorUIHelperImplTest {
 
     @Test
     public void testGenerateEditPageLinkDefault() {
-        String TOUCH_PAGE_URL_REL = "/editor.html/content/main/testPage.html";
-        String TOUCH_PAGE_URL_ABS = "http://localhost:4502/editor.html/content/main/testPage.html";
-        when(externalizer.authorLink(null, TOUCH_PAGE_URL_REL)).thenReturn(TOUCH_PAGE_URL_ABS);
+        String touchPageUrlRel = "/editor.html/content/main/testPage.html";
+        String touchPageUrlAbs = "http://localhost:4502/editor.html/content/main/testPage.html";
+        when(externalizer.authorLink(null, touchPageUrlRel)).thenReturn(touchPageUrlAbs);
 
         authorUIHelper.activate(osgiConfig);
         String relAuthorPageLink = authorUIHelper.generateEditPageLink(pagePath, false, null);
         String absAuthorPageLink = authorUIHelper.generateEditPageLink(pagePath, true, null);
-        assertEquals(TOUCH_PAGE_URL_REL, relAuthorPageLink);
-        assertEquals(TOUCH_PAGE_URL_ABS, absAuthorPageLink);
+        assertEquals(touchPageUrlRel, relAuthorPageLink);
+        assertEquals(touchPageUrlAbs, absAuthorPageLink);
     }
 
     @Test
     public void testGenerateEditPageLinkOverride() {
-        String TOUCH_PAGE_URL_OVERRIDE = "/override.html/content/main/testPage.html";
+        String touchPageUrlOverride = "/override.html/content/main/testPage.html";
 
         //override touch ui page editor
         osgiConfig.put("wcmEditorTouchURL", "/override.html");
         authorUIHelper.activate(osgiConfig);
         String overrideAuthorPageLink = authorUIHelper.generateEditPageLink(pagePath, false, null);
-        assertEquals(TOUCH_PAGE_URL_OVERRIDE, overrideAuthorPageLink);
+        assertEquals(touchPageUrlOverride, overrideAuthorPageLink);
     }
 
     @Test
     public void testGenerateEditPageLinkClassic() {
-        String CLASSIC_PAGE_URL_REL = "/cf#/content/main/testPage.html";
-        String CLASSIC_PAGE_URL_ABS = "http://localhost:4502/cf#/content/main/testPage.html";
+        String classicPageUrlRel = "/cf#/content/main/testPage.html";
+        String classicPageUrlAbs = "http://localhost:4502/cf#/content/main/testPage.html";
 
-        when(externalizer.authorLink(null, CLASSIC_PAGE_URL_REL)).thenReturn(CLASSIC_PAGE_URL_ABS);
+        when(externalizer.authorLink(null, classicPageUrlRel)).thenReturn(classicPageUrlAbs);
         osgiConfig.put("isTouch", "false");
         authorUIHelper.activate(osgiConfig);
 
         String relAuthorPageLink = authorUIHelper.generateEditPageLink(pagePath, false, null);
         String absAuthorPageLink = authorUIHelper.generateEditPageLink(pagePath, true, null);
-        assertEquals(CLASSIC_PAGE_URL_REL, relAuthorPageLink);
-        assertEquals(CLASSIC_PAGE_URL_ABS, absAuthorPageLink);
+        assertEquals(classicPageUrlRel, relAuthorPageLink);
+        assertEquals(classicPageUrlAbs, absAuthorPageLink);
     }
 
     @Test
     public void testGenerateEditPageLinkOverrideClassic() {
-        String CLASSIC_PAGE_URL_OVERRIDE = "/override.html/content/main/testPage.html";
+        final String classicPageUrlOverride = "/override.html/content/main/testPage.html";
 
         //override classic ui page editor
         osgiConfig.put("isTouch", "false");
@@ -119,51 +119,51 @@ public class AuthorUIHelperImplTest {
 
         authorUIHelper.activate(osgiConfig);
         String overrideAuthorPageLink = authorUIHelper.generateEditPageLink(pagePath, false, null);
-        assertEquals(CLASSIC_PAGE_URL_OVERRIDE, overrideAuthorPageLink);
+        assertEquals(classicPageUrlOverride, overrideAuthorPageLink);
     }
 
     @Test
     public void testGenerateEditAssetLinkDefault() {
-        String TOUCH_ASSET_URL_REL = "/assetdetails.html/content/dam/testAsset.jpg";
-        String TOUCH_ASSET_URL_ABS = "http://localhost:4502/assetdetails.html/content/dam/testAsset.jpg";
-        when(externalizer.authorLink(null, TOUCH_ASSET_URL_REL)).thenReturn(TOUCH_ASSET_URL_ABS);
+        String touchAssetUrlRel = "/assetdetails.html/content/dam/testAsset.jpg";
+        String touchAssetUrlAbs = "http://localhost:4502/assetdetails.html/content/dam/testAsset.jpg";
+        when(externalizer.authorLink(null, touchAssetUrlRel)).thenReturn(touchAssetUrlAbs);
 
         authorUIHelper.activate(osgiConfig);
         String relAuthorAssetLink = authorUIHelper.generateEditAssetLink(assetPath, false, null);
         String absAuthorAssetLink = authorUIHelper.generateEditAssetLink(assetPath, true, null);
-        assertEquals(TOUCH_ASSET_URL_REL, relAuthorAssetLink);
-        assertEquals(TOUCH_ASSET_URL_ABS, absAuthorAssetLink);
+        assertEquals(touchAssetUrlRel, relAuthorAssetLink);
+        assertEquals(touchAssetUrlAbs, absAuthorAssetLink);
     }
 
     @Test
     public void testGenerateEditAssetLinkOverride() {
-        String TOUCH_ASSET_URL_OVERRIDE = "/override.html/content/dam/testAsset.jpg";
+        String touchAssetUrlOverride = "/override.html/content/dam/testAsset.jpg";
 
         //override touch ui page editor
         osgiConfig.put("damEditorTouchURL", "/override.html");
         authorUIHelper.activate(osgiConfig);
         String overrideAuthorPageLink = authorUIHelper.generateEditAssetLink(assetPath, false, null);
-        assertEquals(TOUCH_ASSET_URL_OVERRIDE, overrideAuthorPageLink);
+        assertEquals(touchAssetUrlOverride, overrideAuthorPageLink);
     }
 
     @Test
     public void testGenerateEditAssetLinkClassic() {
-        String CLASSIC_ASSET_URL_REL = "/damadmin#/content/dam/testAsset.jpg";
-        String CLASSIC_ASSET_URL_ABS = "http://localhost:4502/damadmin#/content/dam/testAsset.jpg";
+        String classicAssetUrlRel = "/damadmin#/content/dam/testAsset.jpg";
+        String classicAssetUrlAbs = "http://localhost:4502/damadmin#/content/dam/testAsset.jpg";
 
-        when(externalizer.authorLink(null, CLASSIC_ASSET_URL_REL)).thenReturn(CLASSIC_ASSET_URL_ABS);
+        when(externalizer.authorLink(null, classicAssetUrlRel)).thenReturn(classicAssetUrlAbs);
         osgiConfig.put("isTouch", "false");
         authorUIHelper.activate(osgiConfig);
 
         String relAuthorPageLink = authorUIHelper.generateEditAssetLink(assetPath, false, null);
         String absAuthorPageLink = authorUIHelper.generateEditAssetLink(assetPath, true, null);
-        assertEquals(CLASSIC_ASSET_URL_REL, relAuthorPageLink);
-        assertEquals(CLASSIC_ASSET_URL_ABS, absAuthorPageLink);
+        assertEquals(classicAssetUrlRel, relAuthorPageLink);
+        assertEquals(classicAssetUrlAbs, absAuthorPageLink);
     }
 
     @Test
     public void testGenerateAssetPageLinkOverrideClassic() {
-        String CLASSIC_ASSET_URL_OVERRIDE = "/override.html/content/dam/testAsset.jpg";
+        final String classicAssetUrlOverride = "/override.html/content/dam/testAsset.jpg";
 
         //override classic ui asset editor
         osgiConfig.put("isTouch", "false");
@@ -171,7 +171,7 @@ public class AuthorUIHelperImplTest {
 
         authorUIHelper.activate(osgiConfig);
         String overrideAuthorPageLink = authorUIHelper.generateEditAssetLink(assetPath, false, null);
-        assertEquals(CLASSIC_ASSET_URL_OVERRIDE, overrideAuthorPageLink);
+        assertEquals(classicAssetUrlOverride, overrideAuthorPageLink);
     }
 
     @After

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/CQIncludePropertyNamespaceServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/CQIncludePropertyNamespaceServletTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.wcm.impl;
 
 import com.day.cq.commons.jcr.JcrConstants;
@@ -14,6 +33,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
+@SuppressWarnings("checkstyle:abbreviationaswordinname")
 @RunWith(MockitoJUnitRunner.class)
 public class CQIncludePropertyNamespaceServletTest {
 
@@ -36,7 +56,7 @@ public class CQIncludePropertyNamespaceServletTest {
         final CQIncludePropertyNamespaceServlet servlet = new CQIncludePropertyNamespaceServlet();
         servlet.activate(config);
 
-        CQIncludePropertyNamespaceServlet.PropertyNamespaceUpdater visitor =
+        final CQIncludePropertyNamespaceServlet.PropertyNamespaceUpdater visitor =
                 servlet.new PropertyNamespaceUpdater("test");
 
         final JSONObject json = new JSONObject();
@@ -65,7 +85,7 @@ public class CQIncludePropertyNamespaceServletTest {
         final CQIncludePropertyNamespaceServlet servlet = new CQIncludePropertyNamespaceServlet();
         servlet.activate(config);
 
-        CQIncludePropertyNamespaceServlet.PropertyNamespaceUpdater visitor =
+        final CQIncludePropertyNamespaceServlet.PropertyNamespaceUpdater visitor =
                 servlet.new PropertyNamespaceUpdater("test");
 
         final JSONObject json = new JSONObject();
@@ -96,7 +116,7 @@ public class CQIncludePropertyNamespaceServletTest {
         final CQIncludePropertyNamespaceServlet servlet = new CQIncludePropertyNamespaceServlet();
         servlet.activate(config);
 
-        CQIncludePropertyNamespaceServlet.PropertyNamespaceUpdater visitor =
+        final CQIncludePropertyNamespaceServlet.PropertyNamespaceUpdater visitor =
                 servlet.new PropertyNamespaceUpdater("test");
 
         final JSONObject json = new JSONObject();
@@ -112,7 +132,7 @@ public class CQIncludePropertyNamespaceServletTest {
 
     @Test
     public void testIsCqincludeNamspaceWidget() throws JSONException {
-        CQIncludePropertyNamespaceServlet.PropertyNamespaceUpdater pnu = new CQIncludePropertyNamespaceServlet().new PropertyNamespaceUpdater("my-namespace");
+        final CQIncludePropertyNamespaceServlet.PropertyNamespaceUpdater pnu = new CQIncludePropertyNamespaceServlet().new PropertyNamespaceUpdater("my-namespace");
 
         final JSONObject json = new JSONObject();
 

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/FileImporterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/FileImporterTest.java
@@ -1,6 +1,6 @@
 /*
  * #%L
- * ACS AEM Tools Bundle
+ * ACS AEM Commons Bundle
  * %%
  * Copyright (C) 2014 Adobe
  * %%
@@ -93,9 +93,9 @@ public class FileImporterTest {
 
     @Test
     public void testImportToFolderHavingFileWhichIsOlder() throws Exception {
-        Calendar earliest = Calendar.getInstance();
+        final Calendar earliest = Calendar.getInstance();
         earliest.setTimeInMillis(0L);
-        Node file = JcrUtils.putFile(folder, testFile.getName(), "x-text/test", new ByteArrayInputStream("".getBytes()),
+        final Node file = JcrUtils.putFile(folder, testFile.getName(), "x-text/test", new ByteArrayInputStream("".getBytes()),
                 earliest);
 
         session.save();
@@ -111,9 +111,9 @@ public class FileImporterTest {
 
     @Test
     public void testImportToFolderHavingFileWhichIsNewer() throws Exception {
-        Calendar latest = Calendar.getInstance();
+        final Calendar latest = Calendar.getInstance();
         latest.add(Calendar.DATE, 2);
-        Node file = JcrUtils.putFile(folder, testFile.getName(), "x-text/test", new ByteArrayInputStream("".getBytes()),
+        final Node file = JcrUtils.putFile(folder, testFile.getName(), "x-text/test", new ByteArrayInputStream("".getBytes()),
                 latest);
 
         session.save();

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderMultiImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderMultiImplTest.java
@@ -43,13 +43,15 @@ public class PageRootProviderMultiImplTest {
     private PageRootProviderConfig config2;
 
     private static final Map<String, Object> FIRST = new HashMap<String, Object>(){{
-        this.put(Constants.SERVICE_RANKING, 1);
-        this.put(Constants.SERVICE_ID, 1l);
-    }};
+            this.put(Constants.SERVICE_RANKING, 1);
+            this.put(Constants.SERVICE_ID, 1L);
+        }
+    };
     private static final Map<String, Object> SECOND = new HashMap<String, Object>(){{
-        this.put(Constants.SERVICE_RANKING, 2);
-        this.put(Constants.SERVICE_ID, 2l);
-    }};
+            this.put(Constants.SERVICE_RANKING, 2);
+            this.put(Constants.SERVICE_ID, 2L);
+        }
+    };
 
     PageRootProviderMultiImpl provider = null;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/QrCodeServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/QrCodeServletTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.wcm.impl;
 
 import com.day.cq.commons.Externalizer;
@@ -38,7 +57,7 @@ public class QrCodeServletTest {
     MockSlingHttpServletResponse response;
     Resource requestResource;
 
-    String RESOURCE_PATH = "/etc/acs-commons/qr-code/_jcr_content/config";
+    static final String RESOURCE_PATH = "/etc/acs-commons/qr-code/_jcr_content/config";
 
     @Before
     public void setUp() throws Exception {

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/SiteMapServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/SiteMapServletTest.java
@@ -78,8 +78,9 @@ public class SiteMapServletTest {
     @Test
     public void testDefaultPageSetup() throws Exception {
         servlet.activate(new HashMap<String, Object>() {{
-            put("externalizer.domain", "external");
-        }});
+                put("externalizer.domain", "external");
+            }
+        });
 
         servlet.doGet(request, response);
 
@@ -93,9 +94,10 @@ public class SiteMapServletTest {
     @Test
     public void testExtensionlessPages() throws Exception {
         servlet.activate(new HashMap<String, Object>() {{
-            put("externalizer.domain", "external");
-            put("extensionless.urls", true);
-        }});
+                put("externalizer.domain", "external");
+                put("extensionless.urls", true);
+            }
+        });
 
         servlet.doGet(request, response);
 
@@ -109,10 +111,11 @@ public class SiteMapServletTest {
     @Test
     public void testExtensionlessAndSlashlessPages() throws Exception {
         servlet.activate(new HashMap<String, Object>() {{
-            put("externalizer.domain", "external");
-            put("extensionless.urls", true);
-            put("remove.slash", true);
-        }});
+                put("externalizer.domain", "external");
+                put("extensionless.urls", true);
+                put("remove.slash", true);
+            }
+        });
 
         servlet.doGet(request, response);
 

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/notifications/impl/SystemNotificationsImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/notifications/impl/SystemNotificationsImplTest.java
@@ -90,9 +90,9 @@ public class SystemNotificationsImplTest {
     @Test
     public void testOnAuthorEmptyNotificationsFolder() throws Exception {
         setAuthorRunmode();
-        aemContext.build().
-                resource("/etc/acs-commons/notifications", JCR_PRIMARYTYPE, NT_PAGE).
-                resource("jcr:content", JCR_PRIMARYTYPE, NT_UNSTRUCTURED);
+        aemContext.build()
+                .resource("/etc/acs-commons/notifications", JCR_PRIMARYTYPE, NT_PAGE)
+                .resource("jcr:content", JCR_PRIMARYTYPE, NT_UNSTRUCTURED);
         commit();
         aemContext.registerInjectActivateService(notifications);
         assertEquals(1, aemContext.getServices(EventHandler.class, null).length);
@@ -186,24 +186,24 @@ public class SystemNotificationsImplTest {
     };
 
     private void createEnabledNotification() throws PersistenceException {
-        aemContext.build().
-                resource("/etc/acs-commons/notifications", JCR_PRIMARYTYPE, NT_PAGE).
-                siblingsMode().
-                resource("jcr:content", JCR_PRIMARYTYPE, NT_UNSTRUCTURED).
-                hierarchyMode().
-                resource("enabled", JCR_PRIMARYTYPE, NT_PAGE).
-                resource("jcr:content", JCR_PRIMARYTYPE, NT_UNSTRUCTURED, "enabled", true, "cq:lastModified", zeroHour);
+        aemContext.build()
+                .resource("/etc/acs-commons/notifications", JCR_PRIMARYTYPE, NT_PAGE)
+                .siblingsMode()
+                .resource("jcr:content", JCR_PRIMARYTYPE, NT_UNSTRUCTURED)
+                .hierarchyMode()
+                .resource("enabled", JCR_PRIMARYTYPE, NT_PAGE)
+                .resource("jcr:content", JCR_PRIMARYTYPE, NT_UNSTRUCTURED, "enabled", true, "cq:lastModified", zeroHour);
         commit();
     }
 
     private void createDisabledNotification() throws PersistenceException {
-        aemContext.build().
-                resource("/etc/acs-commons/notifications", JCR_PRIMARYTYPE, NT_PAGE).
-                siblingsMode().
-                resource("jcr:content", JCR_PRIMARYTYPE, NT_UNSTRUCTURED).
-                hierarchyMode().
-                resource("disabled", JCR_PRIMARYTYPE, NT_PAGE).
-                resource("jcr:content", JCR_PRIMARYTYPE, NT_UNSTRUCTURED, "enabled", false, "cq:lastModified", zeroHour);
+        aemContext.build()
+                .resource("/etc/acs-commons/notifications", JCR_PRIMARYTYPE, NT_PAGE)
+                .siblingsMode()
+                .resource("jcr:content", JCR_PRIMARYTYPE, NT_UNSTRUCTURED)
+                .hierarchyMode()
+                .resource("disabled", JCR_PRIMARYTYPE, NT_PAGE)
+                .resource("jcr:content", JCR_PRIMARYTYPE, NT_UNSTRUCTURED, "enabled", false, "cq:lastModified", zeroHour);
         commit();
     }
 

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesBindingsValuesProviderTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesBindingsValuesProviderTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.wcm.properties.shared.impl;
 
 import static org.junit.Assert.assertEquals;
@@ -53,8 +72,8 @@ public class SharedComponentPropertiesBindingsValuesProviderTest {
     resourceResolver = mock(ResourceResolver.class);
     componentManager = mock(ComponentManager.class);
 
-    String globalPropsPath = SITE_ROOT + "/jcr:content/" + SharedComponentProperties.NN_GLOBAL_COMPONENT_PROPERTIES;
-    String sharedPropsPath = SITE_ROOT + "/jcr:content/" + SharedComponentProperties.NN_SHARED_COMPONENT_PROPERTIES +  "/"
+    final String globalPropsPath = SITE_ROOT + "/jcr:content/" + SharedComponentProperties.NN_GLOBAL_COMPONENT_PROPERTIES;
+    final String sharedPropsPath = SITE_ROOT + "/jcr:content/" + SharedComponentProperties.NN_SHARED_COMPONENT_PROPERTIES +  "/"
         + RESOURCE_TYPE;
 
     bindings.put("resource", resource);

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/vanity/impl/ExtensionlessRequestWrapperTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/vanity/impl/ExtensionlessRequestWrapperTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.wcm.vanity.impl;
 
 import io.wcm.testing.mock.aem.junit.AemContext;

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/vanity/impl/VanityURLServiceImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/vanity/impl/VanityURLServiceImplTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.wcm.vanity.impl;
 
 import io.wcm.testing.mock.aem.junit.AemContext;
@@ -21,6 +40,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@SuppressWarnings("checkstyle:abbreviationaswordinname")
 @RunWith(MockitoJUnitRunner.class)
 public class VanityURLServiceImplTest {
 

--- a/bundle/src/test/java/com/adobe/acs/commons/widgets/MultiFieldPanelWCMUseTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/widgets/MultiFieldPanelWCMUseTest.java
@@ -34,7 +34,9 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import javax.script.Bindings;
-import java.util.*;
+
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;

--- a/bundle/src/test/java/com/adobe/acs/commons/workflow/impl/WorkflowPackageManagerImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/workflow/impl/WorkflowPackageManagerImplTest.java
@@ -55,9 +55,9 @@ import static org.mockito.Mockito.when;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ResourceCollectionUtil.class, JcrUtil.class})
 public class WorkflowPackageManagerImplTest {
-    private final String NORMAL_PAGE_PATH = "/content/test";
-    private final String WORKFLOW_PACKAGE_PATH = "/etc/packages/test";
-    private final String[] PAYLOAD_PATHS = {"/content/one", "/content/two"};
+    private static final String NORMAL_PAGE_PATH = "/content/test";
+    private static final String WORKFLOW_PACKAGE_PATH = "/etc/packages/test";
+    private static final String[] PAYLOAD_PATHS = {"/content/one", "/content/two"};
 
     @Mock
     ResourceCollectionManager resourceCollectionManager;

--- a/bundle/src/test/java/com/adobe/acs/commons/workflow/process/impl/BrandPortalSyncProcessTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/workflow/process/impl/BrandPortalSyncProcessTest.java
@@ -92,6 +92,7 @@ public class BrandPortalSyncProcessTest {
     List<String> paths;
 
     String assetPath = "/content/dam/foo.png";
+
     @Before
     public void setUp() throws Exception {
         PowerMockito.mockStatic(DamUtil.class);

--- a/bundle/src/test/java/com/adobe/acs/commons/workflow/process/impl/ReplicateWithOptionsWorkflowProcessTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/workflow/process/impl/ReplicateWithOptionsWorkflowProcessTest.java
@@ -1,8 +1,228 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.workflow.process.impl;
 
-/**
- * Created by dgonzale on 5/16/17.
- */
+import com.adobe.acs.commons.fam.ThrottledTaskRunner;
+import com.adobe.acs.commons.replication.BrandPortalAgentFilter;
+import com.adobe.acs.commons.util.WorkflowHelper;
+import com.adobe.acs.commons.workflow.WorkflowPackageManager;
+import com.day.cq.replication.Agent;
+import com.day.cq.replication.ReplicationActionType;
+import com.day.cq.replication.ReplicationOptions;
+import com.day.cq.replication.Replicator;
+import com.day.cq.workflow.WorkflowException;
+import com.day.cq.workflow.WorkflowSession;
+import com.day.cq.workflow.exec.WorkItem;
+import com.day.cq.workflow.exec.WorkflowData;
+import com.day.cq.workflow.metadata.MetaDataMap;
+import io.wcm.testing.mock.aem.junit.AemContext;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
 public class ReplicateWithOptionsWorkflowProcessTest {
 
+    @Rule
+    public final AemContext context = new AemContext(ResourceResolverType.JCR_MOCK);
+
+    @Mock
+    private WorkflowPackageManager workflowPackageManager;
+
+    @Mock
+    private Replicator replicator;
+
+    @Mock
+    private ThrottledTaskRunner throttledTaskRunner;
+
+    @Mock
+    private WorkflowHelper workflowHelper;
+
+    @Mock
+    private WorkItem workItem;
+
+    @Mock
+    private WorkflowData workflowData;
+
+    @Mock
+    private WorkflowSession workflowSession;
+
+    @Mock
+    private MetaDataMap metaDataMap;
+
+    @InjectMocks
+    private ReplicateWithOptionsWorkflowProcess process = new ReplicateWithOptionsWorkflowProcess();
+
+    @Before
+    public void setup() throws Exception {
+        context.load().json(getClass().getResourceAsStream("ReplicateWithOptionsWorkflowProcessTest.json"), "/content");
+
+        when(workflowHelper.getResourceResolver(workflowSession)).thenReturn(context.resourceResolver());
+        when(workItem.getWorkflowData()).thenReturn(workflowData);
+
+        when(workflowData.getPayload()).thenReturn("/content/payload");
+    }
+
+    @Test
+    public void testExecuteDeactivateWithoutTraversal() throws Exception {
+        when(workflowPackageManager.getPaths(context.resourceResolver(), "/content/payload"))
+                .thenReturn(Arrays.asList("/content/page", "/content/asset"));
+
+        StringBuilder args = new StringBuilder();
+        args.append("replicationActionType=Deactivate");
+        args.append(System.lineSeparator());
+        args.append("agents=agent1");
+
+        when(metaDataMap.get(WorkflowHelper.PROCESS_ARGS, "")).thenReturn(args.toString());
+        process.execute(workItem, workflowSession, metaDataMap);
+
+        ReplicationOptionsMatcher optionsMatcher = new ReplicationOptionsMatcher().withAgentIdFilter("agent1");
+
+        verify(replicator).replicate(any(), eq(ReplicationActionType.DEACTIVATE), eq("/content/page"), argThat(optionsMatcher));
+        verify(replicator).replicate(any(), eq(ReplicationActionType.DEACTIVATE), eq("/content/asset"), argThat(optionsMatcher));
+        verifyNoMoreInteractions(replicator);
+        verifyZeroInteractions(throttledTaskRunner);
+    }
+
+    @Test
+    public void testExecuteDeactivateWithThrottling() throws Exception {
+        when(workflowPackageManager.getPaths(context.resourceResolver(), "/content/payload"))
+                .thenReturn(Arrays.asList("/content/page", "/content/asset"));
+
+        StringBuilder args = new StringBuilder();
+        args.append("replicationActionType=Deactivate");
+        args.append(System.lineSeparator());
+        args.append("agents=agent1");
+        args.append(System.lineSeparator());
+        args.append("throttle=true");
+
+        when(metaDataMap.get(WorkflowHelper.PROCESS_ARGS, "")).thenReturn(args.toString());
+        process.execute(workItem, workflowSession, metaDataMap);
+
+        ReplicationOptionsMatcher optionsMatcher = new ReplicationOptionsMatcher().withAgentIdFilter("agent1");
+
+        verify(replicator).replicate(any(), eq(ReplicationActionType.DEACTIVATE), eq("/content/page"), argThat(optionsMatcher));
+        verify(replicator).replicate(any(), eq(ReplicationActionType.DEACTIVATE), eq("/content/asset"), argThat(optionsMatcher));
+        verify(throttledTaskRunner, times(2)).waitForLowCpuAndLowMemory();
+        verifyNoMoreInteractions(replicator, throttledTaskRunner);
+    }
+
+    @Test
+    public void testExecuteDeactivateWithTraversal() throws Exception {
+        when(workflowPackageManager.getPaths(context.resourceResolver(), "/content/payload"))
+                .thenReturn(Arrays.asList("/content/page", "/content/asset"));
+
+        StringBuilder args = new StringBuilder();
+        args.append("replicationActionType=Deactivate");
+        args.append(System.lineSeparator());
+        args.append("agents=agent1");
+        args.append(System.lineSeparator());
+        args.append("traverseTree=true");
+
+        when(metaDataMap.get(WorkflowHelper.PROCESS_ARGS, "")).thenReturn(args.toString());
+        process.execute(workItem, workflowSession, metaDataMap);
+
+        ReplicationOptionsMatcher optionsMatcher = new ReplicationOptionsMatcher().withAgentIdFilter("agent1");
+
+        verify(replicator).replicate(any(), eq(ReplicationActionType.DEACTIVATE), eq("/content/page"), argThat(optionsMatcher));
+        verify(replicator).replicate(any(), eq(ReplicationActionType.DEACTIVATE), eq("/content/page/child1"), argThat(optionsMatcher));
+        verify(replicator).replicate(any(), eq(ReplicationActionType.DEACTIVATE), eq("/content/page/child2"), argThat(optionsMatcher));
+        verify(replicator).replicate(any(), eq(ReplicationActionType.DEACTIVATE), eq("/content/asset"), argThat(optionsMatcher));
+        verifyNoMoreInteractions(replicator);
+        verifyZeroInteractions(throttledTaskRunner);
+    }
+
+    @Test(expected = WorkflowException.class)
+    public void testExceptionWithNoType() throws Exception {
+        StringBuilder args = new StringBuilder();
+        args.append("agents=agent1");
+        args.append(System.lineSeparator());
+        args.append("traverseTree=true");
+
+        when(metaDataMap.get(WorkflowHelper.PROCESS_ARGS, "")).thenReturn(args.toString());
+        process.execute(workItem, workflowSession, metaDataMap);
+    }
+
+    @Test
+    public void testExecuteBrandPortal() throws Exception {
+        when(workflowPackageManager.getPaths(context.resourceResolver(), "/content/payload"))
+                .thenReturn(Arrays.asList("/content/asset"));
+
+        StringBuilder args = new StringBuilder();
+        args.append("replicationActionType=Deactivate");
+        args.append(System.lineSeparator());
+        args.append("agents=BRAND_PORTAL_AGENTS");
+
+        when(metaDataMap.get(WorkflowHelper.PROCESS_ARGS, "")).thenReturn(args.toString());
+        process.execute(workItem, workflowSession, metaDataMap);
+
+        ReplicationOptionsMatcher optionsMatcher = new ReplicationOptionsMatcher().withBrandPortalFilter();
+
+        verify(replicator).replicate(any(), eq(ReplicationActionType.DEACTIVATE), eq("/content/asset"), argThat(optionsMatcher));
+        verifyNoMoreInteractions(replicator);
+        verifyZeroInteractions(throttledTaskRunner);
+    }
+
+    private static class ReplicationOptionsMatcher extends ArgumentMatcher<ReplicationOptions> {
+
+        private String filterAgentId;
+        private boolean brandPortalFilter;
+
+        public ReplicationOptionsMatcher withAgentIdFilter(String filterAgentId) {
+            this.filterAgentId = filterAgentId;
+            return this;
+        }
+
+        public ReplicationOptionsMatcher withBrandPortalFilter() {
+            this.brandPortalFilter = true;
+            return this;
+        }
+
+        @Override
+        public boolean matches(Object argument) {
+            if (argument instanceof ReplicationOptions) {
+                ReplicationOptions options = (ReplicationOptions) argument;
+                boolean matches = true;
+                if (filterAgentId != null) {
+                    Agent agent = mock(Agent.class);
+                    when(agent.getId()).thenReturn(filterAgentId);
+                    matches = matches && options.getFilter().isIncluded(agent);
+                }
+                if (brandPortalFilter) {
+                    matches = matches && options.getFilter() instanceof BrandPortalAgentFilter;
+                }
+                return matches;
+            } else {
+                return false;
+            }
+        }
+
+    }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/DeprecatedSyntheticCqWorkflowRunnerImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/DeprecatedSyntheticCqWorkflowRunnerImplTest.java
@@ -26,8 +26,8 @@ import com.adobe.acs.commons.workflow.synthetic.impl.cqtestprocesses.RestartWork
 import com.adobe.acs.commons.workflow.synthetic.impl.cqtestprocesses.SetDataWorkflowProcess;
 import com.adobe.acs.commons.workflow.synthetic.impl.cqtestprocesses.TerminateDataWorkflowProcess;
 import com.adobe.acs.commons.workflow.synthetic.impl.cqtestprocesses.UpdateWorkflowDataWorkflowProcess;
-import com.adobe.acs.commons.workflow.synthetic.impl.cqtestprocesses.WFArgsWorkflowProcess;
-import com.adobe.acs.commons.workflow.synthetic.impl.cqtestprocesses.WFDataWorkflowProcess;
+import com.adobe.acs.commons.workflow.synthetic.impl.cqtestprocesses.WfArgsWorkflowProcess;
+import com.adobe.acs.commons.workflow.synthetic.impl.cqtestprocesses.WfDataWorkflowProcess;
 import com.day.cq.workflow.WorkflowSession;
 import com.day.cq.workflow.exec.WorkItem;
 import com.day.cq.workflow.metadata.MetaDataMap;
@@ -65,11 +65,11 @@ public class DeprecatedSyntheticCqWorkflowRunnerImplTest {
     }
 
     @Test
-    public void testExecute_WFData() throws Exception {
+    public void testExecute_WfData() throws Exception {
         Map<Object, Object> map = new HashMap<Object, Object>();
 
         map.put("process.label", "test");
-        swr.bindCqWorkflowProcesses(new WFDataWorkflowProcess(), map);
+        swr.bindCqWorkflowProcesses(new WfDataWorkflowProcess(), map);
 
         Map<String, Map<String, Object>> metadata = new HashMap<String, Map<String, Object>>();
 
@@ -123,7 +123,7 @@ public class DeprecatedSyntheticCqWorkflowRunnerImplTest {
 
         Map<Object, Object> map = new HashMap<Object, Object>();
         map.put("process.label", "wf-args");
-        swr.bindCqWorkflowProcesses(new WFArgsWorkflowProcess(wfArgs), map);
+        swr.bindCqWorkflowProcesses(new WfArgsWorkflowProcess(wfArgs), map);
 
         /** WF Process Metadata */
         Map<String, Map<String, Object>> metadata = new HashMap<String, Map<String, Object>>();

--- a/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/DeprecatedSyntheticGraniteWorkflowRunnerImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/DeprecatedSyntheticGraniteWorkflowRunnerImplTest.java
@@ -26,8 +26,8 @@ import com.adobe.acs.commons.workflow.synthetic.impl.granitetestprocesses.Restar
 import com.adobe.acs.commons.workflow.synthetic.impl.granitetestprocesses.SetDataWorkflowProcess;
 import com.adobe.acs.commons.workflow.synthetic.impl.granitetestprocesses.TerminateDataWorkflowProcess;
 import com.adobe.acs.commons.workflow.synthetic.impl.granitetestprocesses.UpdateWorkflowDataWorkflowProcess;
-import com.adobe.acs.commons.workflow.synthetic.impl.granitetestprocesses.WFArgsWorkflowProcess;
-import com.adobe.acs.commons.workflow.synthetic.impl.granitetestprocesses.WFDataWorkflowProcess;
+import com.adobe.acs.commons.workflow.synthetic.impl.granitetestprocesses.WfArgsWorkflowProcess;
+import com.adobe.acs.commons.workflow.synthetic.impl.granitetestprocesses.WfDataWorkflowProcess;
 
 import com.adobe.granite.workflow.WorkflowSession;
 import com.adobe.granite.workflow.exec.WorkItem;
@@ -66,11 +66,11 @@ public class DeprecatedSyntheticGraniteWorkflowRunnerImplTest {
     }
 
     @Test
-    public void testExecute_WFData() throws Exception {
+    public void testExecute_WfData() throws Exception {
         Map<Object, Object> map = new HashMap<Object, Object>();
 
         map.put("process.label", "test");
-        swr.bindGraniteWorkflowProcesses(new WFDataWorkflowProcess(), map);
+        swr.bindGraniteWorkflowProcesses(new WfDataWorkflowProcess(), map);
 
         Map<String, Map<String, Object>> metadata = new HashMap<String, Map<String, Object>>();
 
@@ -124,7 +124,7 @@ public class DeprecatedSyntheticGraniteWorkflowRunnerImplTest {
 
         Map<Object, Object> map = new HashMap<Object, Object>();
         map.put("process.label", "wf-args");
-        swr.bindGraniteWorkflowProcesses(new WFArgsWorkflowProcess(wfArgs), map);
+        swr.bindGraniteWorkflowProcesses(new WfArgsWorkflowProcess(wfArgs), map);
 
         /** WF Process Metadata */
 

--- a/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticCqWorkflowRunnerImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticCqWorkflowRunnerImplTest.java
@@ -28,8 +28,8 @@ import com.adobe.acs.commons.workflow.synthetic.impl.cqtestprocesses.RestartWork
 import com.adobe.acs.commons.workflow.synthetic.impl.cqtestprocesses.SetDataWorkflowProcess;
 import com.adobe.acs.commons.workflow.synthetic.impl.cqtestprocesses.TerminateDataWorkflowProcess;
 import com.adobe.acs.commons.workflow.synthetic.impl.cqtestprocesses.UpdateWorkflowDataWorkflowProcess;
-import com.adobe.acs.commons.workflow.synthetic.impl.cqtestprocesses.WFArgsWorkflowProcess;
-import com.adobe.acs.commons.workflow.synthetic.impl.cqtestprocesses.WFDataWorkflowProcess;
+import com.adobe.acs.commons.workflow.synthetic.impl.cqtestprocesses.WfArgsWorkflowProcess;
+import com.adobe.acs.commons.workflow.synthetic.impl.cqtestprocesses.WfDataWorkflowProcess;
 import com.day.cq.workflow.WorkflowSession;
 import com.day.cq.workflow.exec.WorkItem;
 import com.day.cq.workflow.metadata.MetaDataMap;
@@ -72,11 +72,11 @@ public class SyntheticCqWorkflowRunnerImplTest {
     }
 
     @Test
-    public void testExecute_WFData() throws Exception {
+    public void testExecute_WfData() throws Exception {
         Map<Object, Object> map = new HashMap<Object, Object>();
 
         map.put("process.label", "test");
-        swr.bindCqWorkflowProcesses(new WFDataWorkflowProcess(), map);
+        swr.bindCqWorkflowProcesses(new WfDataWorkflowProcess(), map);
 
         workflowSteps.add(swr.getSyntheticWorkflowStep("test",
                 SyntheticWorkflowRunner.WorkflowProcessIdType.PROCESS_LABEL));
@@ -134,7 +134,7 @@ public class SyntheticCqWorkflowRunnerImplTest {
 
         Map<Object, Object> map = new HashMap<Object, Object>();
         map.put("process.label", "wf-args");
-        swr.bindCqWorkflowProcesses(new WFArgsWorkflowProcess(wfArgs), map);
+        swr.bindCqWorkflowProcesses(new WfArgsWorkflowProcess(wfArgs), map);
 
         workflowSteps.add(swr.getSyntheticWorkflowStep("wf-args",
                 SyntheticWorkflowRunner.WorkflowProcessIdType.PROCESS_LABEL,
@@ -246,10 +246,10 @@ public class SyntheticCqWorkflowRunnerImplTest {
 
         final Map<Object, Object> map = new HashMap<Object, Object>();
         map.put("process.label", "multi1");
-        swr.bindCqWorkflowProcesses(new WFArgsWorkflowProcess(wfArgs1), map);
+        swr.bindCqWorkflowProcesses(new WfArgsWorkflowProcess(wfArgs1), map);
 
         map.put("process.label", "multi2");
-        swr.bindCqWorkflowProcesses(new WFArgsWorkflowProcess(wfArgs2), map);
+        swr.bindCqWorkflowProcesses(new WfArgsWorkflowProcess(wfArgs2), map);
 
         workflowSteps.add(swr.getSyntheticWorkflowStep("multi1",
                 SyntheticWorkflowRunner.WorkflowProcessIdType.PROCESS_LABEL,

--- a/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticGraniteWorkflowRunnerImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticGraniteWorkflowRunnerImplTest.java
@@ -28,8 +28,8 @@ import com.adobe.acs.commons.workflow.synthetic.impl.granitetestprocesses.Restar
 import com.adobe.acs.commons.workflow.synthetic.impl.granitetestprocesses.SetDataWorkflowProcess;
 import com.adobe.acs.commons.workflow.synthetic.impl.granitetestprocesses.TerminateDataWorkflowProcess;
 import com.adobe.acs.commons.workflow.synthetic.impl.granitetestprocesses.UpdateWorkflowDataWorkflowProcess;
-import com.adobe.acs.commons.workflow.synthetic.impl.granitetestprocesses.WFArgsWorkflowProcess;
-import com.adobe.acs.commons.workflow.synthetic.impl.granitetestprocesses.WFDataWorkflowProcess;
+import com.adobe.acs.commons.workflow.synthetic.impl.granitetestprocesses.WfArgsWorkflowProcess;
+import com.adobe.acs.commons.workflow.synthetic.impl.granitetestprocesses.WfDataWorkflowProcess;
 
 import com.adobe.granite.workflow.WorkflowSession;
 import com.adobe.granite.workflow.exec.WorkItem;
@@ -73,11 +73,11 @@ public class SyntheticGraniteWorkflowRunnerImplTest {
     }
 
     @Test
-    public void testExecute_WFData() throws Exception {
+    public void testExecute_WfData() throws Exception {
         Map<Object, Object> map = new HashMap<Object, Object>();
 
         map.put("process.label", "test");
-        swr.bindGraniteWorkflowProcesses(new WFDataWorkflowProcess(), map);
+        swr.bindGraniteWorkflowProcesses(new WfDataWorkflowProcess(), map);
 
         workflowSteps.add(swr.getSyntheticWorkflowStep("test",
                 SyntheticWorkflowRunner.WorkflowProcessIdType.PROCESS_LABEL));
@@ -134,7 +134,7 @@ public class SyntheticGraniteWorkflowRunnerImplTest {
 
         Map<Object, Object> map = new HashMap<Object, Object>();
         map.put("process.label", "wf-args");
-        swr.bindGraniteWorkflowProcesses(new WFArgsWorkflowProcess(wfArgs), map);
+        swr.bindGraniteWorkflowProcesses(new WfArgsWorkflowProcess(wfArgs), map);
 
         /** WF Process Metadata */
         workflowSteps.add(swr.getSyntheticWorkflowStep("wf-args",
@@ -244,10 +244,10 @@ public class SyntheticGraniteWorkflowRunnerImplTest {
 
         final Map<Object, Object> map = new HashMap<Object, Object>();
         map.put("process.label", "multi1");
-        swr.bindGraniteWorkflowProcesses(new WFArgsWorkflowProcess(wfArgs1), map);
+        swr.bindGraniteWorkflowProcesses(new WfArgsWorkflowProcess(wfArgs1), map);
 
         map.put("process.label", "multi2");
-        swr.bindGraniteWorkflowProcesses(new WFArgsWorkflowProcess(wfArgs2), map);
+        swr.bindGraniteWorkflowProcesses(new WfArgsWorkflowProcess(wfArgs2), map);
 
         workflowSteps.add(swr.getSyntheticWorkflowStep("multi1",
                 SyntheticWorkflowRunner.WorkflowProcessIdType.PROCESS_LABEL,

--- a/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowStepImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/SyntheticWorkflowStepImplTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.workflow.synthetic.impl;
 
 import com.adobe.acs.commons.workflow.synthetic.SyntheticWorkflowRunner;

--- a/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/cq/SyntheticWorkflowSessionTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/cq/SyntheticWorkflowSessionTest.java
@@ -36,8 +36,8 @@ import static org.mockito.Mockito.mock;
 public class SyntheticWorkflowSessionTest {
     @Test
     public void test_updateWorkflowData() throws Exception {
-        SyntheticWorkflowSession session = new SyntheticWorkflowSession(new SyntheticWorkflowRunnerImpl(), mock(Session.class));
-        SyntheticWorkflowData workflowData = new SyntheticWorkflowData("JCR_PATH", "/content/test");
+        final SyntheticWorkflowSession session = new SyntheticWorkflowSession(new SyntheticWorkflowRunnerImpl(), mock(Session.class));
+        final SyntheticWorkflowData workflowData = new SyntheticWorkflowData("JCR_PATH", "/content/test");
 
         workflowData.getMetaDataMap().put("cat", "meow");
         workflowData.getMetaDataMap().put("bird", "ka-kaw");

--- a/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/cqtestprocesses/WfArgsWorkflowProcess.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/cqtestprocesses/WfArgsWorkflowProcess.java
@@ -29,26 +29,23 @@ import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class WFDataWorkflowProcess implements WorkflowProcess {
-    private static final Logger log = LoggerFactory.getLogger(WFDataWorkflowProcess.class);
+import java.util.Map;
 
-    public WFDataWorkflowProcess() {
+public class WfArgsWorkflowProcess implements WorkflowProcess {
+    private static final Logger log = LoggerFactory.getLogger(WfArgsWorkflowProcess.class);
 
+    Map<String, Object> expected;
+
+    public WfArgsWorkflowProcess(Map<String, Object> expected) {
+        this.expected = expected;
     }
 
     @Override
     public void execute(WorkItem workItem, WorkflowSession workflowSession, MetaDataMap metaDataMap) throws WorkflowException {
         // Workflow Data
-        Assert.assertEquals("JCR_PATH", workItem.getWorkflowData().getPayloadType());
-        Assert.assertEquals("/content/test", workItem.getWorkflowData().getPayload());
-
-        // Workitem
-        Assert.assertTrue(workItem.getId().matches("[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}_.+"));
-        Assert.assertEquals(null, workItem.getNode());
-        Assert.assertTrue(workItem.getTimeStarted() != null);
-        Assert.assertTrue(workItem.getTimeEnded() == null);
-        Assert.assertTrue(workItem.getWorkflow() != null);
-        Assert.assertEquals("Synthetic Workflow", workItem.getCurrentAssignee());
-
+        for (final Map.Entry<String, Object> entry : expected.entrySet()) {
+            Assert.assertEquals(entry.getValue(),
+                    metaDataMap.get(entry.getKey(), String.class));
+        }
     }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/cqtestprocesses/WfDataWorkflowProcess.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/cqtestprocesses/WfDataWorkflowProcess.java
@@ -19,7 +19,6 @@
  */
 
 package com.adobe.acs.commons.workflow.synthetic.impl.cqtestprocesses;
-
 import com.day.cq.workflow.WorkflowException;
 import com.day.cq.workflow.WorkflowSession;
 import com.day.cq.workflow.exec.WorkItem;
@@ -29,22 +28,26 @@ import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
+public class WfDataWorkflowProcess implements WorkflowProcess {
+    private static final Logger log = LoggerFactory.getLogger(WfDataWorkflowProcess.class);
 
-public class WFArgsWorkflowProcess implements WorkflowProcess {
-    private static final Logger log = LoggerFactory.getLogger(WFArgsWorkflowProcess.class);
+    public WfDataWorkflowProcess() {
 
-    Map<String, Object> expected;
-    public WFArgsWorkflowProcess(Map<String, Object> expected) {
-        this.expected = expected;
     }
 
     @Override
     public void execute(WorkItem workItem, WorkflowSession workflowSession, MetaDataMap metaDataMap) throws WorkflowException {
         // Workflow Data
-        for (final Map.Entry<String, Object> entry : expected.entrySet()) {
-            Assert.assertEquals(entry.getValue(),
-                    metaDataMap.get(entry.getKey(), String.class));
-        }
+        Assert.assertEquals("JCR_PATH", workItem.getWorkflowData().getPayloadType());
+        Assert.assertEquals("/content/test", workItem.getWorkflowData().getPayload());
+
+        // Workitem
+        Assert.assertTrue(workItem.getId().matches("[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}_.+"));
+        Assert.assertEquals(null, workItem.getNode());
+        Assert.assertTrue(workItem.getTimeStarted() != null);
+        Assert.assertTrue(workItem.getTimeEnded() == null);
+        Assert.assertTrue(workItem.getWorkflow() != null);
+        Assert.assertEquals("Synthetic Workflow", workItem.getCurrentAssignee());
+
     }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/granitetestprocesses/WfArgsWorkflowProcess.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/granitetestprocesses/WfArgsWorkflowProcess.java
@@ -29,26 +29,23 @@ import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class WFDataWorkflowProcess implements WorkflowProcess {
-    private static final Logger log = LoggerFactory.getLogger(WFDataWorkflowProcess.class);
+import java.util.Map;
 
-    public WFDataWorkflowProcess() {
+public class WfArgsWorkflowProcess implements WorkflowProcess {
+    private static final Logger log = LoggerFactory.getLogger(WfArgsWorkflowProcess.class);
 
+    Map<String, Object> expected;
+
+    public WfArgsWorkflowProcess(Map<String, Object> expected) {
+        this.expected = expected;
     }
 
     @Override
     public void execute(WorkItem workItem, WorkflowSession workflowSession, MetaDataMap metaDataMap) throws WorkflowException {
         // Workflow Data
-        Assert.assertEquals("JCR_PATH", workItem.getWorkflowData().getPayloadType());
-        Assert.assertEquals("/content/test", workItem.getWorkflowData().getPayload());
-
-        // Workitem
-        Assert.assertTrue(workItem.getId().matches("[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}_.+"));
-        Assert.assertEquals(null, workItem.getNode());
-        Assert.assertTrue(workItem.getTimeStarted() != null);
-        Assert.assertTrue(workItem.getTimeEnded() == null);
-        Assert.assertTrue(workItem.getWorkflow() != null);
-        Assert.assertEquals("Synthetic Workflow", workItem.getCurrentAssignee());
-
+        for (final Map.Entry<String, Object> entry : expected.entrySet()) {
+            Assert.assertEquals(entry.getValue(),
+                    metaDataMap.get(entry.getKey(), String.class));
+        }
     }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/granitetestprocesses/WfDataWorkflowProcess.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/workflow/synthetic/impl/granitetestprocesses/WfDataWorkflowProcess.java
@@ -29,22 +29,26 @@ import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
+public class WfDataWorkflowProcess implements WorkflowProcess {
+    private static final Logger log = LoggerFactory.getLogger(WfDataWorkflowProcess.class);
 
-public class WFArgsWorkflowProcess implements WorkflowProcess {
-    private static final Logger log = LoggerFactory.getLogger(WFArgsWorkflowProcess.class);
+    public WfDataWorkflowProcess() {
 
-    Map<String, Object> expected;
-    public WFArgsWorkflowProcess(Map<String, Object> expected) {
-        this.expected = expected;
     }
 
     @Override
     public void execute(WorkItem workItem, WorkflowSession workflowSession, MetaDataMap metaDataMap) throws WorkflowException {
         // Workflow Data
-        for (final Map.Entry<String, Object> entry : expected.entrySet()) {
-            Assert.assertEquals(entry.getValue(),
-                    metaDataMap.get(entry.getKey(), String.class));
-        }
+        Assert.assertEquals("JCR_PATH", workItem.getWorkflowData().getPayloadType());
+        Assert.assertEquals("/content/test", workItem.getWorkflowData().getPayload());
+
+        // Workitem
+        Assert.assertTrue(workItem.getId().matches("[a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12}_.+"));
+        Assert.assertEquals(null, workItem.getNode());
+        Assert.assertTrue(workItem.getTimeStarted() != null);
+        Assert.assertTrue(workItem.getTimeEnded() == null);
+        Assert.assertTrue(workItem.getWorkflow() != null);
+        Assert.assertEquals("Synthetic Workflow", workItem.getCurrentAssignee());
+
     }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/xss/XSSFunctionsTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/xss/XSSFunctionsTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.*;
  * Note - these do not test the actual XSS functionality. They only test that
  * the EL functions pass through to XSSAPI correctly.
  */
+@SuppressWarnings("checkstyle:abbreviationaswordinname")
 @RunWith(MockitoJUnitRunner.class)
 public class XSSFunctionsTest {
 

--- a/bundle/src/test/resources/com/adobe/acs/commons/workflow/process/impl/ReplicateWithOptionsWorkflowProcessTest.json
+++ b/bundle/src/test/resources/com/adobe/acs/commons/workflow/process/impl/ReplicateWithOptionsWorkflowProcessTest.json
@@ -1,0 +1,27 @@
+{
+  "page" : {
+    "jcr:primaryType" : "cq:Page",
+    "jcr:content" : {
+      "jcr:primaryType" : "nt:unstructured"
+    },
+    "child1" : {
+      "jcr:primaryType": "cq:Page",
+      "jcr:content": {
+        "jcr:primaryType": "nt:unstructured"
+      }
+    },
+    "child2" : {
+      "jcr:primaryType": "cq:Page",
+      "jcr:content": {
+        "jcr:primaryType": "nt:unstructured"
+      }
+    }
+  },
+  "asset" : {
+    "jcr:primaryType" : "dam:Asset",
+    "jcr:content" : {
+      "jcr:primaryType" : "nt:unstructured"
+    },
+    "mpConfig" : "/content/mpConfig"
+  }
+}


### PR DESCRIPTION
With the recent changes to allow codeclimate/checkstyle to look for the license header, it seems to make sense to also run those checks on the test suite. With this change, Sonar is still not run on the test suite, only Checkstyle and PMD.

This pull request also fixes all of the open checkstyle issues (including adding the license headers of course). It also includes a unit test for `ReplicateWithOptionsWorkflowProcess` as I noticed there was a test class already, but it was empty.