### PR TITLE
#1467 - Versioned ClientLibs cause WARN log messages on AEM 6.3 (#1467)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ## [3.17.4] - 2018-08-15
 
+### Fixed
+- #1467 - Versioned ClientLibs cause WARN log messages on AEM 6.3
 - #1413 - Added ACL to make the redirect maps globally readable
 
 ## [3.17.2] - 2018-08-13

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactoryTest.java
@@ -20,6 +20,7 @@
 
 package com.adobe.acs.commons.rewriter.impl;
 
+import com.adobe.granite.ui.clientlibs.ClientLibrary;
 import com.adobe.granite.ui.clientlibs.HtmlLibrary;
 import com.adobe.granite.ui.clientlibs.HtmlLibraryManager;
 import com.adobe.granite.ui.clientlibs.LibraryType;
@@ -57,6 +58,7 @@ import static org.mockito.Mockito.*;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.util.Collections;
 import java.util.Dictionary;
 import java.util.Hashtable;
 
@@ -327,6 +329,10 @@ public class VersionedClientlibsTransformerFactoryTest {
     @Test
     public void testProxiedJavaScriptClientLibrary() throws Exception {
 
+        ClientLibrary clientLibrary = mock(ClientLibrary.class);
+        when(clientLibrary.getTypes()).thenReturn(Collections.singleton(LibraryType.JS));
+        when(clientLibrary.allowProxy()).thenReturn(true);
+        when(htmlLibraryManager.getLibraries()).thenReturn(Collections.singletonMap(PROXIED_PATH, clientLibrary));
         when(htmlLibraryManager.getLibrary(eq(LibraryType.JS), eq(PROXIED_PATH))).thenReturn(proxiedHtmlLibrary);
 
         final AttributesImpl in = new AttributesImpl();


### PR DESCRIPTION
Avoids the documented warnings for proxied clientlibs by checking whether the respective clientlib exists using the method `HtmlLibraryManage#getLibraries()` before loading the HtmlLibrary as before.