### PR TITLE
Bulk Workflow Manager doing nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1597 - If 'Preserve Filename' unchecked, asset name will support only the following characters: letters, digits, hyphens, underscores, another chars will be replaced with hyphens
 - #1604 - File asset import and url asset imports saves source path as migratedFrom property into assets jcr:content node. If asset is skipped the message in the format "source -> destination" is written into report
 - #1606 - Url Asset Import saves correct path into migratedFrom property of assets's jcr:content node
+- #1610 - Bulk Workflow Manager doing nothing
 
 ### Changed
 - #1571 - Remove separate twitter bundle and use exception trapping to only register AdapterFactory when Twitter4J is available.

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/servlets/StartServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/servlets/StartServlet.java
@@ -26,6 +26,7 @@ import com.adobe.acs.commons.workflow.bulk.execution.impl.runners.FastActionMana
 import com.adobe.acs.commons.workflow.bulk.execution.model.Config;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import org.apache.commons.lang.StringUtils;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
@@ -70,8 +71,7 @@ public class StartServlet extends SlingAllMethodsServlet {
         response.setCharacterEncoding("UTF-8");
 
         try {
-            Gson gson = new Gson();
-            final JsonObject params = (JsonObject) gson.toJsonTree(request.getParameter("params"));
+            final JsonObject params = new JsonParser().parse(request.getParameter("params")).getAsJsonObject();
             final ModifiableValueMap properties = request.getResource().adaptTo(ModifiableValueMap.class);
 
             properties.put("runnerType", getString(params, "runnerType"));


### PR DESCRIPTION
gson.toJsonTree was creating json primitive data types, that wasn't able to be casted to jsonObject