### PR TITLE
Update travis ci java mem opts to use metaspace instead of perm gen.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: java
 jdk: oraclejdk8
 env:
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxPermSize=512m -Duser.language=en -Duser.country=US" POST_COVERAGE=true
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxPermSize=512m -Duser.language=de -Duser.country=DE" POST_COVERAGE=false SKIP_DEPENDENCY_CHECK=true
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxPermSize=512m -Duser.language=es -Duser.country=ES" POST_COVERAGE=false SKIP_DEPENDENCY_CHECK=true
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxPermSize=512m -Duser.language=fr -Duser.country=FR" POST_COVERAGE=false SKIP_DEPENDENCY_CHECK=true
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxPermSize=512m -Duser.language=hi -Duser.country=IN" POST_COVERAGE=false SKIP_DEPENDENCY_CHECK=true
+- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=en -Duser.country=US" POST_COVERAGE=true
+- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=de -Duser.country=DE" POST_COVERAGE=false SKIP_DEPENDENCY_CHECK=true
+- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=es -Duser.country=ES" POST_COVERAGE=false SKIP_DEPENDENCY_CHECK=true
+- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=fr -Duser.country=FR" POST_COVERAGE=false SKIP_DEPENDENCY_CHECK=true
+- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=hi -Duser.country=IN" POST_COVERAGE=false SKIP_DEPENDENCY_CHECK=true
 script: mvn verify -B
 before_install:
   - cp .travis.settings.xml $HOME/.m2/settings.xml


### PR DESCRIPTION
MaxPermSize doesn't do anything in java 8+. Perm Gen space has been replaced with Metaspace. The equivalent CLI flag is -XX:MaxMetaspaceSize.