### PR TITLE
Deprecated AemCapabilityHelper.isOak() 

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/util/AemCapabilityHelper.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/AemCapabilityHelper.java
@@ -28,8 +28,12 @@ public interface AemCapabilityHelper {
 
     /**
      * Determines if the AEM installation is running on an Apache Jackrabbit Oak-based repository.
+     * 
+     * With the current versions of ACS AEM Commons the support for non-Oak based AEM versions has been dropped,
+     * so the usage of this method is no longer required.
      * @return true is running on Oak
      * @throws RepositoryException
+     * @Deprecated
      */
     boolean isOak() throws RepositoryException;
 }


### PR DESCRIPTION
because non-Oak repos are no longer supported