### PR TITLE
file asset import and url asset imports saves source path as migrated…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1593 - Sftp Asset Injector throws URISyntaxException if item contains special characters
 - #1598 - Asset Ingestor | If user provides invalid info, nothing is happens. Erorr in report is expected
 - #1597 - If 'Preserve Filename' unchecked, asset name will support only the following characters: letters, digits, hyphens, underscores, another chars will be replaced with hyphens
+- #1604 - File asset import and url asset imports saves source path as migratedFrom property into assets jcr:content node. If asset is skipped the message in the format "source -> destination" is written into report
 
 ### Changed
 - #1571 - Remove separate twitter bundle and use exception trapping to only register AdapterFactory when Twitter4J is available.

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestor.java
@@ -308,7 +308,9 @@ public abstract class AssetIngestor extends ProcessDefinition {
                     createAsset(source, assetPath, r, false);
                 } else {
                     incrementCount(skippedFiles, 1L);
-                    trackDetailedActivity(assetPath, "Skip", "Skipped existing asset", 0L);
+
+                    trackDetailedActivity(source.getElement().getSourcePath() + " -> " + assetPath,
+                                          "Skip", "Skipped existing asset", 0L);
                 }
                 break;
             case replace:

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestor.java
@@ -253,7 +253,7 @@ public class FileAssetIngestor extends AssetIngestor {
 
         @Override
         public String getItemName() {
-            return file.getName();
+            return file.getPath();
         }
 
         @Override

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileOrRendition.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileOrRendition.java
@@ -116,7 +116,7 @@ public class FileOrRendition implements HierarchicalElement {
 
     @Override
     public String getItemName() {
-        return getName();
+        return folder.getSourcePath();
     }
 
     @Override


### PR DESCRIPTION
file asset import and url asset imports saves source path as migratedFrom property into assets jcr:content node. If asset is skipped the message in the format "source -> destination" is written into report