### PR TITLE
Collection of fields

### DIFF
--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield-nodestore.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield-nodestore.js
@@ -204,7 +204,10 @@
                 cmf = this;
 
             $multifields.each(function(counter, multifield){
-                $fields = $(multifield).children().children(cmf.CFFW);
+                // This looks for children inside children, there is a problem if we try to put in 
+                // tabs can be fixed
+                //$fields = $(multifield).children().children(cmf.CFFW);
+                $fields = $(multifield).find(cmf.CFFW);
 
                 $fields.each(function (j, field) {
                     fillValue($form, $(multifield).data("name"), $(field).find("[name]").not("[name*='@']"), (counter + 1));


### PR DESCRIPTION
The collectDataFromFields function gets only the second children fields with the line
$fields = $(multifield).children.children(cmf.CFFW);
Note: cfm.CFFW = ".coral-Form-fieldwrapper"

Second child is not a field wrapper, it’s a TabPanel wrapper

The fields for the TabPanel are deep within the TabPanel

Solution: Update the code to look for all.coral-Form-fieldwrapper rather than just the second children
$fields = $(multifield).find(cmf.CFFW);