### PR TITLE
Ensures no resource check duplication

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/users/impl/EnsureAce.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/users/impl/EnsureAce.java
@@ -267,6 +267,7 @@ public class EnsureAce {
                 final Resource contentResource = aceResource.getParent().getParent();
 
                 if (!paths.contains(contentResource.getPath())) {
+                    paths.add(contentResource.getPath());
                     for (AccessControlPolicy policy : accessControlManager.getPolicies(contentResource.getPath())) {
                         if (policy instanceof JackrabbitAccessControlList) {
                             acls.add((JackrabbitAccessControlList) policy);


### PR DESCRIPTION
Ensures the current resource path hasn't already been checked

To be honest, I'm not sure this check is even necessary, you could probably get rid of the paths check too.