### PR TITLE
re-enable 3 unit tests

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -73,6 +73,7 @@
                             com.adobe.acs.commons.reports.models
                         </Sling-Model-Packages>
                         <_dsannotations>*</_dsannotations>
+                        <_dsannotations-options>inherit</_dsannotations-options>
                         <_metatypeannotations>*</_metatypeannotations>
                         <_plugin>org.apache.felix.scrplugin.bnd.SCRDescriptorBndPlugin;destdir=${project.build.outputDirectory}</_plugin>
                     </instructions>

--- a/bundle/src/main/java/com/adobe/acs/commons/forms/helpers/impl/AbstractFormHelperImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/forms/helpers/impl/AbstractFormHelperImpl.java
@@ -50,8 +50,7 @@ import java.util.Map;
  * Abstract Form Helper. This provides common behaviors for handling POST-behaviors of the
  *  ACS AEM Commons Forms implementation.
  */
-//@Component(componentAbstract = true,scope=)
-//TODO: how to deal with componentAbstract?
+
 @Component(property= {
 Constants.SERVICE_RANKING +":Integer=" + FormHelper.SERVICE_RANKING_BASE
 })
@@ -67,6 +66,25 @@ public abstract class AbstractFormHelperImpl {
         AUTH_INFO = Collections.singletonMap(ResourceResolverFactory.SUBSERVICE, (Object) SERVICE_NAME);
     }
 
+    /**
+     * TODO refactor me!
+     * 
+     * OSGI r6 (or better: BND, which is wrapped by the maven-bundle-plugin) does not support
+     * instantiating services from inherited classes.
+     * 
+     * The references listed below only work because we set the
+     * <_dsannotations-options>inherit</_dsannotations-options>
+     * setting to the maven-bundle-plugin.
+     * 
+     * See https://stackoverflow.com/questions/41280061/abstract-components-via-org-osgi-service-component-annotations
+     * 
+     * This class would probably benefit from being converted into a Pojo with the required references
+     * being passed in into the constructor.
+     * 
+     */
+    
+    
+    
     @Reference
     private FormsRouter formsRouter;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/forms/helpers/impl/PostRedirectGetWithCookiesFormHelperImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/forms/helpers/impl/PostRedirectGetWithCookiesFormHelperImplTest.java
@@ -91,7 +91,6 @@ public class PostRedirectGetWithCookiesFormHelperImplTest {
     }
 
     @Test
-    @Ignore
     public void shouldSerialiseFormInRedirectUrlParameter() throws Exception {
         request.setMethod("POST");
         request.setParameterMap(ImmutableMap.<String, Object>of(":form", "x", "hello", "world"));
@@ -122,7 +121,6 @@ public class PostRedirectGetWithCookiesFormHelperImplTest {
 
 
     @Test
-    @Ignore
     public void shouldInvalidateCookieOnGetRequest() throws Exception {
         final SlingHttpServletResponse redirectResponse = spy(slingContext.response());
         request.setMethod("GET");
@@ -137,7 +135,6 @@ public class PostRedirectGetWithCookiesFormHelperImplTest {
     }
 
     @Test
-    @Ignore
     public void shouldRemoveCookieDataOnGetRequest() throws Exception {
         final SlingHttpServletResponse redirectResponse = spy(slingContext.response());
         request.setMethod("GET");


### PR DESCRIPTION
Was able to re-enable 3 unittests and also fix the FormHelper functionality (which was broken since the OSGI r6 refactoring)