### PR TITLE
Defect/asset ingestor/folders with spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1610 - Bulk Workflow Manager doing nothing
 - #1613 - Potential NPE in JcrPackageReplicationStatusEventHandler
 - #1623 - Fix timing-related test failures in HealthCheckStatusEmailerTest
+- #1627 - Asset Ingestor and Valid Folder Name: if Preserve File name unchecked, asset and folder names will support only the following characters: letters, digits, hyphens, underscores, another chars will be replaced with hyphens
 
 ### Changed
 - #1571 - Remove separate twitter bundle and use exception trapping to only register AdapterFactory when Twitter4J is available.

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestor.java
@@ -239,6 +239,9 @@ public abstract class AssetIngestor extends ProcessDefinition {
             ignoreExtensions = "";
         }
         ignoreExtensionList = Arrays.asList(ignoreExtensions.trim().toLowerCase().split(","));
+        if (!preserveFileName) {
+            jcrBasePath = NameUtil.createValidDamPath(jcrBasePath);
+        }
     }
 
     @SuppressWarnings("squid:S00112")

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestor.java
@@ -333,7 +333,7 @@ public abstract class AssetIngestor extends ProcessDefinition {
         if (dryRunMode) {
             return true;
         }
-        String folderPath = el.getNodePath();
+        String folderPath = el.getNodePath(preserveFileName);
         synchronized (alreadyCreatedFolders) {
             if (alreadyCreatedFolders.contains(folderPath)) {
                 return false;
@@ -362,20 +362,20 @@ public abstract class AssetIngestor extends ProcessDefinition {
             String nodeName;
 
             if (parent != null) {
-                parentPath = parent.getNodePath();
-                nodeName = el.getNodeName();
+                parentPath = parent.getNodePath(preserveFileName);
+                nodeName = el.getNodeName(preserveFileName);
                 if (!jcrBasePath.equals(parentPath)) {
                     createFolderNode(parent, r);
                 }
             } else {
-                parentPath = StringUtils.substringBeforeLast(el.getNodePath(),"/");
-                nodeName = StringUtils.substringAfterLast(el.getNodePath(),"/");
+                parentPath = StringUtils.substringBeforeLast(el.getNodePath(preserveFileName),"/");
+                nodeName = StringUtils.substringAfterLast(el.getNodePath(preserveFileName),"/");
             }
             Node child = s.getNode(parentPath).addNode(nodeName, DEFAULT_FOLDER_TYPE);
 
             setFolderTitle(child, name);
 
-            trackDetailedActivity(el.getNodePath(), "Create Folder", "Create folder", 0L);
+            trackDetailedActivity(el.getNodePath(preserveFileName), "Create Folder", "Create folder", 0L);
             incrementCount(createdFolders, 1L);
             r.commit();
             r.refresh();
@@ -400,18 +400,14 @@ public abstract class AssetIngestor extends ProcessDefinition {
 
     protected CheckedConsumer<ResourceResolver> importAsset(final Source source, ActionManager actionManager) {
         return (ResourceResolver r) -> {
-            createFolderNode(source.getElement().getParent(), r);
-            actionManager.setCurrentItem(source.getElement().getSourcePath());
             HierarchicalElement el = source.getElement();
-            String path = source.getElement().getNodePath();
-            if(null != el && el.isFile() && el.getName().contains(".") && !preserveFileName){
-                String baseName = StringUtils.substringBeforeLast(el.getName(), ".");
-                String extension = StringUtils.substringAfterLast(el.getName(), ".");
-                path = (el.getParent() == null ? el.getJcrBasePath() : el.getParent().getNodePath()) + "/"
-                        + NameUtil.createValidDamName(baseName,NameUtil.CASE_SENSITIVE_HYPHEN_LABEL_CHAR_MAPPING,"-")
-                        + "." + NameUtil.createValidDamName(extension,NameUtil.CASE_SENSITIVE_HYPHEN_LABEL_CHAR_MAPPING,"-");
+            if (null != el) {
+                createFolderNode(el.getParent(), r);
+                actionManager.setCurrentItem(el.getSourcePath());
+
+                String path = el.getNodePath(preserveFileName);
+                handleExistingAsset(source, path, r);
             }
-            handleExistingAsset(source, path, r);
         };
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestor.java
@@ -172,7 +172,7 @@ public class FileAssetIngestor extends AssetIngestor {
         } catch (IOException ex) {
             Failure failure = new Failure();
             failure.setException(ex);
-            failure.setNodePath(fileSource.getElement().getNodePath());
+            failure.setNodePath(fileSource.getElement().getNodePath(preserveFileName));
             manager.getFailureList().add(failure);
         } finally {
             try {
@@ -180,7 +180,7 @@ public class FileAssetIngestor extends AssetIngestor {
             } catch (IOException ex) {
                 Failure failure = new Failure();
                 failure.setException(ex);
-                failure.setNodePath(fileSource.getElement().getNodePath());
+                failure.setNodePath(fileSource.getElement().getNodePath(preserveFileName));
                 manager.getFailureList().add(failure);
             }
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/HierarchicalElement.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/HierarchicalElement.java
@@ -21,6 +21,7 @@ package com.adobe.acs.commons.mcp.impl.processes.asset;
 
 import com.adobe.acs.commons.functions.CheckedConsumer;
 import com.adobe.acs.commons.functions.CheckedFunction;
+import com.day.cq.commons.jcr.JcrUtil;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.UnsupportedEncodingException;
@@ -59,24 +60,38 @@ public interface HierarchicalElement {
 
     String getJcrBasePath();
 
-    default String getNodePath() {
+    default String getNodePath(boolean preserveName) {
         HierarchicalElement parent = getParent();
         if (excludeBaseFolder()) {
-            return parent == null ? getJcrBasePath() : parent.getNodePath() + "/" + getNodeName();
+            return parent == null ? getJcrBasePath() : parent.getNodePath(preserveName) + "/" + getNodeName(preserveName);
         } else {
-            return (parent == null ? getJcrBasePath() : parent.getNodePath()) + "/" + getNodeName();
+            return (parent == null ? getJcrBasePath() : parent.getNodePath(preserveName)) + "/" + getNodeName(preserveName);
         }
     }
 
-    default String getNodeName() {
+    default String getNodeName(boolean preserveName) {
         String name = getName();
-        if (name == null || (isFile() && name.contains("."))) {
+        if (name == null) {
             return name;
         }
-        if (name.matches("\\w+")) {
+        if (preserveName) {
+            return getNodeName(name);
+        }
+        if (isFile() && name.contains(".")) {
+            String baseName = org.apache.commons.lang3.StringUtils.substringBeforeLast(name, ".");
+            String extension = org.apache.commons.lang3.StringUtils.substringAfterLast(name, ".");
+            return NameUtil.createValidDamName(baseName) + "." + NameUtil.createValidDamName(extension);
+        }
+        return name.matches("\\w+") ? name : NameUtil.createValidDamName(name);
+    }
+
+    default String getNodeName(String name) {
+        if (isFile() && name.contains(".")) {
+            return name;
+        } else if (JcrUtil.isValidName(name)) {
             return name;
         } else {
-            return NameUtil.createValidDamName(name);
+            return JcrUtil.createValidName(name, JcrUtil.HYPHEN_LABEL_CHAR_MAPPING, "-");
         }
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/HierarchicalElement.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/HierarchicalElement.java
@@ -72,7 +72,7 @@ public interface HierarchicalElement {
     default String getNodeName(boolean preserveName) {
         String name = getName();
         if (name == null) {
-            return name;
+            return null;
         }
         if (preserveName) {
             return getNodeName(name);

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/HierarchicalElement.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/HierarchicalElement.java
@@ -82,7 +82,7 @@ public interface HierarchicalElement {
             String extension = org.apache.commons.lang3.StringUtils.substringAfterLast(name, ".");
             return NameUtil.createValidDamName(baseName) + "." + NameUtil.createValidDamName(extension);
         }
-        return name.matches("\\w+") ? name : NameUtil.createValidDamName(name);
+        return name.matches(NameUtil.VALID_NAME_REGEXP) ? name : NameUtil.createValidDamName(name);
     }
 
     default String getNodeName(String name) {

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/HierarchicalElement.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/HierarchicalElement.java
@@ -21,7 +21,6 @@ package com.adobe.acs.commons.mcp.impl.processes.asset;
 
 import com.adobe.acs.commons.functions.CheckedConsumer;
 import com.adobe.acs.commons.functions.CheckedFunction;
-import com.day.cq.commons.jcr.JcrUtil;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.UnsupportedEncodingException;
@@ -71,12 +70,13 @@ public interface HierarchicalElement {
 
     default String getNodeName() {
         String name = getName();
-        if (isFile() && name.contains(".")) {
+        if (name == null || (isFile() && name.contains("."))) {
             return name;
-        } else if (name != null && name.matches("\\w+")) {
+        }
+        if (name.matches("\\w+")) {
             return name;
         } else {
-            return NameUtil.createValidDamName(name, JcrUtil.HYPHEN_LABEL_CHAR_MAPPING, "-");
+            return NameUtil.createValidDamName(name);
         }
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/HierarchicalElement.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/HierarchicalElement.java
@@ -73,10 +73,10 @@ public interface HierarchicalElement {
         String name = getName();
         if (isFile() && name.contains(".")) {
             return name;
-        } else if (JcrUtil.isValidName(name)) {
+        } else if (name != null && name.matches("\\w+")) {
             return name;
         } else {
-            return JcrUtil.createValidName(name, JcrUtil.HYPHEN_LABEL_CHAR_MAPPING, "-");
+            return NameUtil.createValidDamName(name, JcrUtil.HYPHEN_LABEL_CHAR_MAPPING, "-");
         }
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/NameUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/NameUtil.java
@@ -19,7 +19,13 @@
  */
 package com.adobe.acs.commons.mcp.impl.processes.asset;
 
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 final class NameUtil {
+    static final String PATH_SEPARATOR = "/";
     static final String[] CASE_SENSITIVE_HYPHEN_LABEL_CHAR_MAPPING = new String[] {"-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "-", "-", "-", "-", "-", "-", "-", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "-", "-", "-", "-", "_", "-", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "-", "-", "-", "-", "-", "-", "f", "-", "-", "-", "fi", "fi", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "y", "-", "-", "-", "-", "i", "c", "p", "o", "v", "-", "s", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "a", "a", "a", "a", "ae", "a", "ae", "c", "e", "e", "e", "e", "i", "i", "i", "i", "d", "n", "o", "o", "o", "o", "oe", "x", "o", "u", "u", "u", "ue", "y", "b", "ss", "a", "a", "a", "a", "ae", "a", "ae", "c", "e", "e", "e", "e", "i", "i", "i", "i", "o", "n", "o", "o", "o", "o", "oe", "-", "o", "u", "u", "u", "ue", "y", "b", "y"};
 
     private NameUtil() {}
@@ -44,4 +50,15 @@ final class NameUtil {
     static String createValidDamName(String title) {
         return createValidDamName(title, CASE_SENSITIVE_HYPHEN_LABEL_CHAR_MAPPING, "-");
     }
+
+    static String createValidDamPath(String path) {
+        if (StringUtils.isEmpty(path)) {
+            return path;
+        }
+        return Arrays.asList(StringUtils.split(path, PATH_SEPARATOR))
+                .stream()
+                .map(name -> NameUtil.createValidDamName(name))
+                .collect(Collectors.joining(PATH_SEPARATOR));
+    }
+
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/NameUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/NameUtil.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 final class NameUtil {
     static final String PATH_SEPARATOR = "/";
+    static final String VALID_NAME_REGEXP = "(\\w|-)+";
     static final String[] CASE_SENSITIVE_HYPHEN_LABEL_CHAR_MAPPING = new String[] {"-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "-", "-", "-", "-", "-", "-", "-", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z", "-", "-", "-", "-", "_", "-", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "-", "-", "-", "-", "-", "-", "f", "-", "-", "-", "fi", "fi", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "y", "-", "-", "-", "-", "i", "c", "p", "o", "v", "-", "s", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "-", "a", "a", "a", "a", "ae", "a", "ae", "c", "e", "e", "e", "e", "i", "i", "i", "i", "d", "n", "o", "o", "o", "o", "oe", "x", "o", "u", "u", "u", "ue", "y", "b", "ss", "a", "a", "a", "a", "ae", "a", "ae", "c", "e", "e", "e", "e", "i", "i", "i", "i", "o", "n", "o", "o", "o", "o", "oe", "-", "o", "u", "u", "u", "ue", "y", "b", "y"};
 
     private NameUtil() {}
@@ -57,7 +58,7 @@ final class NameUtil {
         }
         return Arrays.asList(StringUtils.split(path, PATH_SEPARATOR))
                 .stream()
-                .map(name -> NameUtil.createValidDamName(name))
+                .map(name -> name.matches(VALID_NAME_REGEXP) ? name : NameUtil.createValidDamName(name))
                 .collect(Collectors.joining(PATH_SEPARATOR));
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/S3AssetIngestor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/S3AssetIngestor.java
@@ -159,7 +159,7 @@ public class S3AssetIngestor extends AssetIngestor {
             } catch (IOException ex) {
                 Failure failure = new Failure();
                 failure.setException(ex);
-                failure.setNodePath(ss.getElement().getNodePath());
+                failure.setNodePath(ss.getElement().getNodePath(preserveFileName));
                 manager.getFailureList().add(failure);
             } finally {
                 try {
@@ -167,7 +167,7 @@ public class S3AssetIngestor extends AssetIngestor {
                 } catch (IOException ex) {
                     Failure failure = new Failure();
                     failure.setException(ex);
-                    failure.setNodePath(ss.getElement().getNodePath());
+                    failure.setNodePath(ss.getElement().getNodePath(preserveFileName));
                     manager.getFailureList().add(failure);
                 }
             }

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestorUtil.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestorUtil.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.mcp.impl.processes.asset;
 
 import java.util.Arrays;

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestorUtil.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestorUtil.java
@@ -1,0 +1,54 @@
+package com.adobe.acs.commons.mcp.impl.processes.asset;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class AssetIngestorUtil {
+
+    static final List<AssetIngestorPaths> FILE_PATHS = Arrays.asList(
+            new AssetIngestorPaths("/qwew/qwewqewqe.jpg"),
+            new AssetIngestorPaths("/qwew/qwew-#/qwewqewqe123213*(0-%.jpg", "/qwew/qwew--/qwewqewqe123213--0--.jpg", "/qwew/qwew-#/qwewqewqe123213*(0-%.jpg"),
+            new AssetIngestorPaths("/qwew/qwew-#/qwewqe-.jpg", "/qwew/qwew--/qwewqe-.jpg"),
+            new AssetIngestorPaths("/?/qwew/qwew-#/qwewqe-.jpg", "/-/qwew/qwew--/qwewqe-.jpg", "/-/qwew/qwew-#/qwewqe-.jpg"),
+            new AssetIngestorPaths("/qwe    wqe-.jpg", "/qwe----wqe-.jpg")
+    );
+
+    static final List<AssetIngestorPaths> FOLDER_PATHS = Arrays.asList(
+            new AssetIngestorPaths("/qwewqewqe123213"),
+            new AssetIngestorPaths("/Fwewqewqe123213"),
+            new AssetIngestorPaths("/qw-/ewqewqe123213"),
+            new AssetIngestorPaths("/qwew/qwew-#/qwewqewqe123213*(0-%.jpg", "/qwew/qwew--/qwewqewqe123213--0---jpg", "/qwew/qwew-#/qwewqewqe123213-0jpg")
+    );
+
+    static class AssetIngestorPaths {
+        String actualPath;
+        String expectedPath;
+        String expectedPreservedPath;
+
+        public AssetIngestorPaths(String actualPath) {
+            this(actualPath, actualPath, actualPath);
+        }
+
+        public AssetIngestorPaths(String actualPath, String expectedPath) {
+            this(actualPath, expectedPath, actualPath);
+        }
+
+        public AssetIngestorPaths(String actualPath, String expectedPath, String expectedPreservedPath) {
+            this.actualPath = actualPath;
+            this.expectedPath = expectedPath;
+            this.expectedPreservedPath = expectedPreservedPath;
+        }
+
+        public String getActualPath() {
+            return actualPath;
+        }
+
+        public String getExpectedPath() {
+            return expectedPath;
+        }
+
+        public String getExpectedPreservedPath() {
+            return expectedPreservedPath;
+        }
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestorUtil.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/AssetIngestorUtil.java
@@ -3,6 +3,9 @@ package com.adobe.acs.commons.mcp.impl.processes.asset;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * Util class for AssetIngestor tests
+ */
 public class AssetIngestorUtil {
 
     static final List<AssetIngestorPaths> FILE_PATHS = Arrays.asList(

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorTest.java
@@ -281,16 +281,16 @@ public class FileAssetIngestorTest {
         assertNull(elem1.getParent());
         assertEquals(SFTP_HOST_TEST_PATH, elem1.getSourcePath());
         // File should be a child node
-        assertEquals("/content/dam/path", elem1.getNodePath());
-        assertEquals("path", elem1.getNodeName());
+        assertEquals("/content/dam/path", elem1.getNodePath(true));
+        assertEquals("path", elem1.getNodeName(true));
 
         FileAssetIngestor.SftpHierarchicalElement elem2 = ingestor.new SftpHierarchicalElement(SFTP_HOST_TEST_PATH);
         elem1.isFile = false;
         assertNull(elem2.getParent());
         assertEquals(SFTP_HOST_TEST_PATH, elem2.getSourcePath());
         // Folder should map to the root folder
-        assertEquals("/content/dam", elem2.getNodePath());
-        assertEquals("path", elem2.getNodeName());
+        assertEquals("/content/dam", elem2.getNodePath(true));
+        assertEquals("path", elem2.getNodeName(true));
     }
 
     @Test
@@ -321,6 +321,7 @@ public class FileAssetIngestorTest {
     @Test
     public void testSftpUrlSupportsSpecialCharacters() throws UnsupportedEncodingException, URISyntaxException {
         configureSftpFields();
+        ingestor.preserveFileName = false;
         ingestor.fileBasePath = "sftp://somehost:20";
         String sourcePath = "/this/is/path with/$pecial/characters#@/some image& chars.jpg";
         String expectedSourcePath = sourcePath.replaceAll("[\\W&&[^/]]", "-");
@@ -331,7 +332,7 @@ public class FileAssetIngestorTest {
         assertEquals("sftp://somehost:20/this/is/path+with/%24pecial/characters%23%40/some+image%26+chars.jpg", elem1.uri.toString());
         assertEquals("somehost", elem1.uri.getHost());
         assertEquals(20, elem1.uri.getPort());
-        assertEquals(ingestor.jcrBasePath + expectedSourcePath, elem1.getNodePath());
+        assertEquals(ingestor.jcrBasePath + expectedSourcePath, elem1.getNodePath(false));
 
         ingestor.fileBasePath = "sftp://somehost2";
         String urlWithoutPort = "sftp://somehost2" + sourcePath;
@@ -340,7 +341,7 @@ public class FileAssetIngestorTest {
         assertEquals(sourcePath, elem2.path);
         assertEquals("sftp://somehost2/this/is/path+with/%24pecial/characters%23%40/some+image%26+chars.jpg", elem2.uri.toString());
         assertEquals("somehost2", elem2.uri.getHost());
-        assertEquals(ingestor.jcrBasePath + expectedSourcePath, elem1.getNodePath());
+        assertEquals(ingestor.jcrBasePath + expectedSourcePath, elem1.getNodePath(false));
     }
 
     private File addFile(File dir, String name, String resourcePath) throws IOException {

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorTest.java
@@ -320,20 +320,27 @@ public class FileAssetIngestorTest {
 
     @Test
     public void testSftpUrlSupportsSpecialCharacters() throws UnsupportedEncodingException, URISyntaxException {
-        String urlWithPort = "sftp://somehost:20/this/is/path with/$pecial/characters#@/some image& chars.jpg";
+        configureSftpFields();
+        ingestor.fileBasePath = "sftp://somehost:20";
+        String sourcePath = "/this/is/path with/$pecial/characters#@/some image& chars.jpg";
+        String expectedSourcePath = sourcePath.replaceAll("[\\W&&[^/]]", "-");
+        String urlWithPort = "sftp://somehost:20" + sourcePath;
         FileAssetIngestor.SftpHierarchicalElement elem1 = ingestor.new SftpHierarchicalElement(urlWithPort);
 
-        assertEquals("/this/is/path with/$pecial/characters#@/some image& chars.jpg", elem1.path);
+        assertEquals(sourcePath, elem1.path);
         assertEquals("sftp://somehost:20/this/is/path+with/%24pecial/characters%23%40/some+image%26+chars.jpg", elem1.uri.toString());
         assertEquals("somehost", elem1.uri.getHost());
         assertEquals(20, elem1.uri.getPort());
+        assertEquals(ingestor.jcrBasePath + expectedSourcePath, elem1.getNodePath());
 
-        String urlWithoutPort = "sftp://somehost2/this/is/path with/$pecial/characters#@/some image& chars.jpg";
+        ingestor.fileBasePath = "sftp://somehost2";
+        String urlWithoutPort = "sftp://somehost2" + sourcePath;
         FileAssetIngestor.SftpHierarchicalElement elem2 = ingestor.new SftpHierarchicalElement(urlWithoutPort);
 
-        assertEquals("/this/is/path with/$pecial/characters#@/some image& chars.jpg", elem2.path);
+        assertEquals(sourcePath, elem2.path);
         assertEquals("sftp://somehost2/this/is/path+with/%24pecial/characters%23%40/some+image%26+chars.jpg", elem2.uri.toString());
         assertEquals("somehost2", elem2.uri.getHost());
+        assertEquals(ingestor.jcrBasePath + expectedSourcePath, elem1.getNodePath());
     }
 
     private File addFile(File dir, String name, String resourcePath) throws IOException {

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorTest.java
@@ -323,7 +323,6 @@ public class FileAssetIngestorTest {
         ingestor.preserveFileName = false;
         ingestor.fileBasePath = "sftp://somehost:20";
         String sourcePath = "/this/is/path with/$pecial/characters#@/some image& chars.jpg";
-        String expectedSourcePath = sourcePath.replaceAll("[\\W&&[^/]]", "-");
         String urlWithPort = "sftp://somehost:20" + sourcePath;
         FileAssetIngestor.SftpHierarchicalElement elem1 = ingestor.new SftpHierarchicalElement(urlWithPort);
 
@@ -331,6 +330,7 @@ public class FileAssetIngestorTest {
         assertEquals("sftp://somehost:20/this/is/path+with/%24pecial/characters%23%40/some+image%26+chars.jpg", elem1.uri.toString());
         assertEquals("somehost", elem1.uri.getHost());
         assertEquals(20, elem1.uri.getPort());
+        String expectedSourcePath = sourcePath.replaceAll("[\\W&&[^/]]", "-");
         assertEquals(ingestor.jcrBasePath + expectedSourcePath, elem1.getNodePath(false));
 
         ingestor.fileBasePath = "sftp://somehost2";

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorTest.java
@@ -29,6 +29,7 @@ import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
 import com.jcraft.jsch.SftpException;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -36,6 +37,7 @@ import org.apache.sling.commons.mime.MimeTypeService;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.junit.SlingContext;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,12 +45,10 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
 
 import javax.annotation.Nullable;
-
+import javax.jcr.RepositoryException;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -58,6 +58,7 @@ import java.util.Collections;
 import java.util.Vector;
 import java.util.stream.Collectors;
 
+import static com.adobe.acs.commons.mcp.impl.processes.asset.AssetIngestorUtil.*;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.*;
@@ -103,6 +104,7 @@ public class FileAssetIngestorTest {
         context.resourceResolver().commit();
         tempDirectory = Files.createTempDir();
         ingestor = new FileAssetIngestor(context.getService(MimeTypeService.class));
+        ingestor.timeout = 1;
         ingestor.jcrBasePath = "/content/dam";
         ingestor.ignoreFileList = Collections.emptyList();
         ingestor.ignoreExtensionList = Collections.emptyList();
@@ -110,13 +112,10 @@ public class FileAssetIngestorTest {
         ingestor.existingAssetAction = AssetIngestor.AssetAction.skip;
         ingestor.fileBasePath = tempDirectory.getAbsolutePath();
 
-        doAnswer(new Answer() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                CheckedConsumer<ResourceResolver> method = (CheckedConsumer<ResourceResolver>) invocation.getArguments()[0];
-                method.accept(context.resourceResolver());
-                return null;
-            }
+        doAnswer(invocation -> {
+            CheckedConsumer<ResourceResolver> method = (CheckedConsumer<ResourceResolver>) invocation.getArguments()[0];
+            method.accept(context.resourceResolver());
+            return null;
         }).when(actionManager).deferredWithResolver(any(CheckedConsumer.class));
     }
 
@@ -272,7 +271,7 @@ public class FileAssetIngestorTest {
         newDir.mkdir();
         return newDir;
     }
-    
+
     @Test
     public void testSftpStructures() throws URISyntaxException, JSchException, UnsupportedEncodingException {
         configureSftpFields();
@@ -299,7 +298,7 @@ public class FileAssetIngestorTest {
         ChannelSftp channel = mock(ChannelSftp.class);
         when(channel.isConnected()).thenReturn(true);
         when(channel.getSession()).thenReturn(mock(Session.class));
-        
+
         Vector<ChannelSftp.LsEntry> entries = (new MockDirectoryBuilder())
                 .addDirectory(".")
                 .addDirectory("..")
@@ -307,7 +306,7 @@ public class FileAssetIngestorTest {
                 .addFile("file2.png", 4567L)
                 .asVector();
         when(channel.ls(anyObject())).thenReturn(entries);
-        
+
         FileAssetIngestor.SftpHierarchicalElement elem1 = ingestor.new SftpHierarchicalElement(SFTP_HOST_TEST_PATH, channel, false);
         int count = 0;
         for (HierarchicalElement e : elem1.getChildren().collect(Collectors.toList())) {
@@ -342,6 +341,60 @@ public class FileAssetIngestorTest {
         assertEquals("sftp://somehost2/this/is/path+with/%24pecial/characters%23%40/some+image%26+chars.jpg", elem2.uri.toString());
         assertEquals("somehost2", elem2.uri.getHost());
         assertEquals(ingestor.jcrBasePath + expectedSourcePath, elem1.getNodePath(false));
+    }
+
+    @Test
+    public void testPathSupportsSpecialCharacters() throws UnsupportedEncodingException, URISyntaxException, RepositoryException {
+        configureSftpFields();
+        ingestor.preserveFileName = false;
+        ingestor.jcrBasePath = ingestor.jcrBasePath.concat("#");
+        ingestor.init();
+
+        Assert.assertTrue(ingestor.jcrBasePath.endsWith("-"));
+
+        for (AssetIngestorPaths pathsToValidate : FILE_PATHS) {
+            String expectedPath = pathsToValidate.getExpectedPath();
+            String actualPath = pathsToValidate.getActualPath();
+            FileAssetIngestor.SftpHierarchicalElement elem = ingestor.new SftpHierarchicalElement(ingestor.fileBasePath + actualPath);
+            elem.isFile = true;
+            boolean validPath = StringUtils.substringBeforeLast(actualPath.replaceAll(NameUtil.PATH_SEPARATOR, StringUtils.EMPTY), ".")
+                    .matches(NameUtil.VALID_NAME_REGEXP);
+            Assert.assertEquals(validPath, expectedPath.equals(actualPath));
+            Assert.assertEquals(ingestor.jcrBasePath + expectedPath, elem.getNodePath(false));
+        }
+
+        for (AssetIngestorPaths pathsToValidate : FOLDER_PATHS) {
+            String expectedPath = pathsToValidate.getExpectedPath();
+            String actualPath = pathsToValidate.getActualPath();
+            FileAssetIngestor.SftpHierarchicalElement elem = ingestor.new SftpHierarchicalElement(ingestor.fileBasePath + actualPath);
+            boolean validPath = actualPath.replaceAll(NameUtil.PATH_SEPARATOR, StringUtils.EMPTY).matches(NameUtil.VALID_NAME_REGEXP);
+            Assert.assertEquals(validPath, expectedPath.equals(actualPath));
+            Assert.assertEquals(ingestor.jcrBasePath + expectedPath, elem.getNodePath(false));
+        }
+    }
+
+    @Test
+    public void testPreservePathWithSpecialCharacters() throws UnsupportedEncodingException, URISyntaxException, RepositoryException {
+        configureSftpFields();
+        ingestor.jcrBasePath = ingestor.jcrBasePath.concat("#");
+        ingestor.init();
+
+        Assert.assertTrue(ingestor.jcrBasePath.endsWith("#"));
+
+        for (AssetIngestorPaths pathsToValidate : FILE_PATHS) {
+            String expectedPath = pathsToValidate.getExpectedPreservedPath();
+            String actualPath = pathsToValidate.getActualPath();
+            FileAssetIngestor.SftpHierarchicalElement elem = ingestor.new SftpHierarchicalElement(ingestor.fileBasePath + actualPath);
+            elem.isFile = true;
+            Assert.assertEquals(ingestor.jcrBasePath + expectedPath, elem.getNodePath(true));
+        }
+
+        for (AssetIngestorPaths pathsToValidate : FOLDER_PATHS) {
+            String expectedPath = pathsToValidate.getExpectedPreservedPath();
+            String actualPath = pathsToValidate.getActualPath();
+            FileAssetIngestor.SftpHierarchicalElement elem = ingestor.new SftpHierarchicalElement(ingestor.fileBasePath + actualPath);
+            Assert.assertEquals(ingestor.jcrBasePath + expectedPath, elem.getNodePath(true));
+        }
     }
 
     private File addFile(File dir, String name, String resourcePath) throws IOException {

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorUtilitiesTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorUtilitiesTest.java
@@ -63,7 +63,7 @@ public class FileAssetIngestorUtilitiesTest {
         assertEquals(folder2.getAbsolutePath(), el.getSourcePath());
         assertTrue(el.isFolder());
         assertFalse(el.isFile());
-        assertEquals("/content/dam/folder1/folder2", el.getNodePath());
+        assertEquals("/content/dam/folder1/folder2", el.getNodePath(true));
         assertEquals("folder2", el.getName());
 
         HierarchicalElement parent = el.getParent();

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/S3AssetIngestorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/S3AssetIngestorTest.java
@@ -335,8 +335,8 @@ public class S3AssetIngestorTest {
         assertEquals(4, ingestor.getCount(ingestor.createdFolders));
         assertNotNull(context.resourceResolver().getResource("/content/dam/folder-with-hyphens-after-16chars"));
         assertNotNull(context.resourceResolver().getResource("/content/dam/folder-with-hyphens-after-16chars/nested-folder-with-hyphens-after-16chars"));
-        assertNotNull(context.resourceResolver().getResource("/content/dam/folder-with-hyphensafter16charsand"));
-        assertNotNull(context.resourceResolver().getResource("/content/dam/folder-with-hyphensafter16charsand/nested-folder-with-hyphens-after-16chars"));
+        assertNotNull(context.resourceResolver().getResource("/content/dam/folder-with-hyphens-after-16chars-and--"));
+        assertNotNull(context.resourceResolver().getResource("/content/dam/folder-with-hyphens-after-16chars-and--/nested-folder-with-hyphens-after-16chars"));
     }
 
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/S3AssetIngestorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/S3AssetIngestorTest.java
@@ -335,8 +335,8 @@ public class S3AssetIngestorTest {
         assertEquals(4, ingestor.getCount(ingestor.createdFolders));
         assertNotNull(context.resourceResolver().getResource("/content/dam/folder-with-hyphens-after-16chars"));
         assertNotNull(context.resourceResolver().getResource("/content/dam/folder-with-hyphens-after-16chars/nested-folder-with-hyphens-after-16chars"));
-        assertNotNull(context.resourceResolver().getResource("/content/dam/folder-with-hyphens-after-16chars-and--"));
-        assertNotNull(context.resourceResolver().getResource("/content/dam/folder-with-hyphens-after-16chars-and--/nested-folder-with-hyphens-after-16chars"));
+        assertNotNull(context.resourceResolver().getResource("/content/dam/folder-with-hyphensafter16charsand"));
+        assertNotNull(context.resourceResolver().getResource("/content/dam/folder-with-hyphensafter16charsand/nested-folder-with-hyphens-after-16chars"));
     }
 
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/S3AssetIngestorUtilitiesTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/S3AssetIngestorUtilitiesTest.java
@@ -45,7 +45,7 @@ public class S3AssetIngestorUtilitiesTest {
         assertEquals("testbucket:folder1/folder2/", el.getItemName());
         assertTrue(el.isFolder());
         assertFalse(el.isFile());
-        assertEquals("/content/dam/folder1/folder2", el.getNodePath());
+        assertEquals("/content/dam/folder1/folder2", el.getNodePath(true));
         assertEquals("folder2", el.getName());
 
         HierarchicalElement parent = el.getParent();
@@ -65,7 +65,7 @@ public class S3AssetIngestorUtilitiesTest {
         assertEquals("testbucket:folder1/folder2/folder3/", el.getItemName());
         assertTrue(el.isFolder());
         assertFalse(el.isFile());
-        assertEquals("/content/dam/folder2/folder3", el.getNodePath());
+        assertEquals("/content/dam/folder2/folder3", el.getNodePath(true));
         assertEquals("folder3", el.getName());
 
         HierarchicalElement parent = el.getParent();
@@ -73,7 +73,7 @@ public class S3AssetIngestorUtilitiesTest {
         assertNotNull(parent);
         assertTrue(parent.isFolder());
         assertFalse(parent.isFile());
-        assertEquals("/content/dam/folder2", parent.getNodePath());
+        assertEquals("/content/dam/folder2", parent.getNodePath(true));
         assertEquals("folder2", parent.getName());
 
         assertNull(parent.getParent());
@@ -112,7 +112,7 @@ public class S3AssetIngestorUtilitiesTest {
         assertFalse(el.isFolder());
         assertTrue(el.isFile());
         assertEquals("image.png", el.getName());
-        assertEquals("/content/dam/folder2/folder3/image.png", el.getNodePath());
+        assertEquals("/content/dam/folder2/folder3/image.png", el.getNodePath(true));
 
         HierarchicalElement parent = el.getParent();
         assertEquals("testbucket:folder1/folder2/folder3/", parent.getItemName());
@@ -120,7 +120,7 @@ public class S3AssetIngestorUtilitiesTest {
         assertTrue(parent.isFolder());
         assertFalse(parent.isFile());
         assertEquals("folder3", parent.getName());
-        assertEquals("/content/dam/folder2/folder3", parent.getNodePath());
+        assertEquals("/content/dam/folder2/folder3", parent.getNodePath(true));
 
         parent = parent.getParent();
         assertEquals("testbucket:folder1/folder2/", parent.getItemName());
@@ -128,7 +128,7 @@ public class S3AssetIngestorUtilitiesTest {
         assertTrue(parent.isFolder());
         assertFalse(parent.isFile());
         assertEquals("folder2", parent.getName());
-        assertEquals("/content/dam/folder2", parent.getNodePath());
+        assertEquals("/content/dam/folder2", parent.getNodePath(true));
 
         assertNull(parent.getParent());
     }


### PR DESCRIPTION
If Preserve File name unchecked, asset and folder names will support only the following characters: letters, digits, hyphens, underscores, another chars will be replaced with hyphens