### PR TITLE
Use the ScrBndPlugin to provide SCR metadata for unittests as well.

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -46,6 +46,25 @@
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>
+                <executions>
+				    <!-- Configure extra execution of 'manifest' in process-classes phase to make sure SCR metadata is generated before unit test runs -->
+				    <execution>
+				      <id>scr-metadata</id>
+				      <goals>
+				        <goal>manifest</goal>
+				      </goals>
+				      <configuration>
+				        <supportIncrementalBuild>true</supportIncrementalBuild>
+				      </configuration>
+				    </execution>
+				</executions>
+				<dependencies>
+					<dependency>
+					  <groupId>org.apache.felix</groupId>
+					  <artifactId>org.apache.felix.scr.bnd</artifactId>
+					  <version>1.9.0</version>
+					</dependency>
+				</dependencies>
                 <configuration>
                     <instructions>
                         <Bundle-Activator>com.adobe.acs.commons.util.impl.Activator</Bundle-Activator>
@@ -76,6 +95,15 @@
                             com.adobe.acs.commons.mcp.model,
                             com.adobe.acs.commons.reports.models
                         </Sling-Model-Packages>
+
+
+						<!-- Enable processing of OSGI DS component annotations -->
+						<_dsannotations>*</_dsannotations>
+						<!-- Enable processing of OSGI metatype annotations -->
+						<_metatypeannotations>*</_metatypeannotations>
+						<!-- Support parsing of maven-scr-plugin annotations through the felix.scr.bnd
+								plugin -->
+						<_plugin>org.apache.felix.scrplugin.bnd.SCRDescriptorBndPlugin;destdir=${project.build.outputDirectory};</_plugin>
                     </instructions>
                 </configuration>
             </plugin>
@@ -352,6 +380,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <!--
         needed to override the embedded commons.osgi in org.apache.sling.models.impl
         -->

--- a/bundle/src/main/java/com/adobe/acs/commons/audit_log_search/impl/AuditLogSearchServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/audit_log_search/impl/AuditLogSearchServlet.java
@@ -51,7 +51,7 @@ import java.util.Set;
 
 @SlingServlet(label = "ACS AEM Commons - Audit Log Search Servlet", methods = { "GET" }, resourceTypes = {
 "acs-commons/components/utilities/audit-log-search" }, selectors = {
-"auditlogsearch" }, extensions = { "json" }, metatype = true)
+"auditlogsearch" }, extensions = { "json" })
 @SuppressWarnings("serial")
 public class AuditLogSearchServlet extends SlingSafeMethodsServlet {
 

--- a/bundle/src/main/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutorImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutorImpl.java
@@ -77,7 +77,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Component(
         label = "ACS AEM Commons - On-Deploy Scripts Executor",
         description = "Developer tool that triggers scripts (specified via an implementation of OnDeployScriptProvider) to execute on deployment.",
-        metatype = true, policy = ConfigurationPolicy.REQUIRE)
+        policy = ConfigurationPolicy.REQUIRE)
 @Properties({ @Property(label = "MBean Name", name = "jmx.objectname",
         value = "com.adobe.acs.commons:type=On-Deploy Scripts", propertyPrivate = true) })
 @Service(value = DynamicMBean.class)

--- a/bundle/src/main/java/com/adobe/acs/commons/reports/internal/ReportCSVExportServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/reports/internal/ReportCSVExportServlet.java
@@ -51,7 +51,7 @@ import com.day.text.csv.Csv;
  */
 @SlingServlet(label = "ACS AEM Commons - Report CSV Export Servlet", methods = { "GET" }, resourceTypes = {
     "acs-commons/components/utilities/report-builder/report-page" }, selectors = {
-        "report" }, extensions = { "csv" }, metatype = true)
+        "report" }, extensions = { "csv" })
 public class ReportCSVExportServlet extends SlingSafeMethodsServlet {
 
   private static final long serialVersionUID = 2794836639686938093L;

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/StylesheetInlinerTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/StylesheetInlinerTransformerFactory.java
@@ -52,8 +52,7 @@ import com.adobe.granite.ui.clientlibs.LibraryType;
  * them as <style> elements. Links found in <head> are added to the beginning of
  * <body>, whereas those in <body> are included where they're found.
  */
-@Component(
-        metatype = true, 
+@Component( 
         label = "Stylesheet Inliner Transformer Factory", 
         description = "Sling Rewriter Transformer Factory which inlines CSS references")
 @Properties({ 

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesImpl.java
@@ -27,8 +27,7 @@ import org.apache.felix.scr.annotations.Service;
 @Component(
         label = "ACS AEM Commons - Shared Component Properties",
         description = "Create an OSGi configuration to enable Shared Component Properties",
-        policy = ConfigurationPolicy.REQUIRE,
-        metatype = true
+        policy = ConfigurationPolicy.REQUIRE
 )
 @Service
 public class SharedComponentPropertiesImpl implements SharedComponentProperties {


### PR DESCRIPTION
To use services in unittests too (for example for SlingMocks or AemMocks),
the SCR metadata needs to be available during runtime, too.

See http://felix.apache.org/documentation/faqs/apache-felix-bundle-plugin-faq.html#use-scr-metadata-generated-by-bnd-in-unit-tests

Additionally, it complained about the use of the "metatype=true" directive
for services which don't have public OSGI properites. I removed the metatype=true
directive for them.

