### PR TITLE
Fix Closure Compiler bug in Parsys Placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+### Fixed
+- #1386 - Fixed ajax calls like undefined.2.json when hovering over parsys
+
 ## [3.17.0] - 2018-05-22
 
 ### Fixed

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/configure-parsys-placeholder/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/configure-parsys-placeholder/.content.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
           jcr:primaryType="cq:ClientLibraryFolder"
-          jsProcessor="[default:none,min:gcc;compilationLevel=whitespace]"
+          jsProcessor="[default:none,min:gcc]"
           categories="[acs-commons.cq-authoring.add-ons.touchui-parsys-placeholder]"/>

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/configure-parsys-placeholder/.content.xml
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/configure-parsys-placeholder/.content.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
           jcr:primaryType="cq:ClientLibraryFolder"
-          jsProcessor="[default:none,min:gcc]"
+          jsProcessor="[default:none,min:gcc;compilationLevel=whitespace]"
           categories="[acs-commons.cq-authoring.add-ons.touchui-parsys-placeholder]"/>

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/configure-parsys-placeholder/touchui-configure-parsys-placeholder.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/configure-parsys-placeholder/touchui-configure-parsys-placeholder.js
@@ -40,19 +40,17 @@
             designSrc = parsys.config.designDialogSrc,
             result = {}, param;
 
-        if (designSrc === undefined) {
-            return undefined;
+        if (designSrc !== undefined) {
+            designSrc = designSrc.substring(designSrc.indexOf("?") + 1);
+
+            designSrc.split(/&/).forEach(function (it) {
+                if (_.isEmpty(it)) {
+                    return undefined;
+                }
+                param = it.split("=");
+                result[param[0]] = param[1];
+            });
         }
-
-        designSrc = designSrc.substring(designSrc.indexOf("?") + 1);
-
-        designSrc.split(/&/).forEach( function(it) {
-            if (_.isEmpty(it)) {
-                return;
-            }
-            param = it.split("=");
-            result[param[0]] = param[1];
-        });
 
         if (result.content === undefined) {
             return undefined;


### PR DESCRIPTION
The default settings change the minified JS code logic so it exits with the String "undefined" instead of the object undefined causing the JS logic to fail. Probably a bug in the Google Closure Compiler version AEM is using (which is dated, a version of 2016 in our AEM 6.3.1.2). This fixes the undefined.2.json bug #1386