### PR TITLE
Decode attribute value before mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ after the 3.9.0 release. All changes up until the 3.9.0 release can be found in 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+- #1492 - Fix double encoding with Resource Resolver Mapping Rewriter.
 
 ### Fixed
 - #1467 - Versioned ClientLibs cause WARN log messages on AEM 6.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ after the 3.9.0 release. All changes up until the 3.9.0 release can be found in 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+### Fixed
+- #1492 - Avoid double encoding with Resource Resolver Mapping Rewriter
 
 ## [3.18.0] - 2018-09-24
 
@@ -13,7 +15,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 - #1460 - Adobe.IO Integration donated by Emerging Technologies EMEA team
 
 ### Fixed
-- #1492 - Avoid double encoding with Resource Resolver Mapping Rewriter
 - #1428 - URL Asset Import retain case sensitivity in column names
 - #1458 - Fixed issue where page date was not updated when modifying redirect map file
 - #1467 - Versioned ClientLibs cause WARN log messages on AEM 6.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ after the 3.9.0 release. All changes up until the 3.9.0 release can be found in 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ## Unreleased
-- #1492 - Fix double encoding with Resource Resolver Mapping Rewriter.
 
 ### Fixed
+- #1492 - Avoid double encoding with Resource Resolver Mapping Rewriter
 - #1467 - Versioned ClientLibs cause WARN log messages on AEM 6.3
 - #1458 - Fixed issue where page date was not updated when modifying redirect map file
 


### PR DESCRIPTION
The resource resolver map transformer needs to first decode the attribute before passing it on to be mapped since the resolver map function is returning an encoded value. 
If the attribute is encoded before passing to map, the result is a double encoded value which results in 404 errors.