### PR TITLE
Creation of ResourceResolvers in a try-with-resource clause

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/dam/impl/ReviewTaskAssetMoverHandler.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/dam/impl/ReviewTaskAssetMoverHandler.java
@@ -159,10 +159,8 @@ public class ReviewTaskAssetMoverHandler implements EventHandler {
 
     @Override
     public void handleEvent(Event event) {
-        ResourceResolver resourceResolver = null;
 
-        try {
-            resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO);
+        try (ResourceResolver resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO)){
             final String path = (String) event.getProperty("TaskId");
             final Resource taskResource = resourceResolver.getResource(path);
 
@@ -186,11 +184,6 @@ public class ReviewTaskAssetMoverHandler implements EventHandler {
             }
         } catch (LoginException e) {
             log.error("Could not get resource resolver", e);
-        } finally {
-            // Always close resource resolvers you open
-            if (resourceResolver != null) {
-                resourceResolver.close();
-            }
         }
     }
 
@@ -203,10 +196,7 @@ public class ReviewTaskAssetMoverHandler implements EventHandler {
 
         @Override
         public void run() {
-            ResourceResolver resourceResolver = null;
-            try {
-                // Always use service users; never admin resource resolvers for "real" code
-                resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO);
+            try (ResourceResolver resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO)){
 
                 // Access data passed into the Job from the Event
                 Resource resource = resourceResolver.getResource(path);
@@ -229,11 +219,6 @@ public class ReviewTaskAssetMoverHandler implements EventHandler {
                 }
             } catch (Exception e) {
                 log.error("Could not process Review Task Mover", e);
-            } finally {
-                // Always close resource resolvers you open
-                if (resourceResolver != null) {
-                    resourceResolver.close();
-                }
             }
         }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/email/impl/EmailServiceImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/email/impl/EmailServiceImpl.java
@@ -264,10 +264,8 @@ public final class EmailServiceImpl implements EmailService {
 
     private MailTemplate getMailTemplate(String templatePath) throws IllegalArgumentException {
         MailTemplate mailTemplate = null;
-        ResourceResolver resourceResolver = null;
-        try {
-            Map<String, Object> authInfo = Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, (Object) SERVICE_NAME);
-            resourceResolver = resourceResolverFactory.getServiceResourceResolver(authInfo);
+        Map<String, Object> authInfo = Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, (Object) SERVICE_NAME);
+        try (ResourceResolver resourceResolver = resourceResolverFactory.getServiceResourceResolver(authInfo) ){
             mailTemplate = MailTemplate.create(templatePath, resourceResolver.adaptTo(Session.class));
 
             if (mailTemplate == null) {
@@ -277,10 +275,6 @@ public final class EmailServiceImpl implements EmailService {
         } catch (LoginException e) {
             log.error("Unable to obtain an administrative resource resolver to get the Mail Template at [ "
                     + templatePath + " ]", e);
-        } finally {
-            if (resourceResolver != null) {
-                resourceResolver.close();
-            }
         }
 
         return mailTemplate;

--- a/bundle/src/main/java/com/adobe/acs/commons/errorpagehandler/impl/ErrorPageHandlerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/errorpagehandler/impl/ErrorPageHandlerImpl.java
@@ -908,10 +908,8 @@ public final class ErrorPageHandlerImpl implements ErrorPageHandlerService {
 
         // Absolute path
         if (StringUtils.startsWith(this.errorImagePath, "/")) {
-            ResourceResolver serviceResourceResolver = null;
-            try {
-                Map<String, Object> authInfo = Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, (Object) SERVICE_NAME);
-                serviceResourceResolver = resourceResolverFactory.getServiceResourceResolver(authInfo);
+            Map<String, Object> authInfo = Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, (Object) SERVICE_NAME);
+            try (ResourceResolver serviceResourceResolver = resourceResolverFactory.getServiceResourceResolver(authInfo)) {
                 final Resource resource = serviceResourceResolver.resolve(this.errorImagePath);
 
                 if (resource != null && resource.isResourceType(JcrConstants.NT_FILE)) {
@@ -926,10 +924,6 @@ public final class ErrorPageHandlerImpl implements ErrorPageHandlerService {
                 }
             } catch (LoginException e) {
                 log.error("Could not get admin resource resolver to inspect validity of absolute errorImagePath");
-            } finally {
-                if (serviceResourceResolver != null) {
-                    serviceResourceResolver.close();
-                }
             }
         }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/forms/helpers/impl/AbstractFormHelperImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/forms/helpers/impl/AbstractFormHelperImpl.java
@@ -120,17 +120,11 @@ public abstract class AbstractFormHelperImpl {
     public final String getAction(final String path, final String formSelector) {
         String actionPath = path;
 
-        ResourceResolver serviceResourceResolver = null;
-        try {
-            serviceResourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO);
+        try (ResourceResolver serviceResourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO)){
             actionPath = serviceResourceResolver.map(path);
         } catch (LoginException e) {
             log.error("Could not attain an admin ResourceResolver to map the Form's Action URI");
             // Use the unmapped ActionPath
-        } finally {
-            if (serviceResourceResolver != null && serviceResourceResolver.isLive()) {
-                serviceResourceResolver.close();
-            }
         }
 
         actionPath += FormHelper.EXTENSION + this.getSuffix();

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/invalidator/HttpCacheInvalidationJobConsumer.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/invalidator/HttpCacheInvalidationJobConsumer.java
@@ -124,9 +124,7 @@ public class HttpCacheInvalidationJobConsumer implements JobConsumer {
      * @param path the path to search for
      */
     void invalidateReferences(String path) {
-        ResourceResolver adminResolver = null;
-        try {
-            adminResolver = resolverFactory.getServiceResourceResolver(null);
+        try (ResourceResolver adminResolver = resolverFactory.getServiceResourceResolver(null)){
             Collection<ReferenceSearch.Info> refs = new ReferenceSearch()
                     .search(adminResolver, path).values();
             for (ReferenceSearch.Info info : refs) {
@@ -136,10 +134,6 @@ public class HttpCacheInvalidationJobConsumer implements JobConsumer {
             }
         } catch (Exception e){
             log.debug("failed to invalidate references of {}", path);
-        } finally {
-            if (adminResolver != null) {
-                adminResolver.close();
-            }
         }
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/jcr/impl/JCRHttpCacheStoreImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/jcr/impl/JCRHttpCacheStoreImpl.java
@@ -483,9 +483,7 @@ public class JCRHttpCacheStoreImpl extends AbstractJCRCacheMBean<CacheKey, Cache
     }
 
     public <T> T withSession(final Function<Session, T> onSuccess, final Consumer<Exception> onError){
-        ResourceResolver resourceResolver = null;
-        try {
-            resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO);
+        try (ResourceResolver resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO)){
             final Session session = resourceResolver.adaptTo(Session.class);
             return onSuccess.apply(session);
 
@@ -497,10 +495,6 @@ public class JCRHttpCacheStoreImpl extends AbstractJCRCacheMBean<CacheKey, Cache
                 }
             } catch (Exception subException) {
                 log.error("Error in handling the exception", subException);
-            }
-        } finally {
-            if(resourceResolver != null && resourceResolver.isLive()){
-                resourceResolver.close();
             }
         }
         return null;

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/ProcessInstanceImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/ProcessInstanceImpl.java
@@ -288,19 +288,13 @@ public class ProcessInstanceImpl implements ProcessInstance, Serializable {
     }
 
     public void asServiceUser(CheckedConsumer<ResourceResolver> action) {
-        ResourceResolver rr = null;
-        try {
-            rr = manager.getServiceResourceResolver();
+        try (ResourceResolver rr = manager.getServiceResourceResolver()){
             action.accept(rr);
             if (rr.hasChanges()) {
                 rr.commit();
             }
         } catch (Exception ex) {
             LOG.error("Error while performing JCR operations", ex);
-        } finally {
-            if (rr != null) {
-                rr.close();
-            }
         }
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexJobHandler.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexJobHandler.java
@@ -126,12 +126,10 @@ public class EnsureOakIndexJobHandler implements Runnable {
     @Override
     @SuppressWarnings("squid:S1141")
     public void run() {
-        ResourceResolver resourceResolver = null;
+        Map<String, Object> authInfo = Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, (Object) SERVICE_NAME);
+        try (ResourceResolver resourceResolver = this.ensureOakIndex.getResourceResolverFactory().getServiceResourceResolver(authInfo)) {
 
-        try {
-            Map<String, Object> authInfo = Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, (Object) SERVICE_NAME);
-            resourceResolver = this.ensureOakIndex.getResourceResolverFactory().getServiceResourceResolver(authInfo);
-
+            // we should rethink this nested try here ...
             try {
                 this.ensure(resourceResolver, ensureDefinitionsPath, oakIndexesPath);
             } catch (IOException e) {
@@ -143,10 +141,6 @@ public class EnsureOakIndexJobHandler implements Runnable {
             log.error("Could not get an admin resource resolver to ensure Oak Indexes", e);
         } catch (Exception e) {
             log.error("Unknown error occurred while ensuring indexes", e);
-        } finally {
-            if (resourceResolver != null) {
-                resourceResolver.close();
-            }
         }
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlushRulesImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlushRulesImpl.java
@@ -159,10 +159,7 @@ public class DispatcherFlushRulesImpl implements Preprocessor {
         final ReplicationActionType flushActionType =
                 replicationActionType == null ? replicationAction.getType() : replicationActionType;
 
-        ResourceResolver resourceResolver = null;
-
-        try {
-            resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO);
+        try (ResourceResolver resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO)){
 
             // Flush full content hierarchies
             for (final Map.Entry<Pattern, String[]> entry : this.hierarchicalFlushRules.entrySet()) {
@@ -201,10 +198,6 @@ public class DispatcherFlushRulesImpl implements Preprocessor {
 
         } catch (LoginException e) {
             log.error("Error issuing  dispatcher flush rules do to repository login exception: {}", e.getMessage());
-        } finally {
-            if (resourceResolver != null) {
-                resourceResolver.close();
-            }
         }
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/replication/packages/automatic/impl/AutomaticPackageReplicatorJob.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/replication/packages/automatic/impl/AutomaticPackageReplicatorJob.java
@@ -69,9 +69,7 @@ public class AutomaticPackageReplicatorJob implements Runnable, EventHandler {
     public void excute() throws RepositoryException, PackageException, IOException, ReplicationException {
 
         boolean succeeded = false;
-        ResourceResolver resolver = null;
-        try {
-            resolver = ConfigurationUpdateListener.getResourceResolver(resolverFactory);
+        try (ResourceResolver resolver = ConfigurationUpdateListener.getResourceResolver(resolverFactory)){
 
             Session session = resolver.adaptTo(Session.class);
 
@@ -95,9 +93,6 @@ public class AutomaticPackageReplicatorJob implements Runnable, EventHandler {
             fireEvent(OSGI_EVENT_REPLICATED_TOPIC);
             succeeded = true;
         } finally {
-            if(resolver != null){
-                resolver.close();
-            }
             if(!succeeded){
                 fireEvent(OSGI_EVENT_FAILED_TOPIC);
             }

--- a/bundle/src/main/java/com/adobe/acs/commons/users/impl/EnsureGroup.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/users/impl/EnsureGroup.java
@@ -128,10 +128,7 @@ public final class EnsureGroup implements EnsureAuthorizable {
     public void ensure(Operation operation, AbstractAuthorizable group) throws EnsureAuthorizableException {
         final long start = System.currentTimeMillis();
 
-        ResourceResolver resourceResolver = null;
-
-        try {
-            resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO);
+        try (ResourceResolver resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO)){
 
             if (Operation.ADD.equals(operation)) {
                 ensureExistance(resourceResolver, (Group) group);
@@ -154,10 +151,6 @@ public final class EnsureGroup implements EnsureAuthorizable {
         } catch (Exception e) {
             throw new EnsureAuthorizableException(String.format("Failed to ensure [ %s ] of Group [ %s ]",
                     operation.toString(), group.getPrincipalName()), e);
-        } finally {
-            if (resourceResolver != null) {
-                resourceResolver.close();
-            }
         }
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/users/impl/EnsureServiceUser.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/users/impl/EnsureServiceUser.java
@@ -112,11 +112,7 @@ public final class EnsureServiceUser implements EnsureAuthorizable {
     public void ensure(Operation operation, AbstractAuthorizable serviceUser) throws EnsureAuthorizableException {
         final long start = System.currentTimeMillis();
 
-        ResourceResolver resourceResolver = null;
-
-        try {
-            resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO);
-
+        try (ResourceResolver resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO)){
             if (Operation.ADD.equals(operation)) {
                 ensureExistance(resourceResolver, (ServiceUser) serviceUser);
             } else if (Operation.REMOVE.equals(operation)) {
@@ -140,10 +136,6 @@ public final class EnsureServiceUser implements EnsureAuthorizable {
         } catch (Exception e) {
             throw new EnsureAuthorizableException(String.format("Failed to ensure [ %s ] of Service User [ %s ]",
                     operation.toString(), serviceUser.getPrincipalName()), e);
-        } finally {
-            if (resourceResolver != null) {
-                resourceResolver.close();
-            }
         }
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/ComponentErrorHandlerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/ComponentErrorHandlerImpl.java
@@ -280,25 +280,18 @@ public class ComponentErrorHandlerImpl implements ComponentErrorHandler, Filter 
     }
 
     private String getHTML(final String path) {
-        ResourceResolver resourceResolver = null;
-
         // Handle blank HTML conditions first; Avoid looking in JCR for them.
         if (StringUtils.isBlank(path) || StringUtils.equals(BLANK_HTML, path)) {
             return "";
         }
 
-        try {
+        try (ResourceResolver resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO)){
             // Component error renditions are typically stored under /apps as part of the application; and thus
             // requires elevated ACLs to work on Publish instances.
-            resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO);
 
             return ResourceDataUtil.getNTFileAsString(path, resourceResolver);
         } catch (final Exception e) {
             log.error("Could not get the component error HTML at [ {} ], using blank.", path);
-        } finally {
-            if (resourceResolver != null) {
-                resourceResolver.close();
-            }
         }
 
         return "";

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/WCMInboxWebConsolePlugin.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/WCMInboxWebConsolePlugin.java
@@ -74,9 +74,7 @@ public class WCMInboxWebConsolePlugin extends HttpServlet {
 
         PrintWriter pw = resp.getWriter();
 
-        ResourceResolver resolver = null;
-        try {
-            resolver = rrFactory.getServiceResourceResolver(AUTH_INFO);
+        try (ResourceResolver resolver = rrFactory.getServiceResourceResolver(AUTH_INFO)) {
 
             pw.println("<p class='statline ui-state-highlight'>Inbox Notification Configurations</p>");
             pw.println("<ul>");
@@ -115,10 +113,6 @@ public class WCMInboxWebConsolePlugin extends HttpServlet {
 
         } catch (Exception e) {
             throw new ServletException(e);
-        } finally {
-            if (resolver != null && resolver.isLive()) {
-                resolver.close();
-            }
         }
     }
     
@@ -126,10 +120,8 @@ public class WCMInboxWebConsolePlugin extends HttpServlet {
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         String path = req.getParameter("path");
         if (path != null) {
-            ResourceResolver resolver = null;
-            try {
+            try (ResourceResolver resolver = rrFactory.getServiceResourceResolver(AUTH_INFO)){
                 int counter = 0;
-                resolver = rrFactory.getServiceResourceResolver(AUTH_INFO);
                 Session session = resolver.adaptTo(Session.class);
                 Node node = session.getNode(path);
                 NodeIterator it = node.getNodes();
@@ -142,10 +134,6 @@ public class WCMInboxWebConsolePlugin extends HttpServlet {
                 resp.getWriter().printf("<p class='statline ui-state-error'>Deleted %s notifications</p>%n", counter);
             } catch (Exception e) {
                 throw new ServletException(e);
-            } finally {
-                if (resolver != null && resolver.isLive()) {
-                    resolver.close();
-                }
             }
         }
         resp.sendRedirect((String) req.getAttribute("felix.webconsole.pluginRoot"));

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/notifications/impl/SystemNotificationsImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/notifications/impl/SystemNotificationsImpl.java
@@ -264,10 +264,7 @@ public class SystemNotificationsImpl extends AbstractHtmlRequestInjector impleme
 
     private boolean hasNotifications() {
 
-        ResourceResolver resourceResolver = null;
-
-        try {
-            resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO);
+        try (ResourceResolver resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO)) {
 
             final Resource notificationsFolder = resourceResolver.getResource(PATH_NOTIFICATIONS);
             if (notificationsFolder != null) {
@@ -283,10 +280,6 @@ public class SystemNotificationsImpl extends AbstractHtmlRequestInjector impleme
             }
         } catch (LoginException e) {
             log.error("Could not get an service ResourceResolver", e);
-        } finally {
-            if (resourceResolver != null) {
-                resourceResolver.close();
-            }
         }
 
         return false;

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesPageInfoProvider.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesPageInfoProvider.java
@@ -185,12 +185,10 @@ public class SharedComponentPropertiesPageInfoProvider implements PageInfoProvid
      * options for editing shared/global configs.
      */
     private void updateSharedComponentsMap() {
-        ResourceResolver resourceResolver = null;
-        try {
+        Map<String, Object> authInfo = Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, (Object) SERVICE_NAME);
+        try (ResourceResolver resourceResolver = resourceResolverFactory.getServiceResourceResolver(authInfo)){
             log.debug("Calculating map of components with shared properties dialogs");
 
-            Map<String, Object> authInfo = Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, (Object) SERVICE_NAME);
-            resourceResolver = resourceResolverFactory.getServiceResourceResolver(authInfo);
             resourceResolver.refresh();
             ComponentManager componentManager = resourceResolver.adaptTo(ComponentManager.class);
             Map<String, List<Boolean>> localComponentsWithSharedProperties = new HashMap<>();
@@ -213,10 +211,6 @@ public class SharedComponentPropertiesPageInfoProvider implements PageInfoProvid
             log.error("Unable to log into service user to determine list of components with shared properties dialogs", e);
         } catch (RepositoryException e) {
             log.error("Unexpected error attempting to determine list of components with shared properties dialogs", e);
-        } finally {
-            if (resourceResolver != null) {
-                resourceResolver.close();
-            }
         }
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/runners/AEMTransientWorkflowRunnerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/runners/AEMTransientWorkflowRunnerImpl.java
@@ -128,13 +128,11 @@ public class AEMTransientWorkflowRunnerImpl extends AbstractAEMWorkflowRunner im
         public void run() {
             log.debug("Running Bulk AEM Transient Workflow job [ {} ]", jobName);
 
-            ResourceResolver serviceResourceResolver = null;
             Resource configResource = null;
             Config config = null;
             Workspace workspace = null;
 
-            try {
-                serviceResourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO);
+            try (ResourceResolver serviceResourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO)){
                 configResource = serviceResourceResolver.getResource(configPath);
 
                 if (configResource != null) {
@@ -221,10 +219,6 @@ public class AEMTransientWorkflowRunnerImpl extends AbstractAEMWorkflowRunner im
                     stop(workspace);
                 } catch (PersistenceException e1) {
                     log.error("Unable to mark this workspace [ {} ] as stopped.", workspacePath, e1);
-                }
-            } finally {
-                if (serviceResourceResolver != null) {
-                    serviceResourceResolver.close();
                 }
             }
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/runners/AEMWorkflowRunnerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/runners/AEMWorkflowRunnerImpl.java
@@ -181,13 +181,11 @@ public class AEMWorkflowRunnerImpl extends AbstractAEMWorkflowRunner implements 
         public void run() {
             log.debug("Running Bulk AEM Workflow job [ {} ]", jobName);
 
-            ResourceResolver adminResourceResolver = null;
             Resource configResource = null;
             Config config = null;
             Workspace workspace = null;
 
-            try {
-                adminResourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO);
+            try (ResourceResolver adminResourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO)) {
                 configResource = adminResourceResolver.getResource(configPath);
 
                 if (configResource != null) {
@@ -306,10 +304,6 @@ public class AEMWorkflowRunnerImpl extends AbstractAEMWorkflowRunner implements 
                     stop(workspace);
                 } catch (PersistenceException e1) {
                     log.error("Unable to mark this workspace [ {} ] as stopped.", workspacePath, e1);
-                }
-            } finally {
-                if (adminResourceResolver != null) {
-                    adminResourceResolver.close();
                 }
             }
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/runners/FastActionManagerRunnerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/runners/FastActionManagerRunnerImpl.java
@@ -190,11 +190,9 @@ public class FastActionManagerRunnerImpl extends AbstractWorkflowRunner implemen
         @Override
         @SuppressWarnings({"squid:S3776", "squid:S1141", "squid:S1854"})
         public void run() {
-            ResourceResolver resourceResolver;
             Resource configResource;
 
-            try {
-                resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO);
+            try (ResourceResolver resourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO)){
 
                 configResource = resourceResolver.getResource(configPath);
 

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/runners/SyntheticWorkflowRunnerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/runners/SyntheticWorkflowRunnerImpl.java
@@ -120,14 +120,12 @@ public class SyntheticWorkflowRunnerImpl extends AbstractWorkflowRunner implemen
         @Override
         @SuppressWarnings({"squid:S3776", "squid:S1141"})
         public void run() {
-            ResourceResolver serviceResourceResolver = null;
             Resource configResource;
             long start = System.currentTimeMillis();
             int total = 0;
             boolean stopped = false;
 
-            try {
-                serviceResourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO);
+            try (ResourceResolver serviceResourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO)){
                 configResource = serviceResourceResolver.getResource(configPath);
 
                 final Config config = configResource.adaptTo(Config.class);
@@ -215,10 +213,6 @@ public class SyntheticWorkflowRunnerImpl extends AbstractWorkflowRunner implemen
                 }
             } catch (Exception e) {
                 log.error("Error processing Bulk Synthetic Workflow execution.", e);
-            } finally {
-                if (serviceResourceResolver != null) {
-                    serviceResourceResolver.close();
-                }
             }
         }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/removal/impl/WorkflowInstanceRemoverScheduler.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/removal/impl/WorkflowInstanceRemoverScheduler.java
@@ -153,9 +153,7 @@ public class WorkflowInstanceRemoverScheduler implements Runnable {
     @SuppressWarnings("squid:S2142")
     public final void run() {
 
-        ResourceResolver adminResourceResolver = null;
-        try {
-            adminResourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO);
+        try (ResourceResolver adminResourceResolver = resourceResolverFactory.getServiceResourceResolver(AUTH_INFO)){
 
             final long start = System.currentTimeMillis();
 
@@ -182,10 +180,6 @@ public class WorkflowInstanceRemoverScheduler implements Runnable {
             log.error("Interrupted Exception during Workflow Removal", e);
         } catch (WorkflowRemovalForceQuitException e) {
             log.info("Workflow Removal force quit", e);
-        } finally {
-            if (adminResourceResolver != null) {
-                adminResourceResolver.close();
-            }
         }
     }
 


### PR DESCRIPTION
Use try-with-resource for all ResourceResolvers, so we don't need the "finally" Block anymore and never forget to close the ResourceResolver.

Regarding the change to FastActionManagerRunnerImpl:
I am not sure if my change is correct, because it seems to me that a lot of async activities
are started, and therefor the automatic close of the RR when leaving the block might not be correct.

But even the original implementation had a flaw, because I haven't found a matching "close" of
this RR at first sight. @davidjgonzalez Can you help here?

converted JcrPackageReplicationStatusEventHandler
converted crPackageReplicationStatusEventHandler
converted AutomaticPackageReplicatorJob
converted WCMInboxWebConsolePlugin
converted EmailServiceImpl
converted SystemNotificationsImpl
converted SharedComponentPropertiesPageInfoProvider
converted ComponentErrorHandlerImpl
converted ErrorPageHandlerImpl
converted DispatcherFlushRulesImpl
converted ReviewTaskAssetMoverHandler
converted JCRHttpCacheStoreImpl
converted HttpCacheInvalidationJobConsumer
converted EnsureServiceUser
converted EnsureGroup
converted WorkflowInstanceRemoverScheduler
converted AEMTransientWorkflowRunnerImpl
converted FastActionManagerRunnerImpl -- although I am not sure if that works at all here ...
converted AEMWorkflowRunnerImpl
converted SyntheticWorkflowRunnerImpl
converted ProcessInstanceImpl
converted AbstractFormHelperImpl
converted EnsureOakIndexJobHandler