### PR TITLE
Feature/asset ingestor foldername with hyphen

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestor.java
@@ -303,7 +303,7 @@ public abstract class AssetIngestor extends ProcessDefinition {
         if (s.nodeExists(folderPath)) {
             Node folderNode = s.getNode(folderPath);
             Node folderContentNode = folderNode.hasNode(JcrConstants.JCR_CONTENT) ? folderNode.getNode(JcrConstants.JCR_CONTENT) : null;
-            if (folderPath.equals(jcrBasePath) || (null != folderContentNode
+            if (folderNode.getPath().equals(jcrBasePath) || (null != folderContentNode
                     && folderContentNode.hasProperty(JcrConstants.JCR_TITLE)
                     && folderContentNode.getProperty(JcrConstants.JCR_TITLE).getString().equals(name))) {
                 return false;
@@ -327,17 +327,21 @@ public abstract class AssetIngestor extends ProcessDefinition {
         }
         Node child = s.getNode(parentPath).addNode(el.getNodeName(), DEFAULT_FOLDER_TYPE);
         trackDetailedActivity(el.getNodePath(), "Create Folder", "Create folder", 0L);
+        setFolderTitle(child,folderPath,name);
         incrementCount(createdFolders, 1L);
-        if (!folderPath.equals(jcrBasePath)) {
-            if(child.hasNode(JcrConstants.JCR_CONTENT)){
-                child.getNode(JcrConstants.JCR_CONTENT).setProperty(JcrConstants.JCR_TITLE, name);
-            }else{
-                child.addNode(JcrConstants.JCR_CONTENT, JcrConstants.NT_UNSTRUCTURED).setProperty(JcrConstants.JCR_TITLE, name);
-            }
-        }
         r.commit();
         r.refresh();
         return true;
+    }
+
+    private void setFolderTitle (Node child,String folderPath,String title) throws RepositoryException{
+        if (!folderPath.equals(jcrBasePath)) {
+            if(child.hasNode(JcrConstants.JCR_CONTENT)){
+                child.getNode(JcrConstants.JCR_CONTENT).setProperty(JcrConstants.JCR_TITLE, title);
+            }else{
+                child.addNode(JcrConstants.JCR_CONTENT, JcrConstants.NT_UNSTRUCTURED).setProperty(JcrConstants.JCR_TITLE, title);
+            }
+        }
     }
 
     @SuppressWarnings("squid:S00112")

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestor.java
@@ -54,9 +54,9 @@ public abstract class AssetIngestor extends ProcessDefinition {
 
     public static final String ALL_ASSETS = "All Assets";
     static final String[] AUTHORIZED_GROUPS = new String[]{
-        "administrators",
-        "asset-ingest",
-        "dam-administrators"
+            "administrators",
+            "asset-ingest",
+            "dam-administrators"
     };
 
     protected final transient MimeTypeService mimetypeService;
@@ -355,7 +355,7 @@ public abstract class AssetIngestor extends ProcessDefinition {
                 String baseName = StringUtils.substringBeforeLast(el.getName(), ".");
                 String extension = StringUtils.substringAfterLast(el.getName(), ".");
                 path = (el.getParent() == null ? el.getJcrBasePath() : el.getParent().getNodePath()) + "/"
-                + JcrUtil.createValidName(baseName,JcrUtil.HYPHEN_LABEL_CHAR_MAPPING,"-")
+                        + JcrUtil.createValidName(baseName,JcrUtil.HYPHEN_LABEL_CHAR_MAPPING,"-")
                         + "." + JcrUtil.createValidName(extension,JcrUtil.HYPHEN_LABEL_CHAR_MAPPING,"-");
             }
             handleExistingAsset(source, path, r);

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestor.java
@@ -438,7 +438,7 @@ public abstract class AssetIngestor extends ProcessDefinition {
                 String extension = StringUtils.substringAfterLast(name, ".");
                 return JcrUtil.createValidName(baseName) + "." + JcrUtil.createValidName(extension);
             } else {
-                return JcrUtil.createValidName(name);
+                return JcrUtil.createValidName(name,JcrUtil.HYPHEN_LABEL_CHAR_MAPPING,"-");
             }
         }
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestor.java
@@ -289,7 +289,7 @@ public abstract class AssetIngestor extends ProcessDefinition {
                 versionExistingAsset(source, assetPath, r);
         }
     }
-
+    @SuppressWarnings("squid:S3776")
     protected boolean createFolderNode(HierarchialElement el, ResourceResolver r) throws RepositoryException, PersistenceException {
         if (el == null || !el.isFolder()) {
             return false;

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestor.java
@@ -289,6 +289,7 @@ public abstract class AssetIngestor extends ProcessDefinition {
                 versionExistingAsset(source, assetPath, r);
         }
     }
+
     @SuppressWarnings("squid:S3776")
     protected boolean createFolderNode(HierarchialElement el, ResourceResolver r) throws RepositoryException, PersistenceException {
         if (el == null || !el.isFolder()) {
@@ -334,7 +335,7 @@ public abstract class AssetIngestor extends ProcessDefinition {
         return true;
     }
 
-    private void setFolderTitle (Node child,String folderPath,String title) throws RepositoryException{
+    private void setFolderTitle(Node child,String folderPath,String title) throws RepositoryException{
         if (!folderPath.equals(jcrBasePath)) {
             if(child.hasNode(JcrConstants.JCR_CONTENT)){
                 child.getNode(JcrConstants.JCR_CONTENT).setProperty(JcrConstants.JCR_TITLE, title);


### PR DESCRIPTION
modified two other areas
1. replace the separator in asset name node with "-"
2. folder title property is moved to set on jcr:content node , to be consistent with OOTB
( Title was set on sling:Folder node, earlier)
3. Added "preserveFileName" option to ingestor form