### PR TITLE
Feature/httpcache response write method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1564 - Added SFTP support for asset ingest utilities
 
 ### Fixed
+- #1607 - HttpCache: improved the write to response mechanism.
 - #1590 - Multifield component doesn't render non-composite at all (NPE error)
 - #1588 - Updated error handler JSP to use ModeUtils
 - #1583 - Asset Ingestor may try to create asset folders when they already exist

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/HttpCacheConfig.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/HttpCacheConfig.java
@@ -143,4 +143,5 @@ public interface HttpCacheConfig {
      * @return the filter scope this HttpCacheConfig should involve itself in.
      */
     FilterScope getFilterScope();
+
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/HttpCacheConfigImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/HttpCacheConfigImpl.java
@@ -237,7 +237,6 @@ public class HttpCacheConfigImpl implements HttpCacheConfig {
         order = PropertiesUtil.toInteger(configs.get(PROP_ORDER), DEFAULT_ORDER);
 
         filterScope = FilterScope.valueOf(PropertiesUtil.toString(configs.get(PROP_FILTER_SCOPE), DEFAULT_FILTER_SCOPE).toUpperCase());
-
         // PIDs of cache handling rules.
         cacheHandlingRulesPid = new ArrayList<String>(Arrays.asList(PropertiesUtil.toStringArray(configs
                 .get(PROP_CACHE_HANDLING_RULES_PID), new String[]{})));

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/CacheContent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/CacheContent.java
@@ -49,10 +49,6 @@ public class CacheContent {
 
     private HttpCacheServletResponseWrapper.ResponseWriteMethod writeMethod;
 
-    public CacheContent(String charEncoding, String contentType, Map<String, List<String>> headers, InputStream
-            dataInputStream){
-        this(HttpServletResponse.SC_OK, charEncoding, contentType, headers, dataInputStream, HttpCacheServletResponseWrapper.ResponseWriteMethod.PRINTWRITER);
-    }
     /**
      * Construct <code>CacheContent</code> using parameters. Prefer constructing an instance using <code>build</code>
      * method.
@@ -61,6 +57,21 @@ public class CacheContent {
      * @param contentType
      * @param headers
      * @param dataInputStream
+     */
+    public CacheContent(String charEncoding, String contentType, Map<String, List<String>> headers, InputStream
+            dataInputStream){
+        this(HttpServletResponse.SC_OK, charEncoding, contentType, headers, dataInputStream, HttpCacheServletResponseWrapper.ResponseWriteMethod.PRINTWRITER);
+    }
+
+    /**
+     * Construct <code>CacheContent</code> using parameters. Prefer constructing an instance using <code>build</code>
+     * method.
+     *
+     * @param charEncoding
+     * @param contentType
+     * @param headers
+     * @param dataInputStream
+     * @param writeMethod
      */
     public CacheContent(String charEncoding, String contentType, Map<String, List<String>> headers, InputStream
             dataInputStream,HttpCacheServletResponseWrapper.ResponseWriteMethod writeMethod) {
@@ -88,6 +99,7 @@ public class CacheContent {
         this.headers = headers;
         this.dataInputStream = dataInputStream;
     }
+
     /**
      * Construct <code>CacheContent</code> using parameters. Prefer constructing an instance using <code>build</code>
      * method.
@@ -97,6 +109,7 @@ public class CacheContent {
      * @param contentType
      * @param headers
      * @param dataInputStream
+     * @param writeMethod
      */
     public CacheContent(int status, String charEncoding, String contentType, Map<String, List<String>> headers, InputStream
             dataInputStream, HttpCacheServletResponseWrapper.ResponseWriteMethod writeMethod) {

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/CacheContent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/CacheContent.java
@@ -49,6 +49,10 @@ public class CacheContent {
 
     private HttpCacheServletResponseWrapper.ResponseWriteMethod writeMethod;
 
+    public CacheContent(String charEncoding, String contentType, Map<String, List<String>> headers, InputStream
+            dataInputStream){
+        this(HttpServletResponse.SC_OK, charEncoding, contentType, headers, dataInputStream, HttpCacheServletResponseWrapper.ResponseWriteMethod.PRINTWRITER);
+    }
     /**
      * Construct <code>CacheContent</code> using parameters. Prefer constructing an instance using <code>build</code>
      * method.
@@ -64,6 +68,26 @@ public class CacheContent {
         this(HttpServletResponse.SC_OK, charEncoding, contentType, headers, dataInputStream, writeMethod);
     }
 
+
+    /**
+     * Construct <code>CacheContent</code> using parameters. Prefer constructing an instance using <code>build</code>
+     * method.
+     *
+     * @param status
+     * @param charEncoding
+     * @param contentType
+     * @param headers
+     * @param dataInputStream
+     */
+    public CacheContent(int status, String charEncoding, String contentType, Map<String, List<String>> headers, InputStream
+            dataInputStream) {
+        this.writeMethod = HttpCacheServletResponseWrapper.ResponseWriteMethod.PRINTWRITER;
+        this.status = status;
+        this.charEncoding = charEncoding;
+        this.contentType = contentType;
+        this.headers = headers;
+        this.dataInputStream = dataInputStream;
+    }
     /**
      * Construct <code>CacheContent</code> using parameters. Prefer constructing an instance using <code>build</code>
      * method.

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/CacheContent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/CacheContent.java
@@ -47,6 +47,8 @@ public class CacheContent {
     /** Temp sink attached to this cache content */
     private TempSink tempSink;
 
+    private HttpCacheServletResponseWrapper.ResponseWriteMethod writeMethod;
+
     /**
      * Construct <code>CacheContent</code> using parameters. Prefer constructing an instance using <code>build</code>
      * method.
@@ -57,9 +59,9 @@ public class CacheContent {
      * @param dataInputStream
      */
     public CacheContent(String charEncoding, String contentType, Map<String, List<String>> headers, InputStream
-            dataInputStream) {
+            dataInputStream,HttpCacheServletResponseWrapper.ResponseWriteMethod writeMethod) {
 
-        this(HttpServletResponse.SC_OK, charEncoding, contentType, headers, dataInputStream);
+        this(HttpServletResponse.SC_OK, charEncoding, contentType, headers, dataInputStream, writeMethod);
     }
 
     /**
@@ -73,8 +75,9 @@ public class CacheContent {
      * @param dataInputStream
      */
     public CacheContent(int status, String charEncoding, String contentType, Map<String, List<String>> headers, InputStream
-            dataInputStream) {
+            dataInputStream, HttpCacheServletResponseWrapper.ResponseWriteMethod writeMethod) {
 
+        this.writeMethod = writeMethod;
         this.status = status;
         this.charEncoding = charEncoding;
         this.contentType = contentType;
@@ -116,6 +119,7 @@ public class CacheContent {
 
         // Get hold of the response content available in sink.
         this.dataInputStream = responseWrapper.getTempSink().createInputStream();
+        this.writeMethod = responseWrapper.getWriteMethod();
 
         return this;
     }
@@ -171,4 +175,7 @@ public class CacheContent {
         return this.tempSink;
     }
 
+    public HttpCacheServletResponseWrapper.ResponseWriteMethod getWriteMethod() {
+        return writeMethod;
+    }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/HttpCacheServletResponseWrapper.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/HttpCacheServletResponseWrapper.java
@@ -59,9 +59,10 @@ public class HttpCacheServletResponseWrapper extends SlingHttpServletResponseWra
         this.tempSink = tempSink;
     }
 
+
     @Override
     public ServletOutputStream getOutputStream() throws IOException {
-        if (this.writeMethod.equals(ResponseWriteMethod.PRINTWRITER)) {
+        if (ResponseWriteMethod.PRINTWRITER.equals(this.writeMethod)) {
             throw new IllegalStateException("Cannot invoke getOutputStream() once getWriter() has been called.");
         } else if (this.servletOutputStream == null) {
             try {
@@ -80,7 +81,7 @@ public class HttpCacheServletResponseWrapper extends SlingHttpServletResponseWra
     @Override
     @SuppressWarnings("squid:S2095")
     public PrintWriter getWriter() throws IOException {
-        if (this.writeMethod.equals(ResponseWriteMethod.OUTPUTSTREAM)) {
+        if (ResponseWriteMethod.OUTPUTSTREAM.equals(this.writeMethod)) {
             throw new IllegalStateException("Cannot invoke getWriter() once getOutputStream() has been called.");
         } else if (this.printWriter == null) {
             try {

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/HttpCacheServletResponseWrapper.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/HttpCacheServletResponseWrapper.java
@@ -41,16 +41,18 @@ import java.util.Collections;
  * Wrapper for <code>SlingHttpServletResponse</code>. Wrapped to get hold of the copy of servlet response stream.
  */
 public class HttpCacheServletResponseWrapper extends SlingHttpServletResponseWrapper {
+
+    public enum ResponseWriteMethod {
+        OUTPUTSTREAM,
+        PRINTWRITER
+    }
+
     private static final Logger log = LoggerFactory.getLogger(HttpServletResponseWrapper.class);
 
     private PrintWriter printWriter;
     private ServletOutputStream servletOutputStream;
     private final TempSink tempSink;
 
-    public enum ResponseWriteMethod {
-        OUTPUTSTREAM,
-        PRINTWRITER
-    }
     private ResponseWriteMethod writeMethod;
 
     public HttpCacheServletResponseWrapper(SlingHttpServletResponse wrappedResponse, TempSink tempSink) throws

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImpl.java
@@ -632,7 +632,7 @@ public class HttpCacheEngineImpl extends AnnotatedStandardMBean implements HttpC
 
     private void serveCacheContentIntoResponse(SlingHttpServletResponse response, CacheContent cacheContent)
             throws IOException {
-        if(cacheContent.getWriteMethod().equals(HttpCacheServletResponseWrapper.ResponseWriteMethod.OUTPUTSTREAM)){
+        if(HttpCacheServletResponseWrapper.ResponseWriteMethod.OUTPUTSTREAM.equals(cacheContent.getWriteMethod())){
             try {
                 IOUtils.copy(cacheContent.getInputDataStream(), response.getOutputStream());
             } catch(IllegalStateException ex) {

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImpl.java
@@ -632,10 +632,14 @@ public class HttpCacheEngineImpl extends AnnotatedStandardMBean implements HttpC
 
     private void serveCacheContentIntoResponse(SlingHttpServletResponse response, CacheContent cacheContent)
             throws IOException {
-        try {
-            IOUtils.copy(cacheContent.getInputDataStream(), response.getOutputStream());
-        } catch(IllegalStateException ex) {
-            // in this case, either the writer has already been obtained or the response doesn't support getOutputStream()
+        if(cacheContent.getWriteMethod().equals(HttpCacheServletResponseWrapper.ResponseWriteMethod.OUTPUTSTREAM)){
+            try {
+                IOUtils.copy(cacheContent.getInputDataStream(), response.getOutputStream());
+            } catch(IllegalStateException ex) {
+                // in this case, either the writer has already been obtained or the response doesn't support getOutputStream()
+                IOUtils.copy(cacheContent.getInputDataStream(), response.getWriter(), response.getCharacterEncoding());
+            }
+        }else{
             IOUtils.copy(cacheContent.getInputDataStream(), response.getWriter(), response.getCharacterEncoding());
         }
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/package-info.java
@@ -18,6 +18,6 @@
  * #L%
  */
 
-@aQute.bnd.annotation.Version("3.2.0")
+@aQute.bnd.annotation.Version("3.3.0")
 package com.adobe.acs.commons.httpcache.engine;
 

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/jcr/impl/JCRHttpCacheStoreConstants.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/jcr/impl/JCRHttpCacheStoreConstants.java
@@ -37,6 +37,7 @@ public class JCRHttpCacheStoreConstants
     public static final String PN_CONTENT_TYPE = "content-type";
 
     public static final String OAK_UNSTRUCTURED = "oak:Unstructured";
+    public static final String PN_WRITEMETHOD = "responseWriteMethod";
 
     private JCRHttpCacheStoreConstants(){
 

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/jcr/impl/handler/EntryNodeToCacheContentHandler.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/jcr/impl/handler/EntryNodeToCacheContentHandler.java
@@ -32,6 +32,7 @@ import javax.jcr.PropertyIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 
+import com.adobe.acs.commons.httpcache.engine.HttpCacheServletResponseWrapper;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.SlingConstants;
 
@@ -48,6 +49,7 @@ public class EntryNodeToCacheContentHandler
     private InputStream inputStream;
     private final Map<String, List<String>> headers = new HashMap<String, List<String>>();
     private Binary binary;
+    private HttpCacheServletResponseWrapper.ResponseWriteMethod writeMethod = HttpCacheServletResponseWrapper.ResponseWriteMethod.OUTPUTSTREAM;
 
     private static final String SLING_NAMESPACE = SlingConstants.NAMESPACE_PREFIX + ":";
     private static final String JCR_NAMESPACE = "jcr:";
@@ -81,6 +83,9 @@ public class EntryNodeToCacheContentHandler
             else if(propName.equals(JCRHttpCacheStoreConstants.PN_STATUS)) {
                 status = (int) value.getLong();
             }
+            else if(propName.equals(JCRHttpCacheStoreConstants.PN_WRITEMETHOD)){
+                writeMethod = HttpCacheServletResponseWrapper.ResponseWriteMethod.valueOf(value.getString());
+            }
         }
     }
 
@@ -91,7 +96,8 @@ public class EntryNodeToCacheContentHandler
             charEncoding,
             contentType,
             headers,
-            inputStream
+            inputStream,
+            writeMethod
         );
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/jcr/impl/writer/EntryNodeWriter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/jcr/impl/writer/EntryNodeWriter.java
@@ -95,6 +95,7 @@ public class EntryNodeWriter
         entryNode.setProperty(JCRHttpCacheStoreConstants.PN_STATUS, cacheContent.getStatus());
         entryNode.setProperty(JCRHttpCacheStoreConstants.PN_CHAR_ENCODING, cacheContent.getCharEncoding());
         entryNode.setProperty(JCRHttpCacheStoreConstants.PN_CONTENT_TYPE, cacheContent.getContentType());
+        entryNode.setProperty(JCRHttpCacheStoreConstants.PN_WRITEMETHOD, cacheContent.getWriteMethod().name());
     }
 
     /**

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/mem/impl/MemCachePersistenceObject.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/mem/impl/MemCachePersistenceObject.java
@@ -19,6 +19,7 @@
  */
 package com.adobe.acs.commons.httpcache.store.mem.impl;
 
+import com.adobe.acs.commons.httpcache.engine.HttpCacheServletResponseWrapper;
 import com.adobe.acs.commons.httpcache.exception.HttpCacheDataStreamException;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
@@ -48,6 +49,8 @@ class MemCachePersistenceObject {
     Multimap<String, String> headers;
     /** Byte array to hold the data from the stream */
     private byte[] bytes;
+    private HttpCacheServletResponseWrapper.ResponseWriteMethod writeMethod;
+
     AtomicInteger count = new AtomicInteger(0);
 
     /**
@@ -67,11 +70,12 @@ class MemCachePersistenceObject {
      * @throws HttpCacheDataStreamException
      */
     public MemCachePersistenceObject buildForCaching(int status, String charEncoding, String contentType, Map<String,
-            List<String>> headers, InputStream dataInputStream) throws HttpCacheDataStreamException {
+            List<String>> headers, InputStream dataInputStream, HttpCacheServletResponseWrapper.ResponseWriteMethod writeMethod) throws HttpCacheDataStreamException {
 
         this.status = status;
         this.charEncoding = charEncoding;
         this.contentType = contentType;
+        this.writeMethod = writeMethod;
 
         // Iterate headers and take a copy.
         this.headers = HashMultimap.create();
@@ -160,5 +164,9 @@ class MemCachePersistenceObject {
      */
     public int getHitCount() {
         return count.get();
+    }
+
+    public HttpCacheServletResponseWrapper.ResponseWriteMethod getWriteMethod() {
+        return writeMethod;
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/mem/impl/MemHttpCacheStoreImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/mem/impl/MemHttpCacheStoreImpl.java
@@ -170,8 +170,7 @@ public class MemHttpCacheStoreImpl extends AbstractGuavaCacheMBean<CacheKey, Mem
     @Override
     public void put(CacheKey key, CacheContent content) throws HttpCacheDataStreamException {
         cache.put(key, new MemCachePersistenceObject().buildForCaching(content.getStatus(), content.getCharEncoding(),
-                content.getContentType(), content.getHeaders(), content.getInputDataStream()));
-
+                content.getContentType(), content.getHeaders(), content.getInputDataStream(), content.getWriteMethod()));
     }
 
     @Override
@@ -193,7 +192,7 @@ public class MemHttpCacheStoreImpl extends AbstractGuavaCacheMBean<CacheKey, Mem
         value.incrementHitCount();
 
         return new CacheContent(value.getStatus(), value.getCharEncoding(), value.getContentType(), value.getHeaders(), new
-                ByteArrayInputStream(value.getBytes()));
+                ByteArrayInputStream(value.getBytes()), value.getWriteMethod());
     }
 
     @Override


### PR DESCRIPTION
see : https://github.com/Adobe-Consulting-Services/acs-aem-commons/pull/1600

Persists the write method being used by the servlet to serve up cache content.
Tested locally.
