### PR TITLE
Trim OSGi config array element whitespace for EnsureServiceUser aces property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## [Unreleased]
 
+- #1552 - Ensure Authorizable - trim OSGi config array element whitespace for EnsureServiceUser aces property
+
 ## [3.19.0] - 2018-11-03
 
 ### Added

--- a/bundle/src/main/java/com/adobe/acs/commons/users/impl/AbstractAuthorizable.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/users/impl/AbstractAuthorizable.java
@@ -68,11 +68,13 @@ public abstract class AbstractAuthorizable {
                 PropertiesUtil.toStringArray(config.get(EnsureServiceUser.PROP_ACES), new String[0]);
         for (String entry : acesProperty) {
             if (StringUtils.isNotBlank(entry)) {
+                // issue #1552: trim entry to tolerate osgi config array elements separated by newlines
+                final String aceConfig = entry.trim();
                 try {
-                    aces.add(new Ace(entry));
+                    aces.add(new Ace(aceConfig));
                 } catch (EnsureAuthorizableException e) {
                     log.warn(
-                            "Malformed ACE config [ " + entry + " ] for Service User [ "
+                            "Malformed ACE config [ " + aceConfig + " ] for Service User [ "
                                     + StringUtils.defaultIfEmpty(this.principalName, "NOT PROVIDED") + " ]", e);
                 }
             }

--- a/bundle/src/test/java/com/adobe/acs/commons/users/impl/AbstractAuthorizableTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/users/impl/AbstractAuthorizableTest.java
@@ -111,6 +111,34 @@ public class AbstractAuthorizableTest {
         }
     }
 
+    @Test
+    public void testServiceUser_AcesWithSpaces_1552() throws EnsureAuthorizableException {
+        String[] aces= new String[] {
+                "\ntype=allow;privileges=jcr:versionManagement,jcr:read,crx:replicate,rep:write,jcr:lockManagement,jcr:modifyProperties;path=/content/dam",
+                "\n  type=allow;privileges=jcr:versionManagement,jcr:read,crx:replicate,rep:write,jcr:lockManagement,jcr:modifyProperties;path=/content ",
+                "\n  \ttype=allow;privileges=jcr:versionManagement,jcr:read,crx:replicate,rep:write,jcr:lockManagement,jcr:modifyProperties;path=/content/projects \t",
+                "\n  \t\ttype=allow;privileges=jcr:all;path=/var/workflow \t \n",
+                "\n\n\n\n\ntype=allow;privileges=jcr:all;path=/etc/workflow\n    "
+        };
+
+        Map<String, Object> config = new HashMap<String, Object>();
+        config.put(EnsureServiceUser.PROP_PRINCIPAL_NAME, "test-service-user");
+        config.put(EnsureServiceUser.PROP_ACES, aces);
+
+        FakeAuthorizable serviceUser = new FakeAuthorizable(config);
+
+        assertEquals("test-service-user", serviceUser.getPrincipalName());
+        assertEquals("/home/fake", serviceUser.getIntermediatePath());
+        assertEquals(5, serviceUser.getAces().size());
+
+        for (Ace ace : serviceUser.getAces()) {
+            assertTrue(ace.isAllow());
+            assertFalse(ace.getContentPath().contains("\n"));
+            assertFalse(ace.getContentPath().contains("\t"));
+            assertFalse(ace.getContentPath().contains(" "));
+        }
+    }
+
     @Test(expected=EnsureAuthorizableException.class)
     public void testServiceUser_ProtectedSystemUser() throws EnsureAuthorizableException {
         Map<String, Object> config = new HashMap<String, Object>();


### PR DESCRIPTION
Add .trim() to AbstractAuthorizable Ace config before constructor.
Add testServiceUser_AcesWithSpaces_1552 test to confirm behavior for different variations of leading and trailing whitespace.

Resolves #1552 