### PR TITLE
Feature/action manager priority queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 ## [Unreleased]
 
 ### Added
-- #TBD - Added a priority to the Action Manager and associated classes so that Actions can executed in order of priority.
+- #1526 - Added a priority to the Action Manager and associated classes so that Actions can executed in order of priority.
 
 ### Changed
 - #1523 - Added check to EnsureACEs to avoid duplicate path processing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
 
+### Added
+- #TBD - Added a priority to the Action Manager and associated classes so that Actions can executed in order of priority.
+
 ### Changed
 - #1523 - Added check to EnsureACEs to avoid duplicate path processing.
 

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/ActionManagerConstants.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/ActionManagerConstants.java
@@ -1,0 +1,31 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.fam;
+
+public class ActionManagerConstants {
+
+    private ActionManagerConstants() {
+        //no instances of constants class
+    }
+
+    public static final int DEFAULT_ACTION_PRIORITY = 0;
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/ActionManagerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/ActionManagerFactory.java
@@ -30,8 +30,6 @@ import org.apache.sling.api.resource.ResourceResolver;
 @ProviderType
 public interface ActionManagerFactory extends ActionManagerMBean {
 
-    int DEFAULT_PRIORITY = 0;
-
     /**
      * Creates an ActionManager instead with the provided name and JCR context provided bu the resourceResolver.
      * @param name the name of the ActionManager. This method guarantee uniqueness of the action manager name.

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/ActionManagerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/ActionManagerFactory.java
@@ -29,6 +29,9 @@ import org.apache.sling.api.resource.ResourceResolver;
  */
 @ProviderType
 public interface ActionManagerFactory extends ActionManagerMBean {
+
+    int DEFAULT_PRIORITY = 0;
+
     /**
      * Creates an ActionManager instead with the provided name and JCR context provided bu the resourceResolver.
      * @param name the name of the ActionManager. This method guarantee uniqueness of the action manager name.
@@ -38,6 +41,17 @@ public interface ActionManagerFactory extends ActionManagerMBean {
      * @throws LoginException
      */
     public ActionManager createTaskManager(String name, ResourceResolver resourceResolver, int saveInterval) throws LoginException;
+
+    /**
+     * Creates an ActionManager instead with the provided name and JCR context provided bu the resourceResolver.
+     * @param name the name of the ActionManager. This method guarantee uniqueness of the action manager name.
+     * @param resourceResolver the resourceResolver used to perform
+     * @param saveInterval the number of changed that must incur on the resourceResolver before commit() is called (in support of batch saves)
+     * @param priority the priority of execution for the tasks in this action manager
+     * @return the created ActionManager
+     * @throws LoginException
+     */
+    public ActionManager createTaskManager(String name, ResourceResolver resourceResolver, int saveInterval, int priority) throws LoginException;
 
     /**
      * Gets the named ActionManager from the ActionManagerFactory.

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/ThrottledTaskRunner.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/ThrottledTaskRunner.java
@@ -41,7 +41,6 @@ public interface ThrottledTaskRunner extends ThrottledTaskRunnerMBean {
      * Schedule some kind of work to run in the future using the internal thread pool.
      * The work will be throttled according to the CPU/Memory settings
      * @param work
-     * @param priority the priority of the task
      */
     void scheduleWork(Runnable work);
 
@@ -50,7 +49,6 @@ public interface ThrottledTaskRunner extends ThrottledTaskRunnerMBean {
      * The work will be throttled according to the CPU/Memory settings.  This action can be canceled at any time.
      * @param work
      * @param cancelHandler
-     * @param priority the priority of the task
      */
     void scheduleWork(Runnable work, CancelHandler cancelHandler);
 

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/ThrottledTaskRunner.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/ThrottledTaskRunner.java
@@ -40,17 +40,36 @@ public interface ThrottledTaskRunner extends ThrottledTaskRunnerMBean {
     /**
      * Schedule some kind of work to run in the future using the internal thread pool.
      * The work will be throttled according to the CPU/Memory settings
-     * @param work 
+     * @param work
+     * @param priority the priority of the task
      */
     void scheduleWork(Runnable work);
 
     /**
      * Schedule some kind of work to run in the future using the internal thread pool.
      * The work will be throttled according to the CPU/Memory settings.  This action can be canceled at any time.
-     * @param work 
+     * @param work
      * @param cancelHandler
+     * @param priority the priority of the task
      */
     void scheduleWork(Runnable work, CancelHandler cancelHandler);
+
+    /**
+     * Schedule some kind of work to run in the future using the internal thread pool.
+     * The work will be throttled according to the CPU/Memory settings
+     * @param work
+     * @param priority the priority of the task
+     */
+    void scheduleWork(Runnable work, int priority);
+
+    /**
+     * Schedule some kind of work to run in the future using the internal thread pool.
+     * The work will be throttled according to the CPU/Memory settings.  This action can be canceled at any time.
+     * @param work 
+     * @param cancelHandler
+     * @param priority the priority of the task
+     */
+    void scheduleWork(Runnable work, CancelHandler cancelHandler, int priority);
     
     /**
      * Record statistics

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/impl/ActionManagerFactoryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/impl/ActionManagerFactoryImpl.java
@@ -20,6 +20,7 @@
 package com.adobe.acs.commons.fam.impl;
 
 import com.adobe.acs.commons.fam.ActionManager;
+import com.adobe.acs.commons.fam.ActionManagerConstants;
 import com.adobe.acs.commons.fam.ActionManagerFactory;
 import com.adobe.acs.commons.fam.ThrottledTaskRunner;
 import com.adobe.acs.commons.fam.mbean.ActionManagerMBean;
@@ -58,7 +59,7 @@ public class ActionManagerFactoryImpl extends AnnotatedStandardMBean implements 
 
     @Override
     public ActionManager createTaskManager(String name, ResourceResolver resourceResolver, int saveInterval) throws LoginException {
-        return this.createTaskManager(name, resourceResolver, saveInterval, DEFAULT_PRIORITY);
+        return this.createTaskManager(name, resourceResolver, saveInterval, ActionManagerConstants.DEFAULT_ACTION_PRIORITY);
     }
 
     @Override

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/impl/ActionManagerFactoryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/impl/ActionManagerFactoryImpl.java
@@ -63,10 +63,10 @@ public class ActionManagerFactoryImpl extends AnnotatedStandardMBean implements 
     }
 
     @Override
-    public ActionManager createTaskManager(String name, ResourceResolver resourceResolver, int saveInterval, int priroty) throws LoginException {
+    public ActionManager createTaskManager(String name, ResourceResolver resourceResolver, int saveInterval, int priority) throws LoginException {
         String fullName = String.format("%s (%s)", name, UUID.randomUUID().toString());
         
-        ActionManagerImpl manager = new ActionManagerImpl(fullName, taskRunner, resourceResolver, saveInterval, priroty);
+        ActionManagerImpl manager = new ActionManagerImpl(fullName, taskRunner, resourceResolver, saveInterval, priority);
         tasks.put(fullName, manager);
         return manager;
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/impl/ActionManagerFactoryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/impl/ActionManagerFactoryImpl.java
@@ -45,6 +45,7 @@ import org.apache.sling.api.resource.ResourceResolver;
 @Property(name = "jmx.objectname", value = "com.adobe.acs.commons:type=Action Manager")
 public class ActionManagerFactoryImpl extends AnnotatedStandardMBean implements ActionManagerFactory {
 
+
     @Reference
     ThrottledTaskRunner taskRunner;
     
@@ -54,12 +55,17 @@ public class ActionManagerFactoryImpl extends AnnotatedStandardMBean implements 
         super(ActionManagerMBean.class);
         tasks = Collections.synchronizedMap(new LinkedHashMap<>());
     }
-    
+
     @Override
     public ActionManager createTaskManager(String name, ResourceResolver resourceResolver, int saveInterval) throws LoginException {
+        return this.createTaskManager(name, resourceResolver, saveInterval, DEFAULT_PRIORITY);
+    }
+
+    @Override
+    public ActionManager createTaskManager(String name, ResourceResolver resourceResolver, int saveInterval, int priroty) throws LoginException {
         String fullName = String.format("%s (%s)", name, UUID.randomUUID().toString());
         
-        ActionManagerImpl manager = new ActionManagerImpl(fullName, taskRunner, resourceResolver, saveInterval);
+        ActionManagerImpl manager = new ActionManagerImpl(fullName, taskRunner, resourceResolver, saveInterval, priroty);
         tasks.put(fullName, manager);
         return manager;
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/impl/ActionManagerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/impl/ActionManagerImpl.java
@@ -42,6 +42,7 @@ import javax.management.openmbean.OpenType;
 import javax.management.openmbean.SimpleType;
 import javax.management.openmbean.TabularType;
 
+import com.adobe.acs.commons.fam.ActionManagerConstants;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -49,7 +50,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.adobe.acs.commons.fam.ActionManager;
-import com.adobe.acs.commons.fam.ActionManagerFactory;
 import com.adobe.acs.commons.fam.CancelHandler;
 import com.adobe.acs.commons.fam.Failure;
 import com.adobe.acs.commons.fam.ThrottledTaskRunner;
@@ -98,7 +98,7 @@ class ActionManagerImpl extends CancelHandler implements ActionManager, Serializ
     private final transient List<Runnable> finishHandlers = Collections.synchronizedList(new ArrayList<>());
 
     ActionManagerImpl(String name, ThrottledTaskRunner taskRunner, ResourceResolver resolver, int saveInterval) throws LoginException {
-        this(name, taskRunner, resolver, saveInterval, ActionManagerFactory.DEFAULT_PRIORITY);
+        this(name, taskRunner, resolver, saveInterval, ActionManagerConstants.DEFAULT_ACTION_PRIORITY);
     }
 
     ActionManagerImpl(String name, ThrottledTaskRunner taskRunner, ResourceResolver resolver, int saveInterval, int priority) throws LoginException {

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/impl/PriorityThreadPoolExecutor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/impl/PriorityThreadPoolExecutor.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.fam.impl;
 
 import java.util.concurrent.BlockingQueue;

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/impl/PriorityThreadPoolExecutor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/impl/PriorityThreadPoolExecutor.java
@@ -7,23 +7,39 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * A custom extension of the thread pool executor which uses our {@link TimedRunnableFuture} implementation.
+ * This ensures that deferred tasks still respect the priority and don't cause errors when those are cast to {@link Comparable}.
+ */
 public class PriorityThreadPoolExecutor extends ThreadPoolExecutor {
 
+    /**
+     * {@inheritDoc}
+     */
     public PriorityThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit,
             BlockingQueue<Runnable> workQueue) {
         super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public PriorityThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit,
             BlockingQueue<Runnable> workQueue, ThreadFactory threadFactory) {
         super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public PriorityThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit,
             BlockingQueue<Runnable> workQueue, RejectedExecutionHandler handler) {
         super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, handler);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public PriorityThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit,
             BlockingQueue<Runnable> workQueue, ThreadFactory threadFactory, RejectedExecutionHandler handler) {
         super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory, handler);

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/impl/PriorityThreadPoolExecutor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/impl/PriorityThreadPoolExecutor.java
@@ -1,0 +1,36 @@
+package com.adobe.acs.commons.fam.impl;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.RunnableFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class PriorityThreadPoolExecutor extends ThreadPoolExecutor {
+
+    public PriorityThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit,
+            BlockingQueue<Runnable> workQueue) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue);
+    }
+
+    public PriorityThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit,
+            BlockingQueue<Runnable> workQueue, ThreadFactory threadFactory) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory);
+    }
+
+    public PriorityThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit,
+            BlockingQueue<Runnable> workQueue, RejectedExecutionHandler handler) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, handler);
+    }
+
+    public PriorityThreadPoolExecutor(int corePoolSize, int maximumPoolSize, long keepAliveTime, TimeUnit unit,
+            BlockingQueue<Runnable> workQueue, ThreadFactory threadFactory, RejectedExecutionHandler handler) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue, threadFactory, handler);
+    }
+
+    @Override
+    protected <T> RunnableFuture<T> newTaskFor(Runnable runnable, T value) {
+        return new TimedRunnableFuture(runnable, value);
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/impl/ThrottledTaskRunnerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/impl/ThrottledTaskRunnerImpl.java
@@ -19,7 +19,7 @@
  */
 package com.adobe.acs.commons.fam.impl;
 
-import com.adobe.acs.commons.fam.ActionManagerFactory;
+import com.adobe.acs.commons.fam.ActionManagerConstants;
 import com.adobe.acs.commons.fam.CancelHandler;
 import com.adobe.acs.commons.fam.ThrottledTaskRunner;
 import com.adobe.acs.commons.fam.mbean.ThrottledTaskRunnerMBean;
@@ -50,10 +50,8 @@ import java.lang.management.ManagementFactory;
 import java.util.Dictionary;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 @Component(metatype = true, immediate = true,
@@ -88,12 +86,12 @@ public class ThrottledTaskRunnerImpl extends AnnotatedStandardMBean implements T
 
     @Override
     public void scheduleWork(Runnable work) {
-        TimedRunnable r = new TimedRunnable(work, this, taskTimeout, TimeUnit.MILLISECONDS, ActionManagerFactory.DEFAULT_PRIORITY);
+        TimedRunnable r = new TimedRunnable(work, this, taskTimeout, TimeUnit.MILLISECONDS, ActionManagerConstants.DEFAULT_ACTION_PRIORITY);
         workerPool.submit(r);
     }
 
     public void scheduleWork(Runnable work, CancelHandler cancelHandler) {
-        TimedRunnable r = new TimedRunnable(work, this, taskTimeout, TimeUnit.MILLISECONDS, cancelHandler, ActionManagerFactory.DEFAULT_PRIORITY);
+        TimedRunnable r = new TimedRunnable(work, this, taskTimeout, TimeUnit.MILLISECONDS, cancelHandler, ActionManagerConstants.DEFAULT_ACTION_PRIORITY);
         workerPool.submit(r);
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/impl/ThrottledTaskRunnerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/impl/ThrottledTaskRunnerImpl.java
@@ -79,7 +79,7 @@ public class ThrottledTaskRunnerImpl extends AnnotatedStandardMBean implements T
     private final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
     private ObjectName osBeanName;
     private ObjectName memBeanName;
-    private ThreadPoolExecutor workerPool;
+    private PriorityThreadPoolExecutor workerPool;
     private BlockingQueue<Runnable> workQueue;
 
     public ThrottledTaskRunnerImpl() throws NotCompliantMBeanException {
@@ -299,7 +299,7 @@ public class ThrottledTaskRunnerImpl extends AnnotatedStandardMBean implements T
             workerPool = null;
         }
         if (!isRunning()) {
-            workerPool = new ThreadPoolExecutor(maxThreads, maxThreads, taskTimeout, TimeUnit.MILLISECONDS, workQueue);
+            workerPool = new PriorityThreadPoolExecutor(maxThreads, maxThreads, taskTimeout, TimeUnit.MILLISECONDS, workQueue);
         }
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/impl/TimedRunnable.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/impl/TimedRunnable.java
@@ -24,18 +24,21 @@ import com.adobe.acs.commons.fam.ThrottledTaskRunner;
 import java.util.Optional;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.xmlbeans.impl.xb.substwsdl.TImport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Runnable task that has a time limit
  */
-public class TimedRunnable implements Runnable {
+public class TimedRunnable implements Runnable, Comparable {
 
     long created = System.currentTimeMillis();
     long started = -1;
     long executed = -1;
     long finished = -1;
+    int priority;
     Runnable work;
     ThrottledTaskRunner runner;
     int timeout;
@@ -43,16 +46,17 @@ public class TimedRunnable implements Runnable {
     Optional<CancelHandler> cancelHandler = Optional.empty();
     private static final Logger LOG = LoggerFactory.getLogger(TimedRunnable.class);
 
-    public TimedRunnable(Runnable work, ThrottledTaskRunner runner, int timeout, TimeUnit timeoutUnit) {
+    public TimedRunnable(Runnable work, ThrottledTaskRunner runner, int timeout, TimeUnit timeoutUnit, int priority) {
         this.work = work;
         this.runner = runner;
         this.timeout = timeout;
         this.timeoutUnit = timeoutUnit;
+        this.priority = priority;
         LOG.debug("Task created");
     }
 
-    public TimedRunnable(Runnable work, ThrottledTaskRunner runner, int timeout, TimeUnit timeoutUnit, CancelHandler cancelHandler) {
-        this(work, runner, timeout, timeoutUnit);
+    public TimedRunnable(Runnable work, ThrottledTaskRunner runner, int timeout, TimeUnit timeoutUnit, CancelHandler cancelHandler, int priority) {
+        this(work, runner, timeout, timeoutUnit, priority);
         this.cancelHandler = Optional.of(cancelHandler);
     }
 
@@ -108,5 +112,17 @@ public class TimedRunnable implements Runnable {
                 workThread.interrupt();
             }
         };
+    }
+
+    @Override
+    public int compareTo(Object o) {
+        if(o instanceof TimedRunnable) {
+            TimedRunnable other = (TimedRunnable) o;
+            int compareResult = this.priority - other.priority;
+
+            return compareResult;
+        }
+
+        return 0;
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/impl/TimedRunnable.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/impl/TimedRunnable.java
@@ -19,15 +19,15 @@
  */
 package com.adobe.acs.commons.fam.impl;
 
-import com.adobe.acs.commons.fam.CancelHandler;
-import com.adobe.acs.commons.fam.ThrottledTaskRunner;
 import java.util.Optional;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.xmlbeans.impl.xb.substwsdl.TImport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.adobe.acs.commons.fam.CancelHandler;
+import com.adobe.acs.commons.fam.ThrottledTaskRunner;
 
 /**
  * Runnable task that has a time limit
@@ -118,7 +118,7 @@ public class TimedRunnable implements Runnable, Comparable {
     public int compareTo(Object o) {
         if(o instanceof TimedRunnable) {
             TimedRunnable other = (TimedRunnable) o;
-            int compareResult = this.priority - other.priority;
+            int compareResult = other.priority - this.priority;
 
             return compareResult;
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/impl/TimedRunnableFuture.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/impl/TimedRunnableFuture.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 
 package com.adobe.acs.commons.fam.impl;
 

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/impl/TimedRunnableFuture.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/impl/TimedRunnableFuture.java
@@ -1,0 +1,35 @@
+
+package com.adobe.acs.commons.fam.impl;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.FutureTask;
+
+public class TimedRunnableFuture extends FutureTask implements Comparable {
+
+    private TimedRunnable timedRunnable;
+
+    public TimedRunnableFuture(Callable callable) {
+        super(callable);
+    }
+
+    public TimedRunnableFuture(Runnable runnable, Object result) {
+        super(runnable, result);
+        if(runnable instanceof TimedRunnable) {
+            timedRunnable = (TimedRunnable) runnable;
+        }
+    }
+
+    @Override
+    public int compareTo(Object o) {
+        if(o instanceof TimedRunnableFuture) {
+            TimedRunnableFuture other = (TimedRunnableFuture) o;
+            TimedRunnable otherTimedRunnable = other.timedRunnable;
+            if(otherTimedRunnable!=null && timedRunnable!=null) {
+                return timedRunnable.compareTo(otherTimedRunnable);
+            } else {
+                return 0;
+            }
+        }
+        return 0;
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/impl/TimedRunnableFuture.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/impl/TimedRunnableFuture.java
@@ -4,14 +4,23 @@ package com.adobe.acs.commons.fam.impl;
 import java.util.concurrent.Callable;
 import java.util.concurrent.FutureTask;
 
+/**
+ * A runnable future for {@link TimedRunnable} which implements comparable for the purpsoe of priority execution.
+ */
 public class TimedRunnableFuture extends FutureTask implements Comparable {
 
     private TimedRunnable timedRunnable;
 
+    /**
+     * {@inheritDoc}
+     */
     public TimedRunnableFuture(Callable callable) {
         super(callable);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public TimedRunnableFuture(Runnable runnable, Object result) {
         super(runnable, result);
         if(runnable instanceof TimedRunnable) {

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/package-info.java
@@ -17,5 +17,5 @@
  * limitations under the License.
  * #L%
  */
-@aQute.bnd.annotation.Version("2.3.0")
+@aQute.bnd.annotation.Version("2.4.0")
 package com.adobe.acs.commons.fam;

--- a/bundle/src/test/java/com/adobe/acs/commons/fam/impl/ActionManagerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/fam/impl/ActionManagerTest.java
@@ -20,6 +20,7 @@
 package com.adobe.acs.commons.fam.impl;
 
 import com.adobe.acs.commons.fam.ActionManager;
+import com.adobe.acs.commons.fam.CancelHandler;
 import com.adobe.acs.commons.fam.ThrottledTaskRunner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -51,11 +52,19 @@ public class ActionManagerTest {
         doAnswer(i -> {
             run((Runnable) i.getArguments()[0]);
             return null;
-        }).when(taskRunner).scheduleWork(any());
+        }).when(taskRunner).scheduleWork(any(Runnable.class));
         doAnswer(i -> {
             run((Runnable) i.getArguments()[0]);
             return null;
-        }).when(taskRunner).scheduleWork(any(), any());
+        }).when(taskRunner).scheduleWork(any(Runnable.class),any(CancelHandler.class));
+        doAnswer(i -> {
+            run((Runnable) i.getArguments()[0]);
+            return null;
+        }).when(taskRunner).scheduleWork(any(Runnable.class), any(CancelHandler.class), anyInt());
+        doAnswer(i -> {
+            run((Runnable) i.getArguments()[0]);
+            return null;
+        }).when(taskRunner).scheduleWork(any(Runnable.class), anyInt());
 
         return taskRunner;
     }

--- a/bundle/src/test/java/com/adobe/acs/commons/fam/impl/ThrottledTaskRunnerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/fam/impl/ThrottledTaskRunnerTest.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.fam.impl;
 
 import static org.junit.Assert.assertEquals;

--- a/bundle/src/test/java/com/adobe/acs/commons/fam/impl/ThrottledTaskRunnerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/fam/impl/ThrottledTaskRunnerTest.java
@@ -1,17 +1,19 @@
 package com.adobe.acs.commons.fam.impl;
 
-import com.adobe.acs.commons.fam.ThrottledTaskRunner;
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.management.NotCompliantMBeanException;
+
 import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.management.NotCompliantMBeanException;
-import java.util.ArrayList;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
+import com.adobe.acs.commons.fam.ThrottledTaskRunner;
 
 public class ThrottledTaskRunnerTest {
 
@@ -30,9 +32,10 @@ public class ThrottledTaskRunnerTest {
             int finalI = i;
             ttr.scheduleWork(() -> {
                 try {
-                    Thread.sleep(1000);
+                    // sleep to slow these down so that higher priority tasks go first
+                    Thread.sleep(500);
                 } catch (InterruptedException e) {
-                    e.printStackTrace();
+                    log.error("", e);
                 }
                 log.info("normal priority: {}" + finalI);
                 executions.add(1L);
@@ -57,13 +60,10 @@ public class ThrottledTaskRunnerTest {
         //first 4 items are normal (4 threads execute)
         //next 10 are high
         //then the final 6 items
-        assertEquals("", 20, executions.size());
-        assertEquals("", 1L, executions.get(19).longValue());
-        assertEquals("", 1L, executions.get(18).longValue());
-        assertEquals("", 1L, executions.get(17).longValue());
-        assertEquals("", 1L, executions.get(16).longValue());
-        assertEquals("", 1L, executions.get(15).longValue());
-        assertEquals("", 1L, executions.get(14).longValue());
+        assertEquals("wrong number of items executed", 20, executions.size());
+        for (int i = 19; i > (19 - 6); i--) {
+            assertEquals("wrong priority for item: " + i, 1L, executions.get(i).longValue());
+        }
 
     }
 

--- a/bundle/src/test/java/com/adobe/acs/commons/fam/impl/ThrottledTaskRunnerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/fam/impl/ThrottledTaskRunnerTest.java
@@ -37,7 +37,7 @@ public class ThrottledTaskRunnerTest {
                 } catch (InterruptedException e) {
                     log.error("", e);
                 }
-                log.info("normal priority: {}" + finalI);
+                log.info("normal priority: {}",  finalI);
                 executions.add(1L);
             }, 1);
         }
@@ -46,7 +46,7 @@ public class ThrottledTaskRunnerTest {
         for(int i=0;i<10;i++) {
             int finalI = i;
             ttr.scheduleWork(() -> {
-                log.info("high priority: {}" + finalI);
+                log.info("high priority: {}", finalI);
                 executions.add(5L);
             }, 5);
         }

--- a/bundle/src/test/java/com/adobe/acs/commons/fam/impl/ThrottledTaskRunnerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/fam/impl/ThrottledTaskRunnerTest.java
@@ -1,0 +1,70 @@
+package com.adobe.acs.commons.fam.impl;
+
+import com.adobe.acs.commons.fam.ThrottledTaskRunner;
+import org.apache.sling.testing.mock.osgi.junit.OsgiContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.NotCompliantMBeanException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ThrottledTaskRunnerTest {
+
+    @Rule
+    public final OsgiContext osgiContext = new OsgiContext();
+
+    private static final Logger log = LoggerFactory.getLogger(ThrottledTaskRunnerTest.class);
+
+    @Test
+    public void testExecutionOrder() throws NotCompliantMBeanException, InterruptedException {
+        ThrottledTaskRunner ttr = osgiContext.registerInjectActivateService(new ThrottledTaskRunnerImpl());
+
+        List<Long> executions = new ArrayList<>();
+
+        for(int i=0;i<10;i++) {
+            int finalI = i;
+            ttr.scheduleWork(() -> {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+                log.info("normal priority: {}" + finalI);
+                executions.add(1L);
+            }, 1);
+        }
+
+
+        for(int i=0;i<10;i++) {
+            int finalI = i;
+            ttr.scheduleWork(() -> {
+                log.info("high priority: {}" + finalI);
+                executions.add(5L);
+            }, 5);
+        }
+
+        while(ttr.getActiveCount() > 0) {
+            Thread.sleep(1000);
+        }
+
+        //assert that the last 6 items in the list are all priority 1 (normal)
+        //it's hard to guarantee the exact order before that, but the general expectation is the order
+        //first 4 items are normal (4 threads execute)
+        //next 10 are high
+        //then the final 6 items
+        assertEquals("", 20, executions.size());
+        assertEquals("", 1L, executions.get(19).longValue());
+        assertEquals("", 1L, executions.get(18).longValue());
+        assertEquals("", 1L, executions.get(17).longValue());
+        assertEquals("", 1L, executions.get(16).longValue());
+        assertEquals("", 1L, executions.get(15).longValue());
+        assertEquals("", 1L, executions.get(14).longValue());
+
+    }
+
+}


### PR DESCRIPTION
I think this is mostly self explanatory.  By adding an optional parameter to the action manager for the priority, we can give tasks a priority and order their execution based on this priority.

While this does not exactly guarantee the order of execution (could vary depending on how long various tasks take), it does allow you to order tasks that are more important first.  For example, you may want to execute more resource intensive tasks first to free up those resources for other things.