### PR TITLE
Potential fix for Health Check Status Emailer Test failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1606 - Url Asset Import saves correct path into migratedFrom property of assets's jcr:content node
 - #1610 - Bulk Workflow Manager doing nothing
 - #1613 - Potential NPE in JcrPackageReplicationStatusEventHandler
+- #TBD - Fix timing-related test failures in HealthCheckStatusEmailerTest
 
 ### Changed
 - #1571 - Remove separate twitter bundle and use exception trapping to only register AdapterFactory when Twitter4J is available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1606 - Url Asset Import saves correct path into migratedFrom property of assets's jcr:content node
 - #1610 - Bulk Workflow Manager doing nothing
 - #1613 - Potential NPE in JcrPackageReplicationStatusEventHandler
-- #TBD - Fix timing-related test failures in HealthCheckStatusEmailerTest
+- #1623 - Fix timing-related test failures in HealthCheckStatusEmailerTest
 
 ### Changed
 - #1571 - Remove separate twitter bundle and use exception trapping to only register AdapterFactory when Twitter4J is available.

--- a/bundle/src/test/java/com/adobe/acs/commons/hc/impl/HealthCheckStatusEmailerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/hc/impl/HealthCheckStatusEmailerTest.java
@@ -189,6 +189,7 @@ public class HealthCheckStatusEmailerTest {
         Calendar minuteAgo = Calendar.getInstance();
         // Make sure enough time has "ellapsed" so that the call to send email does something
         minuteAgo.add(Calendar.MINUTE, -1);
+        minuteAgo.add(Calendar.SECOND, -1);
         FieldUtils.writeField(healthCheckStatusEmailer, "nextEmailTime",  minuteAgo, true);
 
         // Send the first time


### PR DESCRIPTION
This does change the behavior slightly of the Health Check Status Emailer. It now sends the email if the threshold has been reached exactly (whereas before it would happen only if it was at least 1 millisecond after the threshold time). My theory is that this is failing on very fast machines. I've never seen this fail locally, but I guess that just means I need a new computer.