### PR TITLE
Fix #1516 Undefined exception on configure-limit-parsys.min.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 - #1497 - Javadoc improvement in EndpointService
 - #1506 - Fixed path browser input fields in MCP to work on AEM 6.4
 - #1501 - Error downloading reports from MCP processes with 6.3.3.0
+- #1516 - Undefined exception on configure-limit-parsys.min.js
 
 ## [3.18.2] - 2018-09-26
 

--- a/content/src/main/content/jcr_root/apps/acs-commons/widgets/configure-limit-parsys/classicui-limit-parsys.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/widgets/configure-limit-parsys/classicui-limit-parsys.js
@@ -69,6 +69,9 @@
             for(var i = 0; i < parNames.length; i++){
                 var prop = parNames[i];
                 cellSearchPathInfo = cellSearchPathInfo[prop];
+                if (!cellSearchPathInfo) {
+                    return;
+                }
             }
             currentLimit = cellSearchPathInfo[ACS_COMPONENTS_LIMIT];
             if(currentLimit){


### PR DESCRIPTION
This prevent the exception since it would not have the  ACS_COMPONENTS_LIMIT configured for it. So in this case this should not trow any error.