### PR TITLE
Add ns-scoped flags to shared-component-properties function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 - #1429 - Fixed Composite Multifield support for pathfield
 - #1431 - Fixed Composite Multifield support for Coral3 Select
 - #1433 - Fixed issue with Coral 3 UI Checkbox
+- Add ns-scoped flags to function to fix repeated toolbar buttons in Edit mode (Shared Component Properties).
 
 ### Changed
 

--- a/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/touchui/js/shared-component-properties.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/touchui/js/shared-component-properties.js
@@ -18,6 +18,14 @@
  * #L%
  */
 (function ($, ns, channel, window, undefined) {
+    // check and set flag to prevent other instances of this script from executing
+    // when embedded in multiple app clientlibs.
+    if (ns.acsSharedComponentPropertiesIsListening) {
+        return;
+    } else {
+        ns.acsSharedComponentPropertiesIsListening = true;
+    }
+
     function initDialog(type) {
         var dialogSrc = "dialog" + type;
         var dialogIcon = 'coral-Icon--' + (type === "shared" ? "layersForward" : "globe");
@@ -100,7 +108,9 @@
     // to figure out when a layer got activated
     channel.on('cq-layer-activated', function (ev) {
         // we continue if the user switched to the Edit layer
-        if (ev.layer === 'Edit') {
+        if (ev.layer === 'Edit' && !ns.acsSharedComponentPropertiesIsRegistered) {
+            // set flag to prevent multiple firings of this event from triggering our action registration
+            ns.acsSharedComponentPropertiesIsRegistered = true;
             // we use the editable toolbar and register an additional action
             ns.EditorFrame.editableToolbar.registerAction('SHARED-COMPONENT-PROPS', initDialog("shared"));
             ns.EditorFrame.editableToolbar.registerAction('GLOBAL-COMPONENT-PROPS', initDialog("global"));


### PR DESCRIPTION
as workaround for ns.edit.Toolbar behavior which allows registering
multiple instances of the same action name, resulting in an accumulation
of buttons when this script is embedded in multiple clientlibs or when
cq-layer-activated messages are forged by third-party clientlibs.