### PR TITLE
Asset Ingestor - fix target path if preserveFileName is unchecked

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/NameUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/NameUtil.java
@@ -53,13 +53,16 @@ final class NameUtil {
     }
 
     static String createValidDamPath(String path) {
-        if (StringUtils.isEmpty(path)) {
-            return path;
+        if (StringUtils.isNotEmpty(path)) {
+            path = Arrays.asList(StringUtils.split(path, PATH_SEPARATOR))
+                    .stream()
+                    .map(name -> name.matches(VALID_NAME_REGEXP) ? name : NameUtil.createValidDamName(name))
+                    .collect(Collectors.joining(PATH_SEPARATOR));
+            if (!path.startsWith(PATH_SEPARATOR)) {
+                path = PATH_SEPARATOR + path;
+            }
         }
-        return Arrays.asList(StringUtils.split(path, PATH_SEPARATOR))
-                .stream()
-                .map(name -> name.matches(VALID_NAME_REGEXP) ? name : NameUtil.createValidDamName(name))
-                .collect(Collectors.joining(PATH_SEPARATOR));
+        return path;
     }
 
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorTest.java
@@ -347,10 +347,11 @@ public class FileAssetIngestorTest {
     public void testPathSupportsSpecialCharacters() throws UnsupportedEncodingException, URISyntaxException, RepositoryException {
         configureSftpFields();
         ingestor.preserveFileName = false;
-        ingestor.jcrBasePath = ingestor.jcrBasePath.concat("#");
+        String jcrBasePath = ingestor.jcrBasePath;
+        ingestor.jcrBasePath = jcrBasePath.concat("#");
         ingestor.init();
 
-        Assert.assertTrue(ingestor.jcrBasePath.endsWith("-"));
+        Assert.assertEquals(jcrBasePath + "-", ingestor.jcrBasePath);
 
         for (AssetIngestorPaths pathsToValidate : FILE_PATHS) {
             String expectedPath = pathsToValidate.getExpectedPath();
@@ -376,10 +377,11 @@ public class FileAssetIngestorTest {
     @Test
     public void testPreservePathWithSpecialCharacters() throws UnsupportedEncodingException, URISyntaxException, RepositoryException {
         configureSftpFields();
-        ingestor.jcrBasePath = ingestor.jcrBasePath.concat("#");
+        String jcrBasePath = ingestor.jcrBasePath;
+        ingestor.jcrBasePath = jcrBasePath.concat("#");
         ingestor.init();
 
-        Assert.assertTrue(ingestor.jcrBasePath.endsWith("#"));
+        Assert.assertEquals(jcrBasePath + "#", ingestor.jcrBasePath);
 
         for (AssetIngestorPaths pathsToValidate : FILE_PATHS) {
             String expectedPath = pathsToValidate.getExpectedPreservedPath();


### PR DESCRIPTION
If preserveFileName option is unchecked, target path is cut off and Asset Ingestor doesn't work properly.
This is a fix of path validate method.