### PR TITLE
allow configured 404 page to not include higher components/templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 - #1480 - Adobe I/O healthcheck must only check 1 onepoint
 - #1487 - Fixing defect in touchui-limit-parsys that breaks touch ui authoring in 6.2
 - #1488 - TouchUI breaks in 6.2 because of using 6.3 JS functions
+- #1495 - Error Page Handler doesn't reset the `com.day.cq.wcm.componentcontext` request attribute
 
 ### Changed
 - #1469 - Exclude transitive dependency on unreleased commons-imaging via AEM Mocks.

--- a/bundle/src/main/java/com/adobe/acs/commons/errorpagehandler/impl/ErrorPageHandlerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/errorpagehandler/impl/ErrorPageHandlerImpl.java
@@ -783,6 +783,9 @@ public final class ErrorPageHandlerImpl implements ErrorPageHandlerService {
         request.setAttribute("com.adobe.granite.ui.clientlibs.HtmlLibraryManager.included",
                 new HashSet<String>());
 
+        //Reset the component context attribute to remove inclusion of response from top level components
+        request.removeAttribute("com.day.cq.wcm.componentcontext");
+
         // Clear the response
         response.reset();
         response.setContentType("text/html");

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/errorpagehandler/404.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/errorpagehandler/404.jsp
@@ -40,6 +40,7 @@
 
 			if (path != null) {
 				slingResponse.setStatus(404);
+                errorPageHandlerService.resetRequestAndResponse(slingRequest, slingResponse, 404);
 				errorPageHandlerService.includeUsingGET(slingRequest, slingResponse, path);
 				return;
             }


### PR DESCRIPTION
… reset method to remove TopLevelComponent context and let the configured 404 page load correctly. The 404 jsp now calls the reset method.