### PR TITLE
Feature/component cloner

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/componentcloner/impl/ComponentClonerServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/componentcloner/impl/ComponentClonerServlet.java
@@ -1,0 +1,114 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.componentcloner.impl;
+
+import com.day.cq.commons.jcr.JcrUtil;
+import com.google.gson.JsonObject;
+import org.apache.felix.scr.annotations.sling.SlingServlet;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import java.io.IOException;
+
+/**
+ * A {@link SlingSafeMethodsServlet} extension for cloning components using the component cloner.
+ */
+@SlingServlet(
+        extensions = { "json" },
+        methods = { "GET" },
+        resourceTypes = { "acs-commons/components/authoring/component-cloner" },
+        selectors = { "clone" }
+)
+public class ComponentClonerServlet extends SlingSafeMethodsServlet {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ComponentClonerServlet.class);
+
+    /*
+     * (non-Javadoc)
+     * @see org.apache.sling.api.servlets.SlingSafeMethodsServlet#doGet()
+     */
+    @Override
+    protected void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response) throws IOException {
+        JsonObject responseJson = new JsonObject();
+        response.setContentType("application/json");
+
+        try {
+            String pathOfNodeToClone = request.getParameter("path");
+            if (pathOfNodeToClone == null) {
+                LOG.error("The cloned component's path is empty. Please make sure path property is configured.");
+                responseJson.addProperty("componentClonerError", true);
+                response.getWriter().write(responseJson.toString());
+            } else {
+                Resource resource = request.getResource();
+                String pathOfNodeToReplace = resource.getPath();
+                Node nodeToReplace = resource.adaptTo(Node.class);
+                Resource nodeToCloneResource = request.getResourceResolver().getResource(pathOfNodeToClone);
+
+                if (nodeToCloneResource == null) {
+                    LOG.error("The node to clone's resource came back null. Invalid path, please make sure path property is configured.");
+                    responseJson.addProperty("componentClonerError", true);
+                    response.getWriter().write(responseJson.toString());
+                } else {
+                    Node nodeToClone = nodeToCloneResource.adaptTo(Node.class);
+                    Node parentNode = resource.adaptTo(Node.class).getParent();
+                    Session session = parentNode.getSession();
+
+                    String uniqueNodeName = createUniqueNodeName(0, nodeToClone.getName(), parentNode);
+                    Node clonedNode = JcrUtil.copy(nodeToClone, parentNode, uniqueNodeName);
+                    parentNode.orderBefore(clonedNode.getName(), nodeToReplace.getName());
+                    session.removeItem(pathOfNodeToReplace);
+                    session.save();
+
+                    responseJson.addProperty("componentClonerError", false);
+                    response.getWriter().write(responseJson.toString());
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("An error has occurred cloning the component.", e);
+            responseJson.addProperty("componentClonerError", true);
+            response.getWriter().write(responseJson.toString());
+        }
+    }
+
+    /**
+     * Recursive method to create a unique node name for the cloned node if the cloned node's name exists
+     * to avoid overwriting existing nodes.
+     * @param count int
+     * @param nodeToCloneName String
+     * @param parentNode Node
+     * @return String
+     * @throws RepositoryException exception
+     */
+    private String createUniqueNodeName(final int count, final String nodeToCloneName, final Node parentNode) throws RepositoryException {
+        if (parentNode.hasNode(nodeToCloneName)) {
+            String tempNodeToCloneName = nodeToCloneName.replaceFirst("_([0-9]+)$", "") + "_" + String.valueOf(count);
+            return createUniqueNodeName(count + 1, tempNodeToCloneName, parentNode);
+        } else {
+            return nodeToCloneName;
+        }
+    }
+}

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/.content.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--/*
+  ~  ACS AEM Commons Package
+  ~
+  ~ Copyright 2018 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+ */-->
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:description="Clones a specified component and all of its children nodes."
+    jcr:primaryType="cq:Component"
+    jcr:title="Component Cloner"
+    sling:resourceSuperType="foundation/components/parbase"
+    componentGroup="General"/>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/_cq_dialog/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/_cq_dialog/.content.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--/*
+  ~  ACS AEM Commons Package
+  ~
+  ~ Copyright 2018 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+ */-->
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Component Cloner"
+    sling:resourceType="cq/gui/components/authoring/dialog">
+    <content
+        jcr:primaryType="nt:unstructured"
+        sling:resourceType="granite/ui/components/foundation/container">
+        <layout
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="granite/ui/components/foundation/layouts/fixedcolumns"/>
+        <items jcr:primaryType="nt:unstructured">
+            <column
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="granite/ui/components/foundation/container">
+                <items jcr:primaryType="nt:unstructured">
+                    <clonePath
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="granite/ui/components/foundation/form/pathbrowser"
+                        class="component-cloner"
+                        fieldDescription="The path to clone specified component and its children."
+                        fieldLabel="Path to Clone"
+                        name="./path"
+                        predicate="nosystem"
+                        rootPath="/content"/>
+                </items>
+            </column>
+        </items>
+    </content>
+</jcr:root>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/_cq_editConfig.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/_cq_editConfig.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--/*
+  ~  ACS AEM Commons Package
+  ~
+  ~ Copyright 2018 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+ */-->
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    cq:actions="[text:Component Cloner |,edit,copymove,delete]"
+    cq:dialogMode="floating"
+    cq:disableTargeting="{Boolean}true"
+    cq:layout="editbar"
+    jcr:primaryType="cq:EditConfig">
+    <cq:dropTargets jcr:primaryType="nt:unstructured">
+        <path
+            jcr:primaryType="cq:DropTargetConfig"
+            accept="[.*]"
+            groups="[paragraph]"
+            propertyName="./path"/>
+    </cq:dropTargets>
+    <cq:listeners
+        jcr:primaryType="cq:EditListenersConfig"
+        afteredit="REFRESH_PAGE"/>
+</jcr:root>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/clientlibs/classic/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/clientlibs/classic/.content.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--/*
+  ~  ACS AEM Commons Package
+  ~
+  ~ Copyright 2018 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+ */-->
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    categories="acs-commons.component-cloner.classic"/>
+    <!-- Embed in cq.widgets -->

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/clientlibs/classic/js.txt
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/clientlibs/classic/js.txt
@@ -1,0 +1,3 @@
+#base=js
+
+listeners.js

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/clientlibs/classic/js/listeners.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/clientlibs/classic/js/listeners.js
@@ -1,0 +1,68 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/**
+ * Classic UI Listeners.
+ */
+var componentCloner = {};
+
+/**
+ * Function to build URI and send a GET request to the servlet to clone the specified component by its path.
+ * See https://helpx.adobe.com/experience-manager/6-3/sites/developing/using/reference-materials/widgets-api/index.html?class=CQ.Dialog
+ *     - Public Events
+ *          - beforesubmit
+ * @param dialog CQ.Dialog
+ * @returns {boolean}
+ */
+componentCloner.clone = function (dialog) {
+    var copyPath = dialog.find('name','./path')[0].value,
+        uri = dialog.path + '.clone' + CQ.shared.HTTP.EXTENSION_JSON,
+        url = CQ.shared.HTTP.addParameter(uri, 'path', copyPath);
+
+    CQ.shared.HTTP.get(url, componentCloner.callback);
+    dialog.close();
+
+    return false;
+};
+
+/**
+ * 'componentCloner.clone' method's callback function.
+ * Callback function to handle the response JSON from the component cloner servlet.
+ * See https://helpx.adobe.com/experience-manager/6-3/sites/developing/using/reference-materials/widgets-api/index.html?class=CQ.shared.HTTP
+ *     - Public Methods
+ *          - get method's callback: Function parameter
+ * @param options Object
+ * @param success Boolean
+ * @param response Object
+ */
+componentCloner.callback = function (options, success, response) {
+    var href = window.location.href,
+        data = JSON.parse(response.body);
+
+    // remove any existing error query params
+    href = href.replace('&componentClonerError=true', '');
+    href = href.replace('?componentClonerError=true', '');
+
+    if (!success || data.componentClonerError) {
+        href += (href.indexOf('?') > 1 ? '&' : '?') + 'componentClonerError=true';
+    }
+
+    window.location.replace(href);
+};

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/clientlibs/touchui/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/clientlibs/touchui/.content.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--/*
+  ~  ACS AEM Commons Package
+  ~
+  ~ Copyright 2018 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+ */-->
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    categories="acs-commons.component-cloner"/>
+    <!-- Embed in cq.authoring.dialog -->

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/clientlibs/touchui/js.txt
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/clientlibs/touchui/js.txt
@@ -1,0 +1,3 @@
+#base=js
+
+listeners.js

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/clientlibs/touchui/js/listeners.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/clientlibs/touchui/js/listeners.js
@@ -1,0 +1,61 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/**
+ * Touch-UI Listeners.
+ */
+(function ($, $document, gAuthor) {
+
+    "use strict";
+
+    /**
+     * Event handler for when submitting/saving the dialog.
+     */
+    $document.on("click", ".cq-dialog-submit", function (e) {
+        var $element = $(this).parents(".cq-dialog").find(".component-cloner");
+        if ($element.length) {
+            e.stopPropagation();
+            e.preventDefault();
+
+            $.ajax({
+                method: 'GET',
+                url: $element.parents("form").attr("action") + '.clone.json',
+                dataType: 'JSON',
+                data: { path: $('input[name="./path"]').val() }
+            }).success(function(data, status, headers, config) {
+                var href = window.location.href;
+
+                // remove any existing error query params
+                href = href.replace('&componentClonerError=true', '');
+                href = href.replace('?componentClonerError=true', '');
+
+                if (data.componentClonerError) {
+                    var hrefError = (window.location.href.indexOf('?') > 1 ? '&' : '?') + 'componentClonerError=true';
+                    window.location.replace(hrefError);
+                } else {
+                    window.location.replace(href);
+                }
+            }).error(function(data, status, headers, config) {
+                var hrefError = (window.location.href.indexOf('?') > 1 ? '&' : '?') + 'componentClonerError=true';
+                window.location.replace(hrefError);
+            });
+        }
+    });
+}(jQuery, jQuery(document), Granite.author));

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/component-cloner.html
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/component-cloner.html
@@ -1,0 +1,26 @@
+<!--/*
+  ~  ACS AEM Commons Package
+  ~
+  ~ Copyright 2018 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+ */-->
+
+<h1>Component Cloner</h1>
+<p data-sly-test="${request.requestParameterMap['componentClonerError']
+        && request.requestParameterMap['componentClonerError'][0].toString == 'true'}">
+    The Component Cloner was unsuccessful. Please check the logs for more information.
+</p>
+<p data-sly-test="${!request.requestParameterMap['componentClonerError']}">
+    Please select a component to copy by opening the dialog and navigating to the desired component.
+</p>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/dialog.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/authoring/component-cloner/dialog.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--/*
+  ~  ACS AEM Commons Package
+  ~
+  ~ Copyright 2018 Adobe
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+ */-->
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Dialog"
+    height="{Long}200"
+    title="Component Cloner"
+    width="{Long}600"
+    xtype="dialog">
+    <listeners
+        jcr:primaryType="nt:unstructured"
+        beforesubmit="function(dialog) { componentCloner.clone(dialog); }"/>
+    <items
+        jcr:primaryType="cq:Widget"
+        xtype="panel">
+        <items jcr:primaryType="cq:WidgetCollection">
+            <clonePath
+                jcr:primaryType="cq:Widget"
+                fieldDescription="The path to clone specified component and its children."
+                fieldLabel="Path to Clone"
+                id="clonePath"
+                name="./path"
+                predicate="nosystem"
+                rootPath="/content"
+                xtype="pathfield"/>
+        </items>
+    </items>
+</jcr:root>


### PR DESCRIPTION
This feature is for a new component called the 'Component Cloner'. It gives an author the ability to drop the Component Cloner inside a parsys and then clone an existing component/node-structure as a 1-to-1 match, include all of its children/grandchildren/etc nodes. This allows an author to recreate existing components and only spend time modifying some properties without having to create the entire structure from scratch. This can potentially save a lot of time for authors, depending on how complex the component is, or how many nested components/nodes are included inside of it.