### PR TITLE
Fix incorrect types in the configuration of ThrottledTaskRunnerImpl

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/fam/impl/ThrottledTaskRunnerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/impl/ThrottledTaskRunnerImpl.java
@@ -69,9 +69,9 @@ public @interface Config {
     @AttributeDefinition(name = "Max threads", description = "Default is 4, recommended not to exceed the number of CPU cores",defaultValue = "4")
         int max_threads() default 4;
     @AttributeDefinition(name = "Max cpu %", description = "Range is 0..1; -1 means disable this check", defaultValue = "0.75")
-        int max_cpu();
+        double max_cpu();
     @AttributeDefinition(name = "Max heap %", description = "Range is 0..1; -1 means disable this check", defaultValue = "0.85")
-        int max_heap();
+        double max_heap();
     @AttributeDefinition(name = "Cooldown time", description="Time to wait for cpu/mem cooldown between checks", defaultValue = "100")
         int cooldown_wait_time();
     @AttributeDefinition(name = "Watchdog time", description="Maximum time allowed (in ms) per action before it is interrupted forcefully. Defaults to 1 hour.", defaultValue = "3600000")


### PR DESCRIPTION
which are since the switch to OSGI r6 annotations and configuration; report in #1652 by @Sc0rpic0m 