### PR TITLE
Upgrade to oakpal-1.1.13 for more maintainable unit tests.

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/XMLParserGenerator.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/XMLParserGenerator.java
@@ -46,7 +46,10 @@ public final class XMLParserGenerator implements Generator {
     private ContentHandler contentHandler;
 
     public XMLParserGenerator() throws ParserConfigurationException, SAXException {
-        SAXParserFactory factory = SAXParserFactory.newInstance();
+        this(SAXParserFactory.newInstance());
+    }
+
+    public XMLParserGenerator(final SAXParserFactory factory) throws ParserConfigurationException, SAXException {
         factory.setNamespaceAware(true);
 
         saxParser = factory.newSAXParser();

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/XMLParserGeneratorFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/XMLParserGeneratorFactory.java
@@ -19,6 +19,9 @@
  */
 package com.adobe.acs.commons.rewriter.impl;
 
+import javax.xml.parsers.FactoryConfigurationError;
+import javax.xml.parsers.SAXParserFactory;
+
 import org.apache.sling.rewriter.Generator;
 import org.apache.sling.rewriter.GeneratorFactory;
 import org.osgi.service.component.annotations.Component;
@@ -32,12 +35,19 @@ public final class XMLParserGeneratorFactory implements GeneratorFactory {
 
     @Override
     public Generator createGenerator() {
+        return createGenerator(SAXParserFactory.newInstance());
+    }
+
+    Generator createGenerator(final SAXParserFactory saxParserFactory) {
         try {
-            return new XMLParserGenerator();
+            if (saxParserFactory == null) {
+                return new XMLParserGenerator();
+            } else {
+                return new XMLParserGenerator(saxParserFactory);
+            }
         } catch (Exception e) {
             log.error("Unable to create parser", e);
             return null;
         }
     }
-
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/XMLParserGeneratorFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/XMLParserGeneratorFactory.java
@@ -19,7 +19,6 @@
  */
 package com.adobe.acs.commons.rewriter.impl;
 
-import javax.xml.parsers.FactoryConfigurationError;
 import javax.xml.parsers.SAXParserFactory;
 
 import org.apache.sling.rewriter.Generator;
@@ -35,7 +34,7 @@ public final class XMLParserGeneratorFactory implements GeneratorFactory {
 
     @Override
     public Generator createGenerator() {
-        return createGenerator(SAXParserFactory.newInstance());
+        return createGenerator(null);
     }
 
     Generator createGenerator(final SAXParserFactory saxParserFactory) {

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/XMLParserGeneratorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/XMLParserGeneratorTest.java
@@ -54,13 +54,15 @@ public class XMLParserGeneratorTest {
         
         XMLParserGeneratorFactory factory = new XMLParserGeneratorFactory();
         XMLParserGenerator generator = (XMLParserGenerator) factory.createGenerator();
+        // nothing to do, nothing to mock...
+        generator.init(null, null);
         generator.setContentHandler(contentHandler);
-        
         PrintWriter printWriter = generator.getWriter();
         printWriter.println("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
         printWriter.println("<fo:root xmlns:fo=\"http://www.w3.org/1999/XSL/Format\"></fo:root>");
         
         generator.finished();
+        generator.dispose();
         
         verify(contentHandler).startDocument();
         verify(contentHandler).setDocumentLocator((Locator) anyObject());
@@ -86,7 +88,6 @@ public class XMLParserGeneratorTest {
             @Override
             public void setFeature(final String name, final boolean value)
                     throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
-
             }
 
             @Override
@@ -100,4 +101,6 @@ public class XMLParserGeneratorTest {
         XMLParserGenerator generator = (XMLParserGenerator) factory.createGenerator(fakeParserFactory);
         Assert.assertNull("generator is null when parser factory throws config exception.", generator);
     }
+
+
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/XMLParserGeneratorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/XMLParserGeneratorTest.java
@@ -23,6 +23,11 @@ import static org.mockito.Mockito.*;
 
 import java.io.PrintWriter;
 
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -32,6 +37,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.Locator;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
 
 @RunWith(MockitoJUnitRunner.class)
 public class XMLParserGeneratorTest {
@@ -65,5 +73,31 @@ public class XMLParserGeneratorTest {
         verify(contentHandler).endPrefixMapping("fo");
         verify(contentHandler).endDocument();
         verifyNoMoreInteractions(contentHandler);
+    }
+
+    @Test
+    public void testParserException() {
+        SAXParserFactory fakeParserFactory = new SAXParserFactory() {
+            @Override
+            public SAXParser newSAXParser() throws ParserConfigurationException, SAXException {
+                throw new ParserConfigurationException("failers gonna fail.");
+            }
+
+            @Override
+            public void setFeature(final String name, final boolean value)
+                    throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
+
+            }
+
+            @Override
+            public boolean getFeature(final String name)
+                    throws ParserConfigurationException, SAXNotRecognizedException, SAXNotSupportedException {
+                return false;
+            }
+        };
+
+        XMLParserGeneratorFactory factory = new XMLParserGeneratorFactory();
+        XMLParserGenerator generator = (XMLParserGenerator) factory.createGenerator(fakeParserFactory);
+        Assert.assertNull("generator is null when parser factory throws config exception.", generator);
     }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/XMLParserGeneratorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/XMLParserGeneratorTest.java
@@ -102,5 +102,10 @@ public class XMLParserGeneratorTest {
         Assert.assertNull("generator is null when parser factory throws config exception.", generator);
     }
 
-
+    @Test
+    public void testOwnParser() {
+        XMLParserGeneratorFactory factory = new XMLParserGeneratorFactory();
+        XMLParserGenerator generator = (XMLParserGenerator) factory.createGenerator(SAXParserFactory.newInstance());
+        Assert.assertNotNull("generator is not null with own default sax parser.", generator);
+    }
 }

--- a/oakpal-checks/src/main/java/com/adobe/acs/commons/oakpal/checks/RecommendEnsureAuthorizable.java
+++ b/oakpal-checks/src/main/java/com/adobe/acs/commons/oakpal/checks/RecommendEnsureAuthorizable.java
@@ -26,7 +26,6 @@ import javax.jcr.RepositoryException;
 import net.adamcin.oakpal.core.ProgressCheck;
 import net.adamcin.oakpal.core.ProgressCheckFactory;
 import net.adamcin.oakpal.core.SimpleProgressCheck;
-import net.adamcin.oakpal.core.SimpleViolation;
 import net.adamcin.oakpal.core.Violation;
 import net.adamcin.oakpal.core.checks.Rule;
 import org.apache.jackrabbit.api.JackrabbitSession;
@@ -88,28 +87,26 @@ public final class RecommendEnsureAuthorizable implements ProgressCheckFactory {
                 throws RepositoryException {
             // fast check for authorizables
             if (node.isNodeType(NT_REP_AUTHORIZABLE)) {
-                UserManager userManager = ((JackrabbitSession) node.getSession()).getUserManager();
-                Authorizable authz = userManager.getAuthorizableByPath(path);
+                final UserManager userManager = ((JackrabbitSession) node.getSession()).getUserManager();
+                final Authorizable authz = userManager.getAuthorizableByPath(path);
 
                 // if an authorizable is not loaded from the path, short circuit.
-                if (authz == null) {
-                    return;
+                if (authz != null) {
+                    final String id = authz.getID();
+
+                    // check for inclusion based on authorizableId
+                    Rule lastMatched = Rule.lastMatch(scopeIds, id);
+
+                    // if id is excluded, or is user and not system user, short circuit
+                    if (lastMatched.isExclude() || (!authz.isGroup() && !((User) authz).isSystemUser())) {
+                        return;
+                    }
+
+                    // report for groups and system users
+                    reportViolation(severity,
+                            String.format("%s: imported explicit %s. %s",
+                                    path, authz.isGroup() ? "group" : "system user", recommendation), packageId);
                 }
-
-                final String id = authz.getID();
-
-                // check for inclusion based on authorizableId
-                Rule lastMatched = Rule.lastMatch(scopeIds, id);
-
-                // if id is excluded, or is user and not system user, short circuit
-                if (lastMatched.isExclude() || (!authz.isGroup() && !((User) authz).isSystemUser())) {
-                    return;
-                }
-
-                // report for groups and system users
-                reportViolation(severity,
-                        String.format("%s: imported explicit %s. %s",
-                                path, authz.isGroup() ? "group" : "system user", recommendation), packageId);
             }
         }
     }

--- a/oakpal-checks/src/test/java/com/adobe/acs/commons/oakpal/checks/AcsCommonsAuthorizableCompatibilityCheckTest.java
+++ b/oakpal-checks/src/test/java/com/adobe/acs/commons/oakpal/checks/AcsCommonsAuthorizableCompatibilityCheckTest.java
@@ -19,12 +19,16 @@
  */
 package com.adobe.acs.commons.oakpal.checks;
 
+import static net.adamcin.oakpal.core.OrgJson.arr;
+import static net.adamcin.oakpal.core.OrgJson.key;
+import static net.adamcin.oakpal.core.OrgJson.obj;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 
 import net.adamcin.oakpal.core.CheckReport;
 import net.adamcin.oakpal.core.ProgressCheck;
+import net.adamcin.oakpal.core.checks.Rule;
 import net.adamcin.oakpal.testing.TestPackageUtil;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -42,23 +46,22 @@ public class AcsCommonsAuthorizableCompatibilityCheckTest extends CheckTestBase 
 
     @Test
     public void testCheckNone() throws Exception {
-        ProgressCheck check = new AcsCommonsAuthorizableCompatibilityCheck().newInstance(
-                new JSONObject("{\"scopeIds\":[{\"type\":\"deny\",\"pattern\":\".*\"}]}"));
+        ProgressCheck check = new AcsCommonsAuthorizableCompatibilityCheck()
+                .newInstance(key("scopeIds", arr(Rule.DEFAULT_DENY)).get());
         CheckReport reportValid = scanWithCheck(check, pack);
         assertEquals("No violations when deny all authorizable ids.", 0, reportValid.getViolations().size());
     }
 
     @Test
     public void testCheckAll() throws Exception {
-        ProgressCheck check = new AcsCommonsAuthorizableCompatibilityCheck().newInstance(
-                new JSONObject("{}"));
+        ProgressCheck check = new AcsCommonsAuthorizableCompatibilityCheck().newInstance(obj().get());
         CheckReport reportValid = scanWithCheck(check, pack);
         assertEquals("3 violations when allow all authorizable ids.", 3, reportValid.getViolations().size());
     }
 
     private void checkSpecificId(final String authorizableId, final boolean expectValid) throws Exception {
         ProgressCheck checkValid = new AcsCommonsAuthorizableCompatibilityCheck().newInstance(
-                new JSONObject(String.format("{\"scopeIds\":[{\"type\":\"allow\",\"pattern\":\"%s\"}]}", authorizableId)));
+                key("scopeIds", arr(key("type", "allow").key("pattern", authorizableId))).get());
         CheckReport reportValid = scanWithCheck(checkValid, pack);
         assertEquals("check specific authorizableId: " + authorizableId, expectValid ? 0 : 1,
                 reportValid.getViolations().size());

--- a/oakpal-checks/src/test/java/com/adobe/acs/commons/oakpal/checks/ContentClassificationsTest.java
+++ b/oakpal-checks/src/test/java/com/adobe/acs/commons/oakpal/checks/ContentClassificationsTest.java
@@ -19,6 +19,8 @@
  */
 package com.adobe.acs.commons.oakpal.checks;
 
+import static net.adamcin.oakpal.core.OrgJson.arr;
+import static net.adamcin.oakpal.core.OrgJson.key;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -78,14 +80,17 @@ public class ContentClassificationsTest extends CheckTestBase {
     }
 
     private ProgressCheck checkForPath(final String path) {
-        return new ContentClassifications().newInstance(
-                new JSONObject(String.format("{\"scopePaths\":[{\"type\":\"allow\",\"pattern\":\"%s\"}]}", path)));
+        return new ContentClassifications()
+                .newInstance(key("scopePaths", arr(key("type", "allow").key("pattern", path))).get());
     }
 
     @Test
     public void testCheckAllValid() throws Exception {
-        ProgressCheck checkValid = new ContentClassifications().newInstance(
-                new JSONObject("{\"scopePaths\":[{\"type\":\"allow\",\"pattern\":\".*/valid.*\"},{\"type\":\"allow\",\"pattern\":\"/apps/acs/(abstract|public).*\"}]}"));
+        ProgressCheck checkValid = new ContentClassifications()
+                .newInstance(key("scopePaths", arr()
+                        .val(key("type", "allow").key("pattern", ".*/valid.*"))
+                        .val(key("type", "allow").key("pattern", "/apps/acs/(abstract|public).*"))
+                ).get());
         CheckReport reportValid = scanWithCheck(checkValid, pack);
         assertEquals("No violations when deny invalid paths.", 0, reportValid.getViolations().size());
     }

--- a/oakpal-checks/src/test/java/com/adobe/acs/commons/oakpal/checks/ContentClassificationsTest.java
+++ b/oakpal-checks/src/test/java/com/adobe/acs/commons/oakpal/checks/ContentClassificationsTest.java
@@ -54,6 +54,8 @@ public class ContentClassificationsTest extends CheckTestBase {
                         "granite:PublicArea")
                 .withForcedRoot("/libs/acs/final", "sling:Folder",
                         "granite:FinalArea")
+                .withForcedRoot("/libs/acs/final/child",
+                        "sling:Folder")
                 .withForcedRoot("/libs/acs/final/public", "sling:Folder",
                         "granite:PublicArea")
                 .withForcedRoot("/libs/acs/abstract", "sling:Folder",
@@ -101,8 +103,9 @@ public class ContentClassificationsTest extends CheckTestBase {
         ProgressCheck check = checkForPath(path);
         CheckReport report = scanWithCheck(check, pack);
         assertEquals(String.format("One violation: %s", description), 1, report.getViolations().size());
-        assertTrue(String.format("Violation contains 'marked %s' (actual: %s): %s.", marked,
-                report.getViolations().iterator().next().getDescription(), description),
+        assertTrue(
+                String.format("Violation contains 'marked %s' (actual: %s): %s.", marked,
+                        report.getViolations().iterator().next().getDescription(), description),
                 report.getViolations().iterator().next().getDescription().contains(String.format("marked %s", marked)));
     }
 
@@ -144,6 +147,11 @@ public class ContentClassificationsTest extends CheckTestBase {
     @Test
     public void testCheckInvalidPageFinalChild() throws Exception {
         checkInvalidPath("/content/acs/invalidpage_final_child", "INTERNAL", "use final child");
+    }
+
+    @Test
+    public void testCheckInvalidPageFinalImplicitChild() throws Exception {
+        checkInvalidPath("/content/acs/invalidpage_final_implicitchild", "INTERNAL", "use final implicit child");
     }
 
     @Test

--- a/oakpal-checks/src/test/java/com/adobe/acs/commons/oakpal/checks/ContentClassificationsTest.java
+++ b/oakpal-checks/src/test/java/com/adobe/acs/commons/oakpal/checks/ContentClassificationsTest.java
@@ -21,6 +21,7 @@ package com.adobe.acs.commons.oakpal.checks;
 
 import static net.adamcin.oakpal.core.OrgJson.arr;
 import static net.adamcin.oakpal.core.OrgJson.key;
+import static net.adamcin.oakpal.core.OrgJson.obj;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -31,7 +32,6 @@ import net.adamcin.oakpal.core.CheckReport;
 import net.adamcin.oakpal.core.InitStage;
 import net.adamcin.oakpal.core.ProgressCheck;
 import net.adamcin.oakpal.testing.TestPackageUtil;
-import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -87,10 +87,12 @@ public class ContentClassificationsTest extends CheckTestBase {
     @Test
     public void testCheckAllValid() throws Exception {
         ProgressCheck checkValid = new ContentClassifications()
-                .newInstance(key("scopePaths", arr()
-                        .val(key("type", "allow").key("pattern", ".*/valid.*"))
-                        .val(key("type", "allow").key("pattern", "/apps/acs/(abstract|public).*"))
-                ).get());
+                .newInstance(obj()
+                        .key("scopePaths", arr()
+                                .val(key("type", "allow").key("pattern", ".*/valid.*"))
+                                .val(key("type", "allow").key("pattern", "/apps/acs/(abstract|public).*")))
+                        .key("searchPaths", arr("/apps", "/libs"))
+                        .get());
         CheckReport reportValid = scanWithCheck(checkValid, pack);
         assertEquals("No violations when deny invalid paths.", 0, reportValid.getViolations().size());
     }

--- a/oakpal-checks/src/test/java/com/adobe/acs/commons/oakpal/checks/RecommendEnsureAuthorizableTest.java
+++ b/oakpal-checks/src/test/java/com/adobe/acs/commons/oakpal/checks/RecommendEnsureAuthorizableTest.java
@@ -19,12 +19,16 @@
  */
 package com.adobe.acs.commons.oakpal.checks;
 
+import static net.adamcin.oakpal.core.OrgJson.arr;
+import static net.adamcin.oakpal.core.OrgJson.key;
+import static net.adamcin.oakpal.core.OrgJson.obj;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 
 import net.adamcin.oakpal.core.CheckReport;
 import net.adamcin.oakpal.core.ProgressCheck;
+import net.adamcin.oakpal.core.checks.Rule;
 import net.adamcin.oakpal.testing.TestPackageUtil;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -42,23 +46,22 @@ public class RecommendEnsureAuthorizableTest extends CheckTestBase {
 
     @Test
     public void testCheckNone() throws Exception {
-        ProgressCheck check = new RecommendEnsureAuthorizable().newInstance(
-                new JSONObject("{\"scopeIds\":[{\"type\":\"deny\",\"pattern\":\".*\"}]}"));
+        ProgressCheck check = new RecommendEnsureAuthorizable()
+                .newInstance(key("scopeIds", arr(Rule.DEFAULT_DENY)).get());
         CheckReport reportValid = scanWithCheck(check, pack);
         assertEquals("No violations when deny all authorizable ids.", 0, reportValid.getViolations().size());
     }
 
     @Test
     public void testCheckAll() throws Exception {
-        ProgressCheck check = new RecommendEnsureAuthorizable().newInstance(
-                new JSONObject("{}"));
+        ProgressCheck check = new RecommendEnsureAuthorizable().newInstance(obj().get());
         CheckReport reportValid = scanWithCheck(check, pack);
         assertEquals("3 violations when allow all authorizable ids.", 3, reportValid.getViolations().size());
     }
 
     private void checkSpecificId(final String authorizableId, final boolean expectValid) throws Exception {
-        ProgressCheck checkValid = new RecommendEnsureAuthorizable().newInstance(
-                new JSONObject(String.format("{\"scopeIds\":[{\"type\":\"allow\",\"pattern\":\"%s\"}]}", authorizableId)));
+        ProgressCheck checkValid = new RecommendEnsureAuthorizable()
+                .newInstance(key("scopeIds", arr(key("type", "allow").key("pattern", authorizableId))).get());
         CheckReport reportValid = scanWithCheck(checkValid, pack);
         assertEquals("check specific authorizableId: " + authorizableId, expectValid ? 0 : 1,
                 reportValid.getViolations().size());

--- a/oakpal-checks/src/test/java/com/adobe/acs/commons/oakpal/checks/RecommendEnsureOakIndexTest.java
+++ b/oakpal-checks/src/test/java/com/adobe/acs/commons/oakpal/checks/RecommendEnsureOakIndexTest.java
@@ -19,6 +19,9 @@
  */
 package com.adobe.acs.commons.oakpal.checks;
 
+import static net.adamcin.oakpal.core.OrgJson.arr;
+import static net.adamcin.oakpal.core.OrgJson.key;
+import static net.adamcin.oakpal.core.OrgJson.obj;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
@@ -27,6 +30,7 @@ import java.net.URL;
 import net.adamcin.oakpal.core.CheckReport;
 import net.adamcin.oakpal.core.InitStage;
 import net.adamcin.oakpal.core.ProgressCheck;
+import net.adamcin.oakpal.core.checks.Rule;
 import net.adamcin.oakpal.testing.TestPackageUtil;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -46,16 +50,15 @@ public class RecommendEnsureOakIndexTest extends CheckTestBase {
 
     @Test
     public void testCheckNone() throws Exception {
-        ProgressCheck check = new RecommendEnsureOakIndex().newInstance(
-                new JSONObject("{\"scopePaths\":[{\"type\":\"deny\",\"pattern\":\".*\"}]}"));
+        ProgressCheck check = new RecommendEnsureOakIndex()
+                .newInstance(key("scopePaths", arr(Rule.DEFAULT_DENY)).get());
         CheckReport reportValid = scanWithCheck(check, pack);
         assertEquals("No violations when deny all oak:index children.", 0, reportValid.getViolations().size());
     }
 
     @Test
     public void testCheckAll() throws Exception {
-        ProgressCheck check = new RecommendEnsureOakIndex().newInstance(
-                new JSONObject("{}"));
+        ProgressCheck check = new RecommendEnsureOakIndex().newInstance(obj().get());
         CheckReport reportValid = scanWithCheck(check, pack);
         assertEquals("3 violations when allow all oak:index children.", 3, reportValid.getViolations().size());
     }

--- a/oakpal-checks/src/test/resources/content-classifications-filevault/META-INF/vault/filter.xml
+++ b/oakpal-checks/src/test/resources/content-classifications-filevault/META-INF/vault/filter.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <workspaceFilter version="1.0">
     <filter root="/apps/acs"/>
+    <filter root="/libs/out_of_bounds"/>
     <filter root="/content/acs"/>
 </workspaceFilter>

--- a/oakpal-checks/src/test/resources/content-classifications-filevault/jcr_root/content/acs/invalidpage_final_implicitchild/.content.xml
+++ b/oakpal-checks/src/test/resources/content-classifications-filevault/jcr_root/content/acs/invalidpage_final_implicitchild/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:Folder"
+          sling:resourceType="acs/final/implicitchild"/>

--- a/oakpal-checks/src/test/resources/content-classifications-filevault/jcr_root/libs/out_of_bounds/.content.xml
+++ b/oakpal-checks/src/test/resources/content-classifications-filevault/jcr_root/libs/out_of_bounds/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+          jcr:primaryType="sling:Folder"/>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <license.addJavaLicenseAfterPackage>false</license.addJavaLicenseAfterPackage>
         <sl4fj.version>1.7.21</sl4fj.version>
         <scr.plugin.version>1.26.0</scr.plugin.version>
-        <oakpal.version>1.1.12</oakpal.version>
+        <oakpal.version>1.1.13</oakpal.version>
     </properties>
 
     <build>


### PR DESCRIPTION
This PR incorporates the changes I made to improve the ProgressCheckFactory API in oakpal core.

- Added a DSL for concise construction of org.json.JSONObject instances to improve maintainability of the tests for ProgressCheckFactories.
- Refactored an emerging boilerplate pattern for evaluating lists of Rules.
- Made all ProgressCheckFactories final and restricted visibility of their Check classes to package private.

BONUS: threw in 100% test coverage for XMLParserGeneratorFactory, which I picked at random to make up for elided SLOCs related to this module.