### PR TITLE
#1648 - SyncSmartTagsToXmpMetadataNodeProcess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1611 - HttpCache: Added custom expiry time per cache configuration (not supported by standard mem-store), caffeine cache store
 - #1612 - Retries count and retry pause is configurable for all Asset Ingestors
 - #1637 - Add support for bounce address setting in EmailService
-
+- #1648 - Add Smart Tags to XMP Metadata Node Workflow Process
 
 ### Fixed
 - #1607 - HttpCache: improved the write to response mechanism.

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/process/impl/SyncSmartTagsToXmpMetadataNodeProcess.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/process/impl/SyncSmartTagsToXmpMetadataNodeProcess.java
@@ -1,0 +1,212 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package com.adobe.acs.commons.workflow.process.impl;
+
+import com.adobe.acs.commons.util.ParameterUtil;
+import com.adobe.acs.commons.util.WorkflowHelper;
+import com.adobe.acs.commons.workflow.WorkflowPackageManager;
+import com.adobe.granite.workflow.WorkflowException;
+import com.adobe.granite.workflow.WorkflowSession;
+import com.adobe.granite.workflow.exec.WorkItem;
+import com.adobe.granite.workflow.exec.WorkflowProcess;
+import com.adobe.granite.workflow.metadata.MetaDataMap;
+import com.day.cq.dam.api.Asset;
+import com.day.cq.dam.api.DamConstants;
+import com.day.cq.dam.commons.util.DamUtil;
+import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jackrabbit.JcrConstants;
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.RepositoryException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+@Component(
+        service = WorkflowProcess.class,
+        property = "process.label=Synchronize Smart Tags to XMP Metadata Node"
+)
+public class SyncSmartTagsToXmpMetadataNodeProcess implements WorkflowProcess {
+    private static final Logger log = LoggerFactory.getLogger(SyncSmartTagsToXmpMetadataNodeProcess.class);
+
+    // OOTB Predicate Tags nodes and properties
+    private static final String NN_PREDICTED_TAGS = "predictedTags";
+    private static final String PN_SMART_TAG_NAME = "name";
+    private static final String PN_SMART_TAG_CONFIDENCE = "confidence";
+
+    // Default nodes and properties to write into
+    private static final String DEFAULT_NN_SEQUENCE = "dam:predictedTags";
+    private static final String DEFAULT_PN_PREDICATED_TAGS_NAME = "dam:predictedTagName";
+    private static final String DEFAULT_PN_PREDICATED_TAGS_CONFIDENCE = "dam:predictedTagConfidence";
+
+    private static final Double DEFAULT_MINIMUM_CONFIDENCE = 0.0;
+
+    @Reference
+    private WorkflowHelper workflowHelper;
+
+    @Reference
+    private WorkflowPackageManager workflowPackageManager;
+
+    public final void execute(WorkItem workItem, WorkflowSession workflowSession, MetaDataMap metaDataMap)
+            throws WorkflowException {
+
+        log.debug("Invoked syncSmartTagsToMetadata Workflow Process step for payload [ {} ]", workItem.getWorkflowData().getPayload());
+
+        final ProcessArgs processArgs = new ProcessArgs(metaDataMap);
+
+        try (ResourceResolver resourceResolver = workflowHelper.getResourceResolver(workflowSession)) {
+            final List<String> payloads = workflowPackageManager.getPaths(resourceResolver,
+                    (String) workItem.getWorkflowData().getPayload());
+
+            final List<Asset> assets = payloads.stream()
+                    .map(payload -> DamUtil.resolveToAsset(resourceResolver.getResource(payload)))
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+
+            assets.stream().forEach(asset -> {
+                try {
+                    syncSmartTagsToMetadata(asset, processArgs);
+                } catch (PersistenceException e) {
+                    log.error("Unable to sync Smart Tags to XMP Metadata structure for asset [ {} ]", asset.getPath(), e);
+                }
+            });
+
+        } catch (RepositoryException e) {
+            log.error("Could not find the payload", e);
+            throw new WorkflowException("Could not find the payload");
+        }
+    }
+
+    protected void syncSmartTagsToMetadata(final Asset asset, ProcessArgs processArgs) throws PersistenceException {
+        final Resource assetResource = asset.adaptTo(Resource.class);
+        final ResourceResolver resourceResolver = assetResource.getResourceResolver();
+
+        final Resource metadataResource = assetResource.getChild(JcrConstants.JCR_CONTENT + "/" + DamConstants.METADATA_FOLDER);
+        final Resource smartTagsResource = assetResource.getChild(JcrConstants.JCR_CONTENT + "/" + DamConstants.METADATA_FOLDER + "/" + NN_PREDICTED_TAGS);
+
+        if (metadataResource.getChild(processArgs.getSequenceName()) != null) {
+            // Remove existing, as they will be re-created
+            resourceResolver.delete(metadataResource.getChild(processArgs.getSequenceName()));
+        }
+
+        final Resource parentResource = resourceResolver.create(metadataResource, processArgs.getSequenceName(),
+                new ImmutableMap.Builder<String, Object>()
+                        .put(JcrConstants.JCR_PRIMARYTYPE, JcrConstants.NT_UNSTRUCTURED)
+                        .put("xmpArrayType", "rdf:Seq")
+                        .put("xmpNodeType", "xmpArray")
+                        .put("xmpArraySize", 0L)
+                        .build());
+
+        final AtomicInteger count = new AtomicInteger(0);
+        if (smartTagsResource != null) {
+            StreamSupport.stream(smartTagsResource.getChildren().spliterator(), false)
+                    .map(Resource::getValueMap)
+                    .filter(properties -> properties.get(PN_SMART_TAG_CONFIDENCE, 0D) >= processArgs.getMinimumConfidence())
+                    .filter(properties -> StringUtils.isNotBlank(properties.get(PN_SMART_TAG_NAME, String.class)))
+                    .forEach(properties -> {
+                        try {
+                            resourceResolver.create(parentResource, String.valueOf(count.incrementAndGet()),
+                                    new ImmutableMap.Builder<String, Object>()
+                                            .put(JcrConstants.JCR_PRIMARYTYPE, JcrConstants.NT_UNSTRUCTURED)
+                                            .put("xmpNodeType", "xmpStruct")
+                                            .put(processArgs.getNameProperty(), properties.get(PN_SMART_TAG_NAME, String.class))
+                                            .put(processArgs.getConfidenceProperty(), properties.get(PN_SMART_TAG_CONFIDENCE, Double.class))
+                                            .build());
+                        } catch (PersistenceException e) {
+                            log.error("Unable to sync Smart Tag [ {} ] to XMP Metadata structure for asset [ {} ]",
+                                    properties.get("name", String.class), asset.getPath(), e);
+                        }
+                    });
+        }
+
+        parentResource.adaptTo(ModifiableValueMap.class).put("xmpArraySize", count.get());
+
+        log.info("Synced [ {} ] Smart Tags to Asset XMP Metadata structure: [ {} ] ",
+                count.get(),
+                asset.getPath() + "/jcr:content/metadata/" + processArgs.getSequenceName());
+    }
+
+    protected static class ProcessArgs {
+        private String ARG_SEQUENCE_NAME = "sequenceName";
+        private String ARG_NAME_PROPERTY = "nameProperty";
+        private String ARG_CONFIDENCE_PROPERTY = "confidenceProperty";
+        private String ARG_MINIMUM_CONFIDENCE = "minimumConfidence";
+
+        private String sequenceName;
+        private String nameProperty;
+        private String confidenceProperty;
+        private Double minimumConfidence;
+
+        public ProcessArgs(MetaDataMap map) {
+
+            String[] lines = org.apache.commons.lang.StringUtils.split(map.get(WorkflowHelper.PROCESS_ARGS, ""), System.lineSeparator());
+            final Map<String, String> data = ParameterUtil.toMap(lines, "=");
+
+            sequenceName = StringUtils.defaultIfEmpty(data.get(ARG_SEQUENCE_NAME), DEFAULT_NN_SEQUENCE);
+            nameProperty = StringUtils.defaultIfEmpty(data.get(ARG_NAME_PROPERTY), DEFAULT_PN_PREDICATED_TAGS_NAME);
+            confidenceProperty = StringUtils.defaultIfEmpty(data.get(ARG_CONFIDENCE_PROPERTY), DEFAULT_PN_PREDICATED_TAGS_CONFIDENCE);
+
+            try {
+                String tmp = data.get(ARG_MINIMUM_CONFIDENCE);
+                if (tmp == null) {
+                    minimumConfidence = DEFAULT_MINIMUM_CONFIDENCE;
+                } else {
+                    minimumConfidence = Double.parseDouble(tmp);
+                }
+            } catch (NumberFormatException | NullPointerException e) {
+                log.warn("Could not parse Double from [ {} ] defaulting to [ {} ]", data.get(ARG_MINIMUM_CONFIDENCE), DEFAULT_MINIMUM_CONFIDENCE);
+                minimumConfidence = DEFAULT_MINIMUM_CONFIDENCE;
+            }
+
+            if (minimumConfidence < 0 || minimumConfidence > 1) {
+                log.warn("Minimum confidence score outside of range [ 0 to 1 ] defaulting to [ {} ]", data.get(ARG_MINIMUM_CONFIDENCE), DEFAULT_MINIMUM_CONFIDENCE);
+                minimumConfidence = DEFAULT_MINIMUM_CONFIDENCE;
+            }
+        }
+
+        public double getMinimumConfidence() {
+            return minimumConfidence;
+        }
+
+        public String getSequenceName() {
+            return sequenceName;
+        }
+
+        public String getNameProperty() {
+            return nameProperty;
+        }
+
+        public String getConfidenceProperty() {
+            return confidenceProperty;
+        }
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/process/impl/SyncSmartTagsToXmpMetadataNodeProcess.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/process/impl/SyncSmartTagsToXmpMetadataNodeProcess.java
@@ -34,7 +34,11 @@ import com.day.cq.dam.commons.util.DamUtil;
 import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.JcrConstants;
-import org.apache.sling.api.resource.*;
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -158,10 +162,10 @@ public class SyncSmartTagsToXmpMetadataNodeProcess implements WorkflowProcess {
     }
 
     protected static class ProcessArgs {
-        private final String ARG_SEQUENCE_NAME = "sequenceName";
-        private final String ARG_NAME_PROPERTY = "nameProperty";
-        private final String ARG_CONFIDENCE_PROPERTY = "confidenceProperty";
-        private final String ARG_MINIMUM_CONFIDENCE = "minimumConfidence";
+        private static final String ARG_SEQUENCE_NAME = "sequenceName";
+        private static final String ARG_NAME_PROPERTY = "nameProperty";
+        private static final String ARG_CONFIDENCE_PROPERTY = "confidenceProperty";
+        private static final String ARG_MINIMUM_CONFIDENCE = "minimumConfidence";
 
         private String sequenceName;
         private String nameProperty;

--- a/bundle/src/test/java/com/adobe/acs/commons/workflow/process/impl/SyncSmartTagsToXmpMetadataNodeProcessTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/workflow/process/impl/SyncSmartTagsToXmpMetadataNodeProcessTest.java
@@ -1,0 +1,140 @@
+package com.adobe.acs.commons.workflow.process.impl;
+
+import com.adobe.granite.workflow.metadata.MetaDataMap;
+import com.adobe.granite.workflow.metadata.SimpleMetaDataMap;
+import com.day.cq.dam.api.Asset;
+import com.day.cq.dam.commons.util.DamUtil;
+import io.wcm.testing.mock.aem.junit.AemContext;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SyncSmartTagsToXmpMetadataNodeProcessTest {
+
+    @Rule
+    public AemContext ctx = new AemContext();
+
+    final MetaDataMap metaDataMap = new SimpleMetaDataMap();
+
+    final SyncSmartTagsToXmpMetadataNodeProcess workflowProcess = new SyncSmartTagsToXmpMetadataNodeProcess();
+
+    @Before
+    public void setUp() throws Exception {
+        ctx.load().json("/com/adobe/acs/commons/workflow/process/impl/SyncSmartTagsToXmpMetadataNodeTest.json", "/content/dam");
+    }
+
+    @Test
+    public void testSyncSmartTagsToMetadata() throws Exception {
+        SyncSmartTagsToXmpMetadataNodeProcess.ProcessArgs processArgs = new SyncSmartTagsToXmpMetadataNodeProcess.ProcessArgs(metaDataMap);
+
+        Asset asset = DamUtil.resolveToAsset(ctx.resourceResolver().getResource("/content/dam/asset.png"));
+        workflowProcess.syncSmartTagsToMetadata(asset, processArgs);
+
+        Resource sequenceResource = ctx.resourceResolver().getResource("/content/dam/asset.png/jcr:content/metadata/dam:predictedTags");
+
+        assertNotNull(sequenceResource);
+        assertEquals(3L, (long)sequenceResource.getValueMap().get("xmpArraySize", Long.class));
+
+        assertNotNull(sequenceResource.getChild("1"));
+        assertEquals("apple", sequenceResource.getChild("1").getValueMap().get("dam:predictedTagName", String.class));
+        assertEquals(1.0D, sequenceResource.getChild("1").getValueMap().get("dam:predictedTagConfidence", Double.class), 0.01);
+
+        assertNotNull(sequenceResource.getChild("2"));
+        assertEquals("orange", sequenceResource.getChild("2").getValueMap().get("dam:predictedTagName", String.class));
+        assertEquals(0.5D, sequenceResource.getChild("2").getValueMap().get("dam:predictedTagConfidence", Double.class), 0.01);
+
+        assertNotNull(sequenceResource.getChild("3"));
+        assertEquals("banana", sequenceResource.getChild("3").getValueMap().get("dam:predictedTagName", String.class));
+        assertEquals(0.1D, sequenceResource.getChild("3").getValueMap().get("dam:predictedTagConfidence", Double.class), 0.01);
+    }
+
+    @Test
+    public void testSyncSmartTagsToMetadata_WithSequenceName() throws Exception {
+        metaDataMap.put("PROCESS_ARGS", "sequenceName=dam:custom");
+
+        SyncSmartTagsToXmpMetadataNodeProcess.ProcessArgs processArgs = new SyncSmartTagsToXmpMetadataNodeProcess.ProcessArgs(metaDataMap);
+
+        Asset asset = DamUtil.resolveToAsset(ctx.resourceResolver().getResource("/content/dam/asset.png"));
+        workflowProcess.syncSmartTagsToMetadata(asset, processArgs);
+
+        Resource sequenceResource = ctx.resourceResolver().getResource("/content/dam/asset.png/jcr:content/metadata/dam:custom");
+        assertNotNull(sequenceResource);
+        assertNotNull(sequenceResource.getChild("1"));
+        assertNotNull(sequenceResource.getChild("2"));
+        assertNotNull(sequenceResource.getChild("3"));
+    }
+
+    @Test
+    public void testSyncSmartTagsToMetadata_WithMinimumConfidence() throws Exception {
+        metaDataMap.put("PROCESS_ARGS", "minimumConfidence=0.8");
+
+        SyncSmartTagsToXmpMetadataNodeProcess.ProcessArgs processArgs = new SyncSmartTagsToXmpMetadataNodeProcess.ProcessArgs(metaDataMap);
+
+        Asset asset = DamUtil.resolveToAsset(ctx.resourceResolver().getResource("/content/dam/asset.png"));
+        workflowProcess.syncSmartTagsToMetadata(asset, processArgs);
+
+        Resource sequenceResource = ctx.resourceResolver().getResource("/content/dam/asset.png/jcr:content/metadata/dam:predictedTags");
+
+        assertNotNull(sequenceResource);
+        assertEquals(1L, (long)sequenceResource.getValueMap().get("xmpArraySize", Long.class));
+
+        assertNotNull(sequenceResource.getChild("1"));
+        assertEquals("apple", sequenceResource.getChild("1").getValueMap().get("dam:predictedTagName", String.class));
+        assertEquals(1.0D, sequenceResource.getChild("1").getValueMap().get("dam:predictedTagConfidence", Double.class), 0.01);
+
+        assertNull(sequenceResource.getChild("2"));
+        assertNull(sequenceResource.getChild("3"));
+    }
+
+
+    @Test
+    public void testSyncSmartTagsToMetadata_WithNameProperty() throws Exception {
+        metaDataMap.put("PROCESS_ARGS", "nameProperty=dam:customName");
+
+        SyncSmartTagsToXmpMetadataNodeProcess.ProcessArgs processArgs = new SyncSmartTagsToXmpMetadataNodeProcess.ProcessArgs(metaDataMap);
+
+        Asset asset = DamUtil.resolveToAsset(ctx.resourceResolver().getResource("/content/dam/asset.png"));
+        workflowProcess.syncSmartTagsToMetadata(asset, processArgs);
+
+        Resource sequenceResource = ctx.resourceResolver().getResource("/content/dam/asset.png/jcr:content/metadata/dam:predictedTags");
+
+        assertNotNull(sequenceResource);
+        assertEquals(3L, (long)sequenceResource.getValueMap().get("xmpArraySize", Long.class));
+
+        assertNotNull(sequenceResource.getChild("1"));
+        assertEquals("apple", sequenceResource.getChild("1").getValueMap().get("dam:customName", String.class));
+
+        assertNotNull(sequenceResource.getChild("2"));
+        assertEquals("orange", sequenceResource.getChild("2").getValueMap().get("dam:customName", String.class));
+
+        assertNotNull(sequenceResource.getChild("3"));
+        assertEquals("banana", sequenceResource.getChild("3").getValueMap().get("dam:customName", String.class));
+    }
+
+
+    @Test
+    public void testSyncSmartTagsToMetadata_WithConfidenceProperty() throws Exception {
+        metaDataMap.put("PROCESS_ARGS", "confidenceProperty=dam:customConfidence");
+        SyncSmartTagsToXmpMetadataNodeProcess.ProcessArgs processArgs = new SyncSmartTagsToXmpMetadataNodeProcess.ProcessArgs(metaDataMap);
+
+        Asset asset = DamUtil.resolveToAsset(ctx.resourceResolver().getResource("/content/dam/asset.png"));
+        workflowProcess.syncSmartTagsToMetadata(asset, processArgs);
+
+        Resource sequenceResource = ctx.resourceResolver().getResource("/content/dam/asset.png/jcr:content/metadata/dam:predictedTags");
+
+        assertNotNull(sequenceResource);
+        assertEquals(3L, (long)sequenceResource.getValueMap().get("xmpArraySize", Long.class));
+
+        assertNotNull(sequenceResource.getChild("1"));
+        assertEquals(1.0D, sequenceResource.getChild("1").getValueMap().get("dam:customConfidence", Double.class), 0.01);
+
+        assertNotNull(sequenceResource.getChild("2"));
+        assertEquals(0.5D, sequenceResource.getChild("2").getValueMap().get("dam:customConfidence", Double.class), 0.01);
+
+        assertNotNull(sequenceResource.getChild("3"));
+        assertEquals(0.1D, sequenceResource.getChild("3").getValueMap().get("dam:customConfidence", Double.class), 0.01);
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/workflow/process/impl/SyncSmartTagsToXmpMetadataNodeProcessTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/workflow/process/impl/SyncSmartTagsToXmpMetadataNodeProcessTest.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.workflow.process.impl;
 
 import com.adobe.granite.workflow.metadata.MetaDataMap;

--- a/bundle/src/test/resources/com/adobe/acs/commons/workflow/process/impl/SyncSmartTagsToXmpMetadataNodeTest.json
+++ b/bundle/src/test/resources/com/adobe/acs/commons/workflow/process/impl/SyncSmartTagsToXmpMetadataNodeTest.json
@@ -1,0 +1,29 @@
+{
+  "asset.png" : {
+    "jcr:primaryType" : "dam:Asset",
+    "jcr:content" : {
+      "jcr:primaryType" : "nt:unstructured",
+      "metadata" : {
+        "jcr:primaryType": "nt:unstructured",
+        "predictedTags" : {
+          "jcr:primaryType": "nt:unstructured",
+          "apple" : {
+            "jcr:primaryType": "nt:unstructured",
+            "name": "apple",
+            "confidence": 1.0
+          },
+          "orange" : {
+            "jcr:primaryType": "nt:unstructured",
+            "name": "orange",
+            "confidence": 0.5
+          },
+          "banana" : {
+            "jcr:primaryType": "nt:unstructured",
+            "name": "banana",
+            "confidence": 0.1
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Workflow Process step that copies out Smart Tags into a XMP'able Node structure under `[dam:Asset]/jcr:content/metadata`.


#### Process Args (Line seperated)

`sequenceName=dam:XXX`
   * This defines the sequence node name in XMP, as well as the node name in AEM (`[dam:Asset]/jcr:content/metadata/<sequenceName>`.
   * Default value: `dam:predictedTags`

`nameProperty=dam:XXX`
   * This defines the property name in which to store the Smart Tag "name"  (`[dam:Asset]/jcr:content/metadata/<sequenceName>/#@<nameProperty>`.
   * Default value: `dam:predictedTagName`

`confidenceProperty=dam:XXX`
  * This defines the property name in which to store the Smart Tag "confidence score"  (`[dam:Asset]/jcr:content/metadata/<sequenceName>/#@<confidenceProperty>`.
   * Default value: `dam:predictedTagConfidence`

`minimumConfidence=0.5`
   * The Smart Tag must have this minimum confidence score to be copied into the new XMP'able node structure
   * Default value:`0.0`


Note that XMP Writeback WF Process step may have to be manually addeded after this step with the following params: `createversion:true,rendition:original`

Example Workflow Model:
[smart-tags-to-metadata-wf-model-1.0.0.zip](https://github.com/Adobe-Consulting-Services/acs-aem-commons/files/2704320/smart-tags-to-metadata-wf-model-1.0.0.zip)

