### PR TITLE
#1441 - Fixed issue with the Report Runner loading custom Report Exec…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 - #1401 - Added AEM 6.3 support for conditional hiding in edit dialogs
 - #1415 - Fixed issue in Error Page Handler where /etc/map'd content confused 'real resource' look-up.
 - #1349 - Fixed issue with infinite loop in BrandPortalAgentFilter, when mpConfig property is not present.
+- #1441 - Fixed issue with the Report Runner loading custom Report Executors
 
 ### Changed
 

--- a/bundle/src/test/java/com/adobe/acs/commons/reports/models/ReportRunnerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/reports/models/ReportRunnerTest.java
@@ -35,6 +35,7 @@ import javax.jcr.RepositoryException;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.apache.sling.commons.classloader.DynamicClassLoaderManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -72,6 +73,9 @@ public class ReportRunnerTest {
 
     @Mock
     private SlingHttpServletRequest invalidRequest;
+
+    @Mock
+    private DynamicClassLoaderManager dynamicClassLoaderManager;
 
     private MockReportExecutor exec = new MockReportExecutor();
 
@@ -117,12 +121,14 @@ public class ReportRunnerTest {
                     }
                 }));
 
+        when(dynamicClassLoaderManager.getDynamicClassLoader()).thenReturn(this.getClass().getClassLoader());
+
     }
 
     @Test
     public void testInvalid() throws RepositoryException {
         log.info("testInvalid");
-        ReportRunner reportRunner = new ReportRunner(invalidRequest);
+        ReportRunner reportRunner = new ReportRunner(invalidRequest, dynamicClassLoaderManager);
         reportRunner.init();
         assertEquals("No configurations found!", reportRunner.getFailureMessage());
         assertFalse(reportRunner.isSuccessful());
@@ -132,7 +138,7 @@ public class ReportRunnerTest {
     @Test
     public void testReportRunner() throws RepositoryException {
         log.info("testReportRunner");
-        ReportRunner reportRunner = new ReportRunner(validRequest);
+        ReportRunner reportRunner = new ReportRunner(validRequest, dynamicClassLoaderManager);
         reportRunner.init();
         assertTrue(reportRunner.isSuccessful());
         assertNull(reportRunner.getFailureMessage());


### PR DESCRIPTION
…utors

It appears the problem is the class loader being used.

This fix switches it to use the DynamicClassLoaderManager.

@klcodanr i don't love the new cstor, but i couldn't figure out how to inject the DCLM for the tests since there is a cstor that takes a request. I wanted to remove that, and just use the @Self annotation for the Request (im not sure why it doesn't, the only use of the cstor I can find is in the test) but that is an API breaking change :(

The new cstor is default, so at least its not usable as a public API.

If you know how to use mockito to force inject a field w/ a mock that'd be a nice enhancement.