### PR TITLE
Fixed for 6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ after the 3.9.0 release. All changes up until the 3.9.0 release can be found in 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ## Unreleased
-
+- #1487 - Fixing defect in touchui-limit-parsys that breaks touch ui authoring in 6.2
 ### Fixed
 - #1467 - Versioned ClientLibs cause WARN log messages on AEM 6.3
 - #1458 - Fixed issue where page date was not updated when modifying redirect map file
@@ -98,15 +98,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ### Changed
 - #1284 - Expose the shared and global properties resources via bindings.
-- #1323 - Remove PMD from pom.xml and added logging rules to CodeClimate's PMD configuration 
+- #1323 - Remove PMD from pom.xml and added logging rules to CodeClimate's PMD configuration
 - #1321 - Switch Jacoco coverage to run offline to improve reporting of Powermock covered code.
 
 ### Added
 - #1314 - Added cards to Tools > ACS Commons for the missing ACS Commons tooling.
-- #1237 - Reporting feature: Adding a report column for finding references to a resource 
+- #1237 - Reporting feature: Adding a report column for finding references to a resource
 - #1279 - New import tools for node metadata and file/url-based asset ingestion
 - #1307 - MCP now has error reporting and also XLSX export for errors.
-- #1238 - HTTP cache JCR storage 
+- #1238 - HTTP cache JCR storage
 - #1245 - On-Deploy Scripts Framework
 
 ### Fixed
@@ -184,7 +184,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ### Fixed
 
-- #1213 - Fixing Redirect Manager Action Load Issues 
+- #1213 - Fixing Redirect Manager Action Load Issues
 - #1204 - Unclosed stream in VersionedClientlibsTransformerFactory
 - #1205 - Calculate MD5 based on minified clientlib (in case minification is enabled). This is a workaround around the AEM limitation to only correctly invalidate either the minified or unminified clientlib).
 - #1217 - Make compile-scope dependencies provided-scope and add enforcer rule to ensure no compile scope dependencies are added in the future.
@@ -229,7 +229,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 - #1148 - Properly handle blank character encoding in SiteMapServlet
 - #1122 - Add clientlib category to touchui-widgets to load in Create Page wizard.
-- #1150 - Fix the empty datetime value displayed as "invalid date" in the touchui dialog 
+- #1150 - Fix the empty datetime value displayed as "invalid date" in the touchui dialog
 - #842 - Fix issue with Environment Indicator title being reset
 - #1143 - Remove current page from result from PagesReferenceProvider
 - #1156 - Remove unnecessary initialization of `window.Granite.author`
@@ -258,11 +258,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 ### Added
 
 - #916: AEM Assets Brand Portal workflow process and Agent filter
-- #958: Named Image Transform Servlet Sharpen transform 
+- #958: Named Image Transform Servlet Sharpen transform
 - #1005: Asset Folder Properties Support to allow custom fields/properties to be added to AEM Assets Folders in UI
 - #1039: Health Check Status E-mailer
 - #1041: QR Code to Publish in Page Editor
-- #1067: Vanity Path Web server re-writer mapping 
+- #1067: Vanity Path Web server re-writer mapping
 - Managed Controlled Processes framework with 5 sample tools: Folder Relocator, Page Relocator, Asset Report (space usage), Deep Prune, Asset Ingestor (aka AntEater v2)
 - `com.adobe.acs.commons.fam.actions.ActionsBatch` for bundling Fast Action Manager actions so multiple changes can be retried if any of them fail and break the commit.
 - Fast Action Manager now has a halt feature in the API which instantly stops an action manager and any of its scheduled work
@@ -276,14 +276,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ### Fixed
 
-- #982: Fixed issue with Touch UI Icon Picker was prefixing icon classes with 'fa' 
+- #982: Fixed issue with Touch UI Icon Picker was prefixing icon classes with 'fa'
 - #1008: E-mail subject mangled for non-latin chars
-- #1043: JCR Package Replication now populates the replicated by properties of the packaged resources with the actual user that requested the replication of the package (with configurable override via OSGi config for backwards compat) 
-- #1044: JCR Package Replication fixes a resource leak where the JCR Packages were not closed after being opened 
-- #1051: Emails sent via EmailService do not have connection/socket timeouts 
+- #1043: JCR Package Replication now populates the replicated by properties of the packaged resources with the actual user that requested the replication of the package (with configurable override via OSGi config for backwards compat)
+- #1044: JCR Package Replication fixes a resource leak where the JCR Packages were not closed after being opened
+- #1051: Emails sent via EmailService do not have connection/socket timeouts
 - #1064: Fixed NPE in ResourceServiceManager when no serviceReferences exist
 - Error page handler OSGi configuration missing web hint for 'not-found' behavior.
-- Touch UI Multi-field saved User-picker values were not populated in dialog 
+- Touch UI Multi-field saved User-picker values were not populated in dialog
 - Fast Action Manager is much more efficient in how it gauges CPU usage, which makes it even faster than before.
 
 ### Security
@@ -293,7 +293,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 - com.adobe.acs.commons.wcm.impl.PageRootProviderImpl has been deprecated. com.adobe.acs.commons.wcm.impl.PageRootProviderConfig should be used instead.
 
 <!---
- 
+
 ### Removed
 
 ---->

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/configure-limit-parsys/touchui-limit-parsys.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/configure-limit-parsys/touchui-limit-parsys.js
@@ -39,7 +39,7 @@
         //didn't find the function in util.js, we'll use _discover instead.
         return Granite.author.components._discover(design, path);
       }
-     };
+     }
     /**
      * mostly taken over from /libs/cq/gui/components/authoring/editors/clientlibs/core/js/storage/components.js _findAllowedComponentsFromPolicy
      */

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/configure-limit-parsys/touchui-limit-parsys.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/configure-limit-parsys/touchui-limit-parsys.js
@@ -27,19 +27,31 @@
     "use strict";
 
     var ACS_COMPONENTS_LIMIT = "acsComponentsLimit";
-
+    /** AEM 6.2 does not have the function resolveProperty in util.js and thus
+    * breaks authoring on a supported version. To deal with this we need to detect
+    * if the function is available and fallback to 6.2 functions if it is not.
+    */
+    function correctlyResolveProperty(design, path){
+      if ("resolveProperty" in Granite.author.util) {
+        //function was found, use it.
+        return Granite.author.util.resolveProperty(design, path);
+      }else{
+        //didn't find the function in util.js, we'll use _discover instead.
+        return Granite.author.components._discover(design, path);
+      }
+     };
     /**
      * mostly taken over from /libs/cq/gui/components/authoring/editors/clientlibs/core/js/storage/components.js _findAllowedComponentsFromPolicy
      */
     function _findPropertyFromPolicy(editable, design, propertyName) {
-        var cell = Granite.author.util.resolveProperty(design, editable.config.policyPath);
+        var cell = correctlyResolveProperty(design, editable.config.policyPath);
 
         if (!cell || !cell[propertyName]) {
             // Inherit property also from its parent (if not set in the local policy path)
             var parent = Granite.author.editables.getParent(editable);
 
             while (parent && !(cell && cell[propertyName])) {
-                cell = Granite.author.util.resolveProperty(design, parent.config.policyPath);
+                cell = correctlyResolveProperty(design, parent.config.policyPath);
                 parent = Granite.author.editables.getParent(parent);
             }
         }
@@ -63,7 +75,7 @@
 
                 if (cellSearchPaths) {
                     for (var i = 0; i < cellSearchPaths.length; i++) {
-                        var cell = Granite.author.util.resolveProperty(design, cellSearchPaths[i]);
+                        var cell = correctlyResolveProperty(design, cellSearchPaths[i]);
 
                         if (cell && cell[propertyName]) {
                             return cell[propertyName];


### PR DESCRIPTION
Fallback on _discover if resolveProperty is not available (it's not in 6.2 SP1). This breaks adding new components to the page in 6.2 SP1