### PR TITLE
added jmx bean to on-deploy scripts.  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ### Changed
 - #1343 - CodeClimate now checks for license header
+- #1354 - Added JMX Bean for monitoring and executing on-dploy scripts  
 
 ## [3.15.2] - 2018-04-25
 

--- a/bundle/src/main/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutor.java
@@ -25,9 +25,6 @@ import javax.management.openmbean.TabularDataSupport;
 import com.adobe.granite.jmx.annotation.Description;
 import com.adobe.granite.jmx.annotation.Name;
 
-import aQute.bnd.annotation.ProviderType;
-
-@ProviderType
 @Description("ACS AEM Commons - On Deploy Script Executor MBean")
 public interface OnDeployExecutor {
 
@@ -36,6 +33,6 @@ public interface OnDeployExecutor {
 
     @Description("Execute the script, given it's fully-qualified class name.  If force==true, script is executed even if it has previously succeeded.")
     void executeScript(@Name(value = "scriptName") String scriptName,
-                    @Name(value = "force") boolean force);
+ @Name(value = "force") boolean force);
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutor.java
@@ -1,0 +1,41 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.ondeploy.impl;
+
+import javax.management.openmbean.OpenDataException;
+import javax.management.openmbean.TabularDataSupport;
+
+import com.adobe.granite.jmx.annotation.Description;
+import com.adobe.granite.jmx.annotation.Name;
+
+import aQute.bnd.annotation.ProviderType;
+
+@ProviderType
+@Description("ACS AEM Commons - On Deploy Script Executor MBean")
+public interface OnDeployExecutor {
+
+    @Description("Scripts")
+    TabularDataSupport getScripts() throws OpenDataException;
+
+    @Description("Execute the script, given it's fully-qualified class name.  If force==true, script is executed even if it has previously succeeded.")
+    void executeScript(@Name(value = "scriptName") String scriptName,
+                    @Name(value = "force") boolean force);
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutor.java
@@ -32,7 +32,7 @@ public interface OnDeployExecutor {
     TabularDataSupport getScripts() throws OpenDataException;
 
     @Description("Execute the script, given it's fully-qualified class name.  If force==true, script is executed even if it has previously succeeded.")
-    void executeScript(@Name(value = "scriptName") String scriptName,
- @Name(value = "force") boolean force);
+    boolean executeScript(@Name(value = "scriptName") String scriptName,
+            @Name(value = "force") boolean force);
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutorImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutorImpl.java
@@ -1,33 +1,28 @@
 /*
- * #%L ACS AEM Commons Bundle %% Copyright (C) 2018 Adobe %% Licensed under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License. #L%
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.ondeploy.impl;
 
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
-
-import javax.management.DynamicMBean;
-import javax.management.NotCompliantMBeanException;
-import javax.management.openmbean.CompositeDataSupport;
-import javax.management.openmbean.CompositeType;
-import javax.management.openmbean.OpenDataException;
-import javax.management.openmbean.OpenType;
-import javax.management.openmbean.SimpleType;
-import javax.management.openmbean.TabularDataSupport;
-import javax.management.openmbean.TabularType;
-
+import com.adobe.acs.commons.ondeploy.OnDeployScriptProvider;
+import com.adobe.acs.commons.ondeploy.scripts.OnDeployScript;
+import com.adobe.granite.jmx.annotation.AnnotatedStandardMBean;
+import com.day.cq.commons.jcr.JcrConstants;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.ConfigurationPolicy;
 import org.apache.felix.scr.annotations.Properties;
@@ -43,25 +38,41 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.commons.classloader.DynamicClassLoaderManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.acs.commons.ondeploy.OnDeployScriptProvider;
-import com.adobe.acs.commons.ondeploy.scripts.OnDeployScript;
-import com.adobe.granite.jmx.annotation.AnnotatedStandardMBean;
-import com.day.cq.commons.jcr.JcrConstants;
+import javax.management.DynamicMBean;
+import javax.management.NotCompliantMBeanException;
+import javax.management.openmbean.CompositeDataSupport;
+import javax.management.openmbean.CompositeType;
+import javax.management.openmbean.OpenDataException;
+import javax.management.openmbean.OpenType;
+import javax.management.openmbean.SimpleType;
+import javax.management.openmbean.TabularDataSupport;
+import javax.management.openmbean.TabularType;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * A service that triggers scripts on deployment to an AEM server.
  * <p>
- * This class manages scripts so that they only run once (unless the script fails). Script execution statuses are
- * stored in the JCR @ /var/acs-commons/on-deploy-scripts-status.
+ * This class manages scripts so that they only run once (unless the script
+ * fails).  Script execution statuses are stored in the JCR @
+ * /var/acs-commons/on-deploy-scripts-status.
  * <p>
  * Scripts are specified via OSGi config, are are run in the order specified.
  * <p>
- * NOTE: Since it's always a possibility that /var/acs-commons/on-deploy-scripts-status will be deleted in the JCR,
- * scripts should be written defensively in case they are actually run more than once. This also covers the scenario
- * where a script is run a second time after failing the first time.
+ * NOTE: Since it's always a possibility that
+ * /var/acs-commons/on-deploy-scripts-status will be deleted in the JCR,
+ * scripts should be written defensively in case they are actually run more
+ * than once.  This also covers the scenario where a script is run a second
+ * time after failing the first time.
  */
 @Component(
         label = "ACS AEM Commons - On-Deploy Scripts Executor",
@@ -87,8 +98,7 @@ public class OnDeployExecutorImpl extends AnnotatedStandardMBean implements OnDe
     @Reference
     private ResourceResolverFactory resourceResolverFactory;
 
-    @Reference(name = "scriptProvider", referenceInterface = OnDeployScriptProvider.class,
-            cardinality = ReferenceCardinality.MANDATORY_MULTIPLE, policy = ReferencePolicy.DYNAMIC)
+    @Reference(name = "scriptProvider", referenceInterface = OnDeployScriptProvider.class, cardinality = ReferenceCardinality.MANDATORY_MULTIPLE, policy = ReferencePolicy.DYNAMIC)
     private List<OnDeployScriptProvider> scriptProviders = new CopyOnWriteArrayList<>();
 
     private static transient String[] scriptsItemNames;
@@ -148,7 +158,7 @@ public class OnDeployExecutorImpl extends AnnotatedStandardMBean implements OnDe
     }
 
     protected void unbindScriptProvider(OnDeployScriptProvider scriptProvider) {
-        scriptProviders.remove(scriptProvider);
+       scriptProviders.remove(scriptProvider);
     }
 
     protected Resource getOrCreateStatusTrackingResource(ResourceResolver resourceResolver, Class<?> scriptClass) {
@@ -157,13 +167,9 @@ public class OnDeployExecutorImpl extends AnnotatedStandardMBean implements OnDe
         if (resource == null) {
             Resource folder = resourceResolver.getResource(SCRIPT_STATUS_JCR_FOLDER);
             try {
-                resource =
-                        resourceResolver.create(folder, scriptClassName,
-                                Collections.singletonMap(JcrConstants.JCR_PRIMARYTYPE, JcrConstants.NT_UNSTRUCTURED));
+                resource = resourceResolver.create(folder, scriptClassName, Collections.singletonMap(JcrConstants.JCR_PRIMARYTYPE, JcrConstants.NT_UNSTRUCTURED));
             } catch (PersistenceException re) {
-                logger.error(
-                        "On-deploy script cannot be run because the system could not find or create the script status node: {}/{}",
-                        SCRIPT_STATUS_JCR_FOLDER, scriptClassName);
+                logger.error("On-deploy script cannot be run because the system could not find or create the script status node: {}/{}", SCRIPT_STATUS_JCR_FOLDER, scriptClassName);
                 throw new OnDeployEarlyTerminationException(re);
             }
         }
@@ -202,9 +208,7 @@ public class OnDeployExecutorImpl extends AnnotatedStandardMBean implements OnDe
                 throw new OnDeployEarlyTerminationException(new RuntimeException(errMsg));
             }
         } else if (!status.equals(SCRIPT_STATUS_SUCCESS)) {
-            String errMsg =
-                    "On-deploy script is already running or in an otherwise unknown state: "
-                            + statusResource.getPath() + " - status: " + status;
+            String errMsg = "On-deploy script is already running or in an otherwise unknown state: " + statusResource.getPath() + " - status: " + status;
             logger.error(errMsg);
             throw new OnDeployEarlyTerminationException(new RuntimeException(errMsg));
         } else {
@@ -229,8 +233,7 @@ public class OnDeployExecutorImpl extends AnnotatedStandardMBean implements OnDe
             properties.put(SCRIPT_DATE_END, Calendar.getInstance());
             statusResource.getResourceResolver().commit();
         } catch (PersistenceException e) {
-            logger.error("On-deploy script status node could not be updated: {} - status: {}",
-                    statusResource.getPath(), status);
+            logger.error("On-deploy script status node could not be updated: {} - status: {}", statusResource.getPath(), status);
             throw new OnDeployEarlyTerminationException(e);
         }
     }
@@ -244,9 +247,7 @@ public class OnDeployExecutorImpl extends AnnotatedStandardMBean implements OnDe
             properties.remove(SCRIPT_DATE_END);
             statusResource.getResourceResolver().commit();
         } catch (PersistenceException e) {
-            logger.error(
-                    "On-deploy script cannot be run because the system could not write to the script status node: {}",
-                    statusResource.getPath());
+            logger.error("On-deploy script cannot be run because the system could not write to the script status node: {}", statusResource.getPath());
             throw new OnDeployEarlyTerminationException(e);
         }
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutorImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutorImpl.java
@@ -16,6 +16,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.management.DynamicMBean;
 import javax.management.NotCompliantMBeanException;
@@ -88,7 +89,7 @@ public class OnDeployExecutorImpl extends AnnotatedStandardMBean implements OnDe
 
     @Reference(name = "scriptProvider", referenceInterface = OnDeployScriptProvider.class,
             cardinality = ReferenceCardinality.MANDATORY_MULTIPLE, policy = ReferencePolicy.DYNAMIC)
-    private List<OnDeployScriptProvider> scriptProviders;
+    private List<OnDeployScriptProvider> scriptProviders = new CopyOnWriteArrayList<>();
 
     private static transient String[] scriptsItemNames;
     private static transient CompositeType scriptsCompositeType;
@@ -124,6 +125,8 @@ public class OnDeployExecutorImpl extends AnnotatedStandardMBean implements OnDe
      */
     protected void bindScriptProvider(OnDeployScriptProvider scriptProvider) {
         logger.info("Executing on-deploy scripts from scriptProvider: {}", scriptProvider.getClass().getName());
+        scriptProviders.add(scriptProvider);
+
         List<OnDeployScript> scripts = scriptProvider.getScripts();
         if (scripts.size() == 0) {
             logger.debug("No on-deploy scripts found.");
@@ -145,7 +148,7 @@ public class OnDeployExecutorImpl extends AnnotatedStandardMBean implements OnDe
     }
 
     protected void unbindScriptProvider(OnDeployScriptProvider scriptProvider) {
-        // noop
+        scriptProviders.remove(scriptProvider);
     }
 
     protected Resource getOrCreateStatusTrackingResource(ResourceResolver resourceResolver, Class<?> scriptClass) {

--- a/bundle/src/main/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutorImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutorImpl.java
@@ -38,7 +38,6 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.api.resource.ValueMap;
-import org.apache.sling.commons.classloader.DynamicClassLoaderManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/bundle/src/main/java/com/adobe/acs/commons/ondeploy/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/ondeploy/package-info.java
@@ -20,5 +20,5 @@
 /**
  * On-Deploy Scripts Framework.
  */
-@aQute.bnd.annotation.Version("1.0.0")
+@aQute.bnd.annotation.Version("1.0.1")
 package com.adobe.acs.commons.ondeploy;

--- a/bundle/src/test/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutorImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutorImplTest.java
@@ -17,32 +17,8 @@
  * limitations under the License.
  * #L%
  */
+
 package com.adobe.acs.commons.ondeploy.impl;
-
-import com.adobe.acs.commons.ondeploy.OnDeployScriptProvider;
-import com.adobe.acs.commons.ondeploy.scripts.OnDeployScript;
-import com.adobe.acs.commons.ondeploy.scripts.OnDeployScriptTestExampleFailExecute;
-import com.adobe.acs.commons.ondeploy.scripts.OnDeployScriptTestExampleSuccess1;
-import com.adobe.acs.commons.ondeploy.scripts.OnDeployScriptTestExampleSuccess2;
-import com.adobe.acs.commons.ondeploy.scripts.OnDeployScriptTestExampleSuccessWithPause;
-import com.adobe.acs.commons.testutil.LogTester;
-import com.day.cq.commons.jcr.JcrConstants;
-import com.day.cq.search.QueryBuilder;
-import io.wcm.testing.mock.aem.junit.AemContext;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.testing.mock.sling.ResourceResolverType;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
-import javax.jcr.Node;
-import javax.jcr.RepositoryException;
-import javax.jcr.Session;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collections;
-import java.util.List;
 
 import static com.adobe.acs.commons.testutil.LogTester.assertLogText;
 import static com.adobe.acs.commons.testutil.LogTester.assertNotLogText;
@@ -61,7 +37,34 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.doThrow;
 
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.List;
+
+import javax.jcr.RepositoryException;
+import javax.management.NotCompliantMBeanException;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.adobe.acs.commons.ondeploy.OnDeployScriptProvider;
+import com.adobe.acs.commons.ondeploy.scripts.OnDeployScript;
+import com.adobe.acs.commons.ondeploy.scripts.OnDeployScriptTestExampleFailExecute;
+import com.adobe.acs.commons.ondeploy.scripts.OnDeployScriptTestExampleSuccess1;
+import com.adobe.acs.commons.ondeploy.scripts.OnDeployScriptTestExampleSuccess2;
+import com.adobe.acs.commons.ondeploy.scripts.OnDeployScriptTestExampleSuccessWithPause;
+import com.adobe.acs.commons.testutil.LogTester;
+import com.day.cq.search.QueryBuilder;
+
+import io.wcm.testing.mock.aem.junit.AemContext;
+
 public class OnDeployExecutorImplTest {
+
     @Rule
     public final AemContext context = new AemContext(ResourceResolverType.JCR_MOCK);
 
@@ -75,7 +78,7 @@ public class OnDeployExecutorImplTest {
     }
 
     @Test
-    public void testCloseResources() {
+    public void testCloseResources() throws NotCompliantMBeanException {
         ResourceResolver resourceResolver = mock(ResourceResolver.class);
 
         OnDeployExecutorImpl impl = spy(new OnDeployExecutorImpl());
@@ -83,6 +86,7 @@ public class OnDeployExecutorImplTest {
         doNothing().when(impl).runScripts(same(resourceResolver), anyList());
 
         context.registerService(OnDeployScriptProvider.class, new OnDeployScriptProvider() {
+
             @Override
             public List<OnDeployScript> getScripts() {
                 return Arrays.asList(new OnDeployScriptTestExampleSuccess1());
@@ -94,7 +98,7 @@ public class OnDeployExecutorImplTest {
     }
 
     @Test
-    public void testCloseResourcesIsFailSafe() {
+    public void testCloseResourcesIsFailSafe() throws NotCompliantMBeanException {
         ResourceResolver resourceResolver = mock(ResourceResolver.class);
 
         OnDeployExecutorImpl impl = spy(new OnDeployExecutorImpl());
@@ -104,6 +108,7 @@ public class OnDeployExecutorImplTest {
         doThrow(new RuntimeException("resolver close failed")).when(resourceResolver).close();
 
         context.registerService(OnDeployScriptProvider.class, new OnDeployScriptProvider() {
+
             @Override
             public List<OnDeployScript> getScripts() {
                 return Arrays.asList(new OnDeployScriptTestExampleSuccess1());
@@ -115,7 +120,7 @@ public class OnDeployExecutorImplTest {
     }
 
     @Test
-    public void testCloseResourcesOnException() {
+    public void testCloseResourcesOnException() throws NotCompliantMBeanException {
         ResourceResolver resourceResolver = mock(ResourceResolver.class);
 
         OnDeployExecutorImpl impl = spy(new OnDeployExecutorImpl());
@@ -123,6 +128,7 @@ public class OnDeployExecutorImplTest {
         doThrow(new RuntimeException("Scripts broke!")).when(impl).runScripts(same(resourceResolver), anyList());
 
         context.registerService(OnDeployScriptProvider.class, new OnDeployScriptProvider() {
+
             @Override
             public List<OnDeployScript> getScripts() {
                 return Arrays.asList(new OnDeployScriptTestExampleSuccess1());
@@ -138,10 +144,11 @@ public class OnDeployExecutorImplTest {
     }
 
     @Test
-    public void testExecuteNoScripts() {
+    public void testExecuteNoScripts() throws NotCompliantMBeanException {
         OnDeployExecutorImpl impl = spy(new OnDeployExecutorImpl());
 
         context.registerService(OnDeployScriptProvider.class, new OnDeployScriptProvider() {
+
             @Override
             public List<OnDeployScript> getScripts() {
                 return Collections.emptyList();
@@ -154,14 +161,17 @@ public class OnDeployExecutorImplTest {
     }
 
     @Test
-    public void testExecuteRerunsFailedScripts() throws RepositoryException {
+    public void testExecuteRerunsFailedScripts() throws RepositoryException, NotCompliantMBeanException {
         OnDeployExecutorImpl impl = new OnDeployExecutorImpl();
         ResourceResolver resourceResolver = context.resourceResolver();
 
         // Mimic the situation where a script initiated in the past failed
-        Resource statusResource = impl.getOrCreateStatusTrackingResource(resourceResolver, OnDeployScriptTestExampleSuccess1.class);
+        Resource statusResource =
+                impl.getOrCreateStatusTrackingResource(resourceResolver, OnDeployScriptTestExampleSuccess1.class);
         String status1ResourcePath = statusResource.getPath();
-        assertEquals(OnDeployExecutorImpl.SCRIPT_STATUS_JCR_FOLDER + "/" + OnDeployScriptTestExampleSuccess1.class.getName(), status1ResourcePath);
+        assertEquals(
+                OnDeployExecutorImpl.SCRIPT_STATUS_JCR_FOLDER + "/"
+                        + OnDeployScriptTestExampleSuccess1.class.getName(), status1ResourcePath);
         impl.trackScriptStart(statusResource);
         impl.trackScriptEnd(statusResource, "fail");
         Resource originalStatus1 = resourceResolver.getResource(status1ResourcePath);
@@ -170,6 +180,7 @@ public class OnDeployExecutorImplTest {
 
         // Here's where the real test begins
         context.registerService(OnDeployScriptProvider.class, new OnDeployScriptProvider() {
+
             @Override
             public List<OnDeployScript> getScripts() {
                 return Arrays.asList(new OnDeployScriptTestExampleSuccess1(), new OnDeployScriptTestExampleSuccess2());
@@ -181,35 +192,49 @@ public class OnDeployExecutorImplTest {
         assertNotNull(status1);
         assertEquals("success", status1.getValueMap().get("status", ""));
 
-        Resource status2 = resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccess2.class.getName());
+        Resource status2 =
+                resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/"
+                        + OnDeployScriptTestExampleSuccess2.class.getName());
         assertNotNull(status2);
         assertEquals("success", status2.getValueMap().get("status", ""));
     }
 
     @Test
-    public void testExecuteSuccessfulScripts() {
+    public void testExecuteSuccessfulScripts() throws NotCompliantMBeanException {
         context.registerService(OnDeployScriptProvider.class, new OnDeployScriptProvider() {
+
             @Override
             public List<OnDeployScript> getScripts() {
-                return Arrays.asList(new OnDeployScriptTestExampleSuccess1(), new OnDeployScriptTestExampleSuccessWithPause());
+                return Arrays.asList(new OnDeployScriptTestExampleSuccess1(),
+                        new OnDeployScriptTestExampleSuccessWithPause());
             }
         });
         context.registerInjectActivateService(new OnDeployExecutorImpl());
 
-        assertLogText("Starting on-deploy script: /var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccess1.class.getName());
-        assertLogText("On-deploy script completed successfully: /var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccess1.class.getName());
-        assertLogText("Starting on-deploy script: /var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccessWithPause.class.getName());
-        assertLogText("On-deploy script completed successfully: /var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccessWithPause.class.getName());
+        assertLogText("Starting on-deploy script: /var/acs-commons/on-deploy-scripts-status/"
+                + OnDeployScriptTestExampleSuccess1.class.getName());
+        assertLogText("On-deploy script completed successfully: /var/acs-commons/on-deploy-scripts-status/"
+                + OnDeployScriptTestExampleSuccess1.class.getName());
+        assertLogText("Starting on-deploy script: /var/acs-commons/on-deploy-scripts-status/"
+                + OnDeployScriptTestExampleSuccessWithPause.class.getName());
+        assertLogText("On-deploy script completed successfully: /var/acs-commons/on-deploy-scripts-status/"
+                + OnDeployScriptTestExampleSuccessWithPause.class.getName());
 
-        assertLogText("Executing test script: OnDeployScriptTestExampleSuccess1", OnDeployScriptTestExampleSuccess1.class.getName());
-        assertLogText("Executing test script: OnDeployScriptTestExampleSuccessWithPause", OnDeployScriptTestExampleSuccessWithPause.class.getName());
+        assertLogText("Executing test script: OnDeployScriptTestExampleSuccess1",
+                OnDeployScriptTestExampleSuccess1.class.getName());
+        assertLogText("Executing test script: OnDeployScriptTestExampleSuccessWithPause",
+                OnDeployScriptTestExampleSuccessWithPause.class.getName());
 
         ResourceResolver resourceResolver = context.resourceResolver();
-        Resource status1 = resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccess1.class.getName());
+        Resource status1 =
+                resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/"
+                        + OnDeployScriptTestExampleSuccess1.class.getName());
         assertNotNull(status1);
         assertEquals("success", status1.getValueMap().get("status", ""));
 
-        Resource status2 = resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccessWithPause.class.getName());
+        Resource status2 =
+                resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/"
+                        + OnDeployScriptTestExampleSuccessWithPause.class.getName());
         assertNotNull(status2);
         final Calendar start = status2.getValueMap().get("startDate", Calendar.class);
         final Calendar end = status2.getValueMap().get("endDate", Calendar.class);
@@ -221,9 +246,10 @@ public class OnDeployExecutorImplTest {
     }
 
     @Test
-    public void testExecuteSkipsAlreadySucccessfulScripts() throws RepositoryException {
+    public void testExecuteSkipsAlreadySucccessfulScripts() throws RepositoryException, NotCompliantMBeanException {
         // Run the script successfully the first time
         context.registerService(OnDeployScriptProvider.class, new OnDeployScriptProvider() {
+
             @Override
             public List<OnDeployScript> getScripts() {
                 return Arrays.asList(new OnDeployScriptTestExampleSuccess1());
@@ -234,32 +260,42 @@ public class OnDeployExecutorImplTest {
 
         // Here's where the real test begins
         context.registerService(OnDeployScriptProvider.class, new OnDeployScriptProvider() {
+
             @Override
             public List<OnDeployScript> getScripts() {
                 return Arrays.asList(new OnDeployScriptTestExampleSuccess1(), new OnDeployScriptTestExampleSuccess2());
             }
         });
 
-        assertLogText("Skipping on-deploy script, as it is already complete: /var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccess1.class.getName());
-        assertNotLogText("Starting on-deploy script: /var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccess1.class.getName());
-        assertLogText("Starting on-deploy script: /var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccess2.class.getName());
+        assertLogText("Skipping on-deploy script, as it is already complete: /var/acs-commons/on-deploy-scripts-status/"
+                + OnDeployScriptTestExampleSuccess1.class.getName());
+        assertNotLogText("Starting on-deploy script: /var/acs-commons/on-deploy-scripts-status/"
+                + OnDeployScriptTestExampleSuccess1.class.getName());
+        assertLogText("Starting on-deploy script: /var/acs-commons/on-deploy-scripts-status/"
+                + OnDeployScriptTestExampleSuccess2.class.getName());
 
         ResourceResolver resourceResolver = context.resourceResolver();
-        Resource status1 = resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccess1.class.getName());
+        Resource status1 =
+                resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/"
+                        + OnDeployScriptTestExampleSuccess1.class.getName());
         assertNotNull(status1);
         assertEquals("success", status1.getValueMap().get("status", ""));
 
-        Resource status2 = resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccess2.class.getName());
+        Resource status2 =
+                resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/"
+                        + OnDeployScriptTestExampleSuccess2.class.getName());
         assertNotNull(status2);
         assertEquals("success", status2.getValueMap().get("status", ""));
     }
 
     @Test
-    public void testExecuteTerminatesWhenScriptAlreadyRunning() throws RepositoryException {
+    public void testExecuteTerminatesWhenScriptAlreadyRunning() throws RepositoryException, NotCompliantMBeanException {
         final OnDeployExecutorImpl impl = new OnDeployExecutorImpl();
 
         // Mimic the situation where a script initiated in the past is still running
-        final Resource statusResource = impl.getOrCreateStatusTrackingResource(context.resourceResolver(), OnDeployScriptTestExampleSuccess1.class);
+        final Resource statusResource =
+                impl.getOrCreateStatusTrackingResource(context.resourceResolver(),
+                        OnDeployScriptTestExampleSuccess1.class);
         final String status1ResourcePath = statusResource.getPath();
         impl.trackScriptStart(statusResource);
         LogTester.reset();
@@ -267,6 +303,7 @@ public class OnDeployExecutorImplTest {
         // Here's where the real test begins
 
         context.registerService(OnDeployScriptProvider.class, new OnDeployScriptProvider() {
+
             @Override
             public List<OnDeployScript> getScripts() {
                 return Arrays.asList(new OnDeployScriptTestExampleSuccess1(), new OnDeployScriptTestExampleSuccess2());
@@ -280,25 +317,34 @@ public class OnDeployExecutorImplTest {
             assertTrue(OnDeployEarlyTerminationException.class.isAssignableFrom(e.getCause().getClass()));
         }
 
-        assertLogText("On-deploy script is already running or in an otherwise unknown state: " + status1ResourcePath + " - status: running");
-        assertNotLogText("Starting on-deploy script: /var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccess1.class.getName());
-        assertNotLogText("Starting on-deploy script: /var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccess2.class.getName());
+        assertLogText("On-deploy script is already running or in an otherwise unknown state: " + status1ResourcePath
+                + " - status: running");
+        assertNotLogText("Starting on-deploy script: /var/acs-commons/on-deploy-scripts-status/"
+                + OnDeployScriptTestExampleSuccess1.class.getName());
+        assertNotLogText("Starting on-deploy script: /var/acs-commons/on-deploy-scripts-status/"
+                + OnDeployScriptTestExampleSuccess2.class.getName());
 
         ResourceResolver resourceResolver = context.resourceResolver();
-        Resource status1 = resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccess1.class.getName());
+        Resource status1 =
+                resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/"
+                        + OnDeployScriptTestExampleSuccess1.class.getName());
         assertNotNull(status1);
         assertEquals("running", status1.getValueMap().get("status", ""));
 
-        Resource status2 = resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccess2.class.getName());
+        Resource status2 =
+                resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/"
+                        + OnDeployScriptTestExampleSuccess2.class.getName());
         assertNull(status2);
     }
 
     @Test
     public void testExecuteTerminatesWhenScriptFails() {
         context.registerService(OnDeployScriptProvider.class, new OnDeployScriptProvider() {
+
             @Override
             public List<OnDeployScript> getScripts() {
-                return Arrays.asList(new OnDeployScriptTestExampleSuccess1(), new OnDeployScriptTestExampleFailExecute(), new OnDeployScriptTestExampleSuccess2());
+                return Arrays.asList(new OnDeployScriptTestExampleSuccess1(),
+                        new OnDeployScriptTestExampleFailExecute(), new OnDeployScriptTestExampleSuccess2());
             }
         });
 
@@ -309,27 +355,41 @@ public class OnDeployExecutorImplTest {
             assertTrue(OnDeployEarlyTerminationException.class.isAssignableFrom(e.getCause().getClass()));
         }
 
-        assertLogText("Starting on-deploy script: /var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccess1.class.getName());
-        assertLogText("On-deploy script completed successfully: /var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccess1.class.getName());
-        assertLogText("Starting on-deploy script: /var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleFailExecute.class.getName());
-        assertNotLogText("On-deploy script completed successfully: /var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleFailExecute.class.getName());
-        assertLogText("On-deploy script failed: /var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleFailExecute.class.getName());
-        assertNotLogText("Starting on-deploy script: /var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccess2.class.getName());
+        assertLogText("Starting on-deploy script: /var/acs-commons/on-deploy-scripts-status/"
+                + OnDeployScriptTestExampleSuccess1.class.getName());
+        assertLogText("On-deploy script completed successfully: /var/acs-commons/on-deploy-scripts-status/"
+                + OnDeployScriptTestExampleSuccess1.class.getName());
+        assertLogText("Starting on-deploy script: /var/acs-commons/on-deploy-scripts-status/"
+                + OnDeployScriptTestExampleFailExecute.class.getName());
+        assertNotLogText("On-deploy script completed successfully: /var/acs-commons/on-deploy-scripts-status/"
+                + OnDeployScriptTestExampleFailExecute.class.getName());
+        assertLogText("On-deploy script failed: /var/acs-commons/on-deploy-scripts-status/"
+                + OnDeployScriptTestExampleFailExecute.class.getName());
+        assertNotLogText("Starting on-deploy script: /var/acs-commons/on-deploy-scripts-status/"
+                + OnDeployScriptTestExampleSuccess2.class.getName());
 
-        assertLogText("Executing test script: OnDeployScriptTestExampleSuccess1", OnDeployScriptTestExampleSuccess1.class.getName());
-        assertLogText("Executing test script: OnDeployScriptTestExampleFailExecute", OnDeployScriptTestExampleFailExecute.class.getName());
+        assertLogText("Executing test script: OnDeployScriptTestExampleSuccess1",
+                OnDeployScriptTestExampleSuccess1.class.getName());
+        assertLogText("Executing test script: OnDeployScriptTestExampleFailExecute",
+                OnDeployScriptTestExampleFailExecute.class.getName());
         assertNotLogText("Executing test script: OnDeployScriptTestExampleSuccess2");
 
         ResourceResolver resourceResolver = context.resourceResolver();
-        Resource status1 = resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccess1.class.getName());
+        Resource status1 =
+                resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/"
+                        + OnDeployScriptTestExampleSuccess1.class.getName());
         assertNotNull(status1);
         assertEquals("success", status1.getValueMap().get("status", ""));
 
-        Resource status2 = resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleFailExecute.class.getName());
+        Resource status2 =
+                resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/"
+                        + OnDeployScriptTestExampleFailExecute.class.getName());
         assertNotNull(status2);
         assertEquals("fail", status2.getValueMap().get("status", ""));
 
-        Resource status3 = resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/" + OnDeployScriptTestExampleSuccess2.class.getName());
+        Resource status3 =
+                resourceResolver.getResource("/var/acs-commons/on-deploy-scripts-status/"
+                        + OnDeployScriptTestExampleSuccess2.class.getName());
         assertNull(status3);
     }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/ondeploy/scripts/OnDeployScriptTestExampleFlipFlop.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/ondeploy/scripts/OnDeployScriptTestExampleFlipFlop.java
@@ -1,0 +1,37 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.ondeploy.scripts;
+
+public class OnDeployScriptTestExampleFlipFlop extends OnDeployScriptBase {
+
+    private static boolean pass=false;
+
+    @Override
+    protected void execute() throws Exception {
+        logger.info("Executing test script: OnDeployScriptTestExampleFlipFlop");
+
+        if(pass) {
+            pass = !pass;
+        } else {
+            pass = !pass;
+            throw new RuntimeException("Oops, this script failed");
+        }
+    }
+}


### PR DESCRIPTION
makes it easier to see the status of all current scripts and makes re-execution easier.

As I've started to play with on-deploy scripts on my current project, I've found myself wishing there was an easier way to see the on-deploy scripts, their status, etc.  Also added a way to re-execute, and to force re-execution of previously succeeded script via force.