### PR TITLE
Resolving #1413 - Fixing Issue where Redirect Manager Not Accessible on Publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+- #1413 - Added ACL to make the redirect maps globally readable
 - #1426 - On Deploy Scripts - added filter.xml include for /etc/rep:policy
 
 ### Fixed

--- a/content/src/main/content/jcr_root/etc/acs-commons/redirect-maps/_rep_policy.xml
+++ b/content/src/main/content/jcr_root/etc/acs-commons/redirect-maps/_rep_policy.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:rep="internal"
+          jcr:primaryType="rep:ACL">
+    
+    <allow
+            jcr:primaryType="rep:GrantACE"
+            rep:principalName="everyone"
+            rep:privileges="{Name}[jcr:read]"/>
+</jcr:root>


### PR DESCRIPTION
By making /etc/acs-commons/redirect-maps globally readable