### PR TITLE
Fix for #526: try get the resource in the ancestor loop first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 ## Unreleased
 
 ### Fixed
+- #1490 - Fixed issue in Error Page Handler where /etc/map'd content confused 'real resource' look-up.
 - #1467 - Versioned ClientLibs cause WARN log messages on AEM 6.3
 - #1458 - Fixed issue where page date was not updated when modifying redirect map file
 

--- a/bundle/src/main/java/com/adobe/acs/commons/errorpagehandler/impl/ErrorPageHandlerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/errorpagehandler/impl/ErrorPageHandlerImpl.java
@@ -530,7 +530,7 @@ public final class ErrorPageHandlerImpl implements ErrorPageHandlerService {
         if (!StringUtils.equals(path, errorResource.getPath())) {
             // Only resolve the resource if the path of the errorResource is different from the cleaned up path; else
             // we know the errorResource and what the path resolves to is the same
-            // #1415 - First try to get get the resource at the direct path; this look-up is very fast (compared to rr.resolve and often what's required)
+            // #1415 - First try to get the resource at the direct path; this look-up is very fast (compared to rr.resolve and often what's required)
             resource = resourceResolver.getResource(path);
 
             if (resource == null) {
@@ -560,6 +560,13 @@ public final class ErrorPageHandlerImpl implements ErrorPageHandlerService {
         for (int i = parts.length - 1; i >= 0; i--) {
             String[] tmpArray = (String[]) ArrayUtils.subarray(parts, 0, i);
             String candidatePath = "/".concat(StringUtils.join(tmpArray, '/'));
+
+            // #1415 - First try to get the resource at the direct path; this look-up is
+            // very fast (compared to rr.resolve and often what's required)
+            final Resource candidatePathResource = resourceResolver.getResource(candidatePath);
+            if (candidatePathResource != null) {
+                return candidatePathResource;
+            }
 
             final Resource candidateResource = resourceResolver.resolve(request, candidatePath);
 


### PR DESCRIPTION
For my use case, i need to try the get resource in the loop to find the first existing ancestor.

This works for me.
Please check, if it break another use case.