### PR TITLE
replacing folder node name default character with hyphen

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestor.java
@@ -438,7 +438,7 @@ public abstract class AssetIngestor extends ProcessDefinition {
                 String extension = StringUtils.substringAfterLast(name, ".");
                 return JcrUtil.createValidName(baseName) + "." + JcrUtil.createValidName(extension);
             } else {
-                return JcrUtil.createValidName(name);
+                return JcrUtil.createValidName(name,JcrUtil.HYPHEN_LABEL_CHAR_MAPPING,"-");
             }
         }
     }


### PR DESCRIPTION
@badvision 
Modified code to create folder node names with "-" as separator instead of "_". Please review.