### PR TITLE
Url Asset Ingestor saves the same path in migratedFom property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1598 - Asset Ingestor | If user provides invalid info, nothing is happens. Erorr in report is expected
 - #1597 - If 'Preserve Filename' unchecked, asset name will support only the following characters: letters, digits, hyphens, underscores, another chars will be replaced with hyphens
 - #1604 - File asset import and url asset imports saves source path as migratedFrom property into assets jcr:content node. If asset is skipped the message in the format "source -> destination" is written into report
+- #1606 - Url Asset Import saves correct path into migratedFrom property of assets's jcr:content node
 
 ### Changed
 - #1571 - Remove separate twitter bundle and use exception trapping to only register AdapterFactory when Twitter4J is available.

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileOrRendition.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileOrRendition.java
@@ -29,6 +29,7 @@ import com.jcraft.jsch.SftpATTRS;
 import com.jcraft.jsch.SftpException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -116,7 +117,14 @@ public class FileOrRendition implements HierarchicalElement {
 
     @Override
     public String getItemName() {
-        return folder.getSourcePath();
+        try {
+            URI uri = new URI(encodeUriParts(url));
+            String filePath = decodeUriParts(uri.getRawPath());
+            return decodeUriParts(filePath);
+        } catch (URISyntaxException | UnsupportedEncodingException ex) {
+            Logger.getLogger(FileOrRendition.class.getName()).log(Level.SEVERE, null, ex);
+        }
+        return url;
     }
 
     @Override

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/NameUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/NameUtil.java
@@ -40,4 +40,8 @@ final class NameUtil {
 
         return name.toString();
     }
+
+    static String createValidDamName(String title) {
+        return createValidDamName(title, CASE_SENSITIVE_HYPHEN_LABEL_CHAR_MAPPING, "-");
+    }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/UrlAssetImport.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/UrlAssetImport.java
@@ -368,7 +368,12 @@ public class UrlAssetImport extends AssetIngestor {
         if (source.startsWith("/")) {
             source = defaultPrefix + source;
         }
+
         String name = source.substring(source.lastIndexOf('/') + 1);
+        if (!preserveFileName) {
+            name = NameUtil.createValidDamName(name);
+        }
+
         Folder folder = extractFolder(assetData);
         FileOrRendition file = new FileOrRendition(clientProvider, name, source, folder, assetData);
 


### PR DESCRIPTION
getItemName returns path of the migrated item, if exception occurs - url will be used as Item Name