### PR TITLE
Feature/httpcache combined key extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1648 - Add Smart Tags to XMP Metadata Node Workflow Process
 - #1670 - Added @JsonValueMapValue, @I18N, @HierarchicalPageProperty, and improved @AemObject and @SharedValueMapValue.
 - #1683 - HttpCache: Added OOTB config extension:: request cookie extension
+- #1685 - HttpCache: Added OOTB config extension:: combined extension
 
 ### Fixed
 - #1667 - Refactored the activate methods of all http cache services

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
@@ -1,0 +1,136 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.httpcache.config.impl;
+
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfigExtension;
+import com.adobe.acs.commons.httpcache.config.impl.keys.CombinedCacheKey;
+import com.adobe.acs.commons.httpcache.exception.HttpCacheKeyCreationException;
+import com.adobe.acs.commons.httpcache.exception.HttpCacheRepositoryAccessException;
+import com.adobe.acs.commons.httpcache.keys.CacheKey;
+import com.adobe.acs.commons.httpcache.keys.CacheKeyFactory;
+import org.apache.commons.lang.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.commons.osgi.Order;
+import org.apache.sling.commons.osgi.RankedServices;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * Aggregates multiple cache config extensions into 1.
+ * This is useful when you need functionality of 2 extensions together.
+ * Instead of duplicating and merging the 2 extensions / factories into 1 class, you can leverage this class.
+ */
+@Component(
+        service = {CacheKeyFactory.class, HttpCacheConfigExtension.class},
+        configurationPolicy = ConfigurationPolicy.REQUIRE,
+        property = {
+                Constants.SERVICE_RANKING + ":Integer=" + Integer.MIN_VALUE
+        },
+        reference = {
+            @Reference(
+                    name = "cacheConfigExtension",
+                    bind = "bindCacheConfigExtension",
+                    unbind = "unbindCacheConfigExtension",
+                    service = HttpCacheConfigExtension.class,
+                    policy = ReferencePolicy.DYNAMIC,
+                    cardinality = ReferenceCardinality.AT_LEAST_ONE)
+        }
+
+)
+@Designate(ocd=CombinedCacheConfigExtension.Config.class,factory=true)
+public class CombinedCacheConfigExtension implements HttpCacheConfigExtension {
+
+    @ObjectClassDefinition(name = "ACS AEM Commons - HTTP Cache - Combined extension for HttpCacheConfig and CacheKeyFactory.",
+            description = "Aggregates multiple extensions into 1")
+    public @interface Config {
+
+        String DEFAULT_EXTENSION_TARGET = "(|(service.factoryPid=com.adobe.acs.commons.httpcache.config.impl.GroupHttpCacheConfigExtension)(configName=unique-confg-name-of-extension)(((service.factoryPid=com.adobe.acs.commons.httpcache.config.impl.ResourceTypeHttpCacheConfigExtension)(configName=unique-confg-name-of-extension))";
+
+        @AttributeDefinition(name = "Config Name")
+        String configName() default StringUtils.EMPTY;
+
+        @AttributeDefinition(
+                name = "HttpCacheConfigExtension service pids",
+                description = "Service pid of target implementation of HttpCacheConfigExtension to be used. Example - "
+                        + "(service.pid=" + DEFAULT_EXTENSION_TARGET + ")."
+                        + " Optional parameter.",
+                defaultValue = DEFAULT_EXTENSION_TARGET)
+        String cacheConfigExtension_target() default DEFAULT_EXTENSION_TARGET;
+
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(CombinedCacheConfigExtension.class);
+    private String configName;
+
+    private RankedServices<HttpCacheConfigExtension> cacheConfigExtensions = new RankedServices<>(Order.ASCENDING);
+    private String cacheConfigExtensionsTarget;
+
+    @Override
+    public boolean accepts(SlingHttpServletRequest request, HttpCacheConfig cacheConfig) throws HttpCacheRepositoryAccessException {
+
+        for(HttpCacheConfigExtension extension: cacheConfigExtensions){
+            if(!extension.accepts(request, cacheConfig)){
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Activate
+    @Modified
+    protected void activate(CombinedCacheConfigExtension.Config config) {
+        this.configName = config.configName();
+        this.cacheConfigExtensionsTarget = config.cacheConfigExtension_target();
+    }
+
+
+
+    protected void bindCacheConfigExtension(HttpCacheConfigExtension extension, Map<String,Object> properties){
+        if(extension != this){
+            cacheConfigExtensions.bind(extension, properties);
+        }else{
+            log.error("Invalid http cache config LDAP target string! Self is target(ed)! Breaking up infinite loop. Target: {}", this.cacheConfigExtensionsTarget);
+        }
+    }
+
+    protected void unbindCacheConfigExtension(HttpCacheConfigExtension extension, Map<String,Object> properties){
+        if(extension != this) {
+            cacheConfigExtensions.unbind(extension, properties);
+        }
+    }
+
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
@@ -55,7 +55,7 @@ import static org.apache.commons.lang.StringUtils.*;
  * Instead of duplicating and merging the 2 extensions / factories into 1 class, you can leverage this class.
  */
 @Component(
-        service = {CacheKeyFactory.class, HttpCacheConfigExtension.class},
+        service = {HttpCacheConfigExtension.class},
         configurationPolicy = ConfigurationPolicy.REQUIRE,
         property = {
                 Constants.SERVICE_RANKING + ":Integer=" + Integer.MIN_VALUE

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
@@ -47,6 +47,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
+import static org.apache.commons.lang.StringUtils.*;
+
 /**
  * Aggregates multiple cache config extensions into 1.
  * This is useful when you need functionality of 2 extensions together.
@@ -76,18 +78,14 @@ public class CombinedCacheConfigExtension implements HttpCacheConfigExtension {
             description = "Aggregates multiple extensions into 1")
     public @interface Config {
 
-        String DEFAULT_EXTENSION_TARGET = "(|(service.factoryPid=com.adobe.acs.commons.httpcache.config.impl.GroupHttpCacheConfigExtension)(configName=unique-confg-name-of-extension)(((service.factoryPid=com.adobe.acs.commons.httpcache.config.impl.ResourceTypeHttpCacheConfigExtension)(configName=unique-confg-name-of-extension))";
-
         @AttributeDefinition(name = "Config Name")
-        String configName() default StringUtils.EMPTY;
+        String configName() default EMPTY;
 
         @AttributeDefinition(
                 name = "HttpCacheConfigExtension service pids",
-                description = "Service pid of target implementation of HttpCacheConfigExtension to be used. Example - "
-                        + "(service.pid=" + DEFAULT_EXTENSION_TARGET + ")."
-                        + " Optional parameter.",
-                defaultValue = DEFAULT_EXTENSION_TARGET)
-        String cacheConfigExtension_target() default DEFAULT_EXTENSION_TARGET;
+                description = "Service pids of target implementation of HttpCacheConfigExtensions to be combined and used. "
+                        + " Optional parameter.")
+        String cacheConfigExtension_target() default EMPTY;
 
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.config.impl;
 
 import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
@@ -1,0 +1,120 @@
+package com.adobe.acs.commons.httpcache.config.impl;
+
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfigExtension;
+import com.adobe.acs.commons.httpcache.config.impl.keys.CombinedCacheKey;
+import com.adobe.acs.commons.httpcache.exception.HttpCacheKeyCreationException;
+import com.adobe.acs.commons.httpcache.keys.CacheKey;
+import com.adobe.acs.commons.httpcache.keys.CacheKeyFactory;
+import org.apache.commons.lang.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.commons.osgi.Order;
+import org.apache.sling.commons.osgi.RankedServices;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * Aggregates multiple cache key factories extensions into 1.
+ * This is useful when you need differentiation of 2 cache keys together.
+ * Instead of duplicating and merging the 2 extensions / factories into 1 class, you can leverage this class.
+ * It will use existing cache key factories to create a key for each one, and put them in a list.
+ */
+@Component(
+        service = {CacheKeyFactory.class, HttpCacheConfigExtension.class},
+        configurationPolicy = ConfigurationPolicy.REQUIRE,
+        property = {
+                Constants.SERVICE_RANKING + ":Integer=" + Integer.MIN_VALUE
+        },
+        reference = {
+            @Reference(
+                    name = "cacheKeyFactory",
+                    bind = "bindCacheKeyFactory",
+                    unbind = "unbindCacheKeyFactory",
+                    service = CacheKeyFactory.class,
+                    policy = ReferencePolicy.DYNAMIC,
+                    cardinality = ReferenceCardinality.MULTIPLE)
+        }
+
+)
+@Designate(ocd=CombinedCacheConfigExtension.Config.class,factory=true)
+public class CombinedCacheKeyFactory implements CacheKeyFactory {
+
+
+    @ObjectClassDefinition(name = "ACS AEM Commons - HTTP Cache - Combined extension for HttpCacheConfig and CacheKeyFactory.",
+            description = "Aggregates multiple extensions into 1")
+    public @interface Config {
+
+        String DEFAULT_KEY_FACTORY_TARGET = "(|(service.factoryPid=com.adobe.acs.commons.httpcache.config.impl.GroupHttpCacheConfigExtension)(configName=unique-confg-name-of-extension)(((service.factoryPid=com.adobe.acs.commons.httpcache.config.impl.ResourceTypeHttpCacheConfigExtension)(configName=unique-confg-name-of-extension))";
+
+        @AttributeDefinition(name = "Config Name")
+        String configName() default StringUtils.EMPTY;
+
+        @AttributeDefinition(name = "CacheKeyFactory service pids",
+                description = "Service pid of target implementation of CacheKeyFactory to be used. Example - "
+                        + "(service.pid=" + DEFAULT_KEY_FACTORY_TARGET + ")."
+                        + " Mandatory parameter.",
+                defaultValue = DEFAULT_KEY_FACTORY_TARGET)
+        String cacheKeyFactory_target() default DEFAULT_KEY_FACTORY_TARGET;
+
+    }
+    private static final Logger log = LoggerFactory.getLogger(CombinedCacheKeyFactory.class);
+
+    private String configName;
+    private String cacheKeyFactoriesTarget;
+
+    private RankedServices<CacheKeyFactory> cacheKeyFactories = new RankedServices<>(Order.ASCENDING);
+
+    @Override
+    public CacheKey build(SlingHttpServletRequest request, HttpCacheConfig cacheConfig) throws HttpCacheKeyCreationException {
+        return new CombinedCacheKey(request, cacheConfig, cacheKeyFactories.getList());
+    }
+
+    @Override
+    public CacheKey build(String resourcePath, HttpCacheConfig cacheConfig) throws HttpCacheKeyCreationException {
+        return new CombinedCacheKey(resourcePath, cacheConfig, cacheKeyFactories.getList());
+    }
+
+    @Override
+    public boolean doesKeyMatchConfig(CacheKey key, HttpCacheConfig cacheConfig) throws HttpCacheKeyCreationException {
+        if(!(key instanceof CombinedCacheKey)){
+            return false;
+        }
+
+        return new CombinedCacheKey(key.getUri(), cacheConfig, cacheKeyFactories.getList()).equals(key);
+    }
+
+    protected void bindCacheKeyFactory(CacheKeyFactory factory, Map<String,Object> properties){
+        if(factory != this) {
+            cacheKeyFactories.bind(factory, properties);
+        }else{
+            log.error("Invalid key factory LDAP target string! Self is target(ed)! Breaking up infinite loop. Target: {}", this.cacheKeyFactoriesTarget);
+        }
+    }
+
+    protected void unbindCacheKeyFactory(CacheKeyFactory factory, Map<String,Object> properties){
+        if(factory != this){
+            cacheKeyFactories.unbind(factory, properties);
+        }
+    }
+
+    @Activate
+    @Modified
+    protected void activate(CombinedCacheKeyFactory.Config config) {
+        this.configName = config.configName();
+        this.cacheKeyFactoriesTarget = config.cacheKeyFactory_target();
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
@@ -52,7 +52,7 @@ import java.util.Map;
  * It will use existing cache key factories to create a key for each one, and put them in a list.
  */
 @Component(
-        service = {CacheKeyFactory.class, HttpCacheConfigExtension.class},
+        service = {CacheKeyFactory.class},
         configurationPolicy = ConfigurationPolicy.REQUIRE,
         property = {
                 Constants.SERVICE_RANKING + ":Integer=" + Integer.MIN_VALUE

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
@@ -58,17 +58,17 @@ import java.util.Map;
                 Constants.SERVICE_RANKING + ":Integer=" + Integer.MIN_VALUE
         },
         reference = {
-            @Reference(
-                    name = "cacheKeyFactory",
-                    bind = "bindCacheKeyFactory",
-                    unbind = "unbindCacheKeyFactory",
-                    service = CacheKeyFactory.class,
-                    policy = ReferencePolicy.DYNAMIC,
-                    cardinality = ReferenceCardinality.MULTIPLE)
+                @Reference(
+                        name = "cacheKeyFactory",
+                        bind = "bindCacheKeyFactory",
+                        unbind = "unbindCacheKeyFactory",
+                        service = CacheKeyFactory.class,
+                        policy = ReferencePolicy.DYNAMIC,
+                        cardinality = ReferenceCardinality.MULTIPLE)
         }
 
 )
-@Designate(ocd=CombinedCacheConfigExtension.Config.class,factory=true)
+@Designate(ocd = CombinedCacheConfigExtension.Config.class, factory = true)
 public class CombinedCacheKeyFactory implements CacheKeyFactory {
 
 
@@ -76,19 +76,16 @@ public class CombinedCacheKeyFactory implements CacheKeyFactory {
             description = "Aggregates multiple extensions into 1")
     public @interface Config {
 
-        String DEFAULT_KEY_FACTORY_TARGET = "(|(service.factoryPid=com.adobe.acs.commons.httpcache.config.impl.GroupHttpCacheConfigExtension)(configName=unique-confg-name-of-extension)(((service.factoryPid=com.adobe.acs.commons.httpcache.config.impl.ResourceTypeHttpCacheConfigExtension)(configName=unique-confg-name-of-extension))";
-
         @AttributeDefinition(name = "Config Name")
         String configName() default StringUtils.EMPTY;
 
         @AttributeDefinition(name = "CacheKeyFactory service pids",
-                description = "Service pid of target implementation of CacheKeyFactory to be used. Example - "
-                        + "(service.pid=" + DEFAULT_KEY_FACTORY_TARGET + ")."
-                        + " Mandatory parameter.",
-                defaultValue = DEFAULT_KEY_FACTORY_TARGET)
-        String cacheKeyFactory_target() default DEFAULT_KEY_FACTORY_TARGET;
+                description = "Service pid(s) of target implementation of CacheKeyFactory to be used."
+        )
+        String cacheKeyFactory_target();
 
     }
+
     private static final Logger log = LoggerFactory.getLogger(CombinedCacheKeyFactory.class);
 
     private String configName;
@@ -108,23 +105,23 @@ public class CombinedCacheKeyFactory implements CacheKeyFactory {
 
     @Override
     public boolean doesKeyMatchConfig(CacheKey key, HttpCacheConfig cacheConfig) throws HttpCacheKeyCreationException {
-        if(!(key instanceof CombinedCacheKey)){
+        if (!(key instanceof CombinedCacheKey)) {
             return false;
         }
 
         return new CombinedCacheKey(key.getUri(), cacheConfig, cacheKeyFactories.getList()).equals(key);
     }
 
-    protected void bindCacheKeyFactory(CacheKeyFactory factory, Map<String,Object> properties){
-        if(factory != this) {
+    protected void bindCacheKeyFactory(CacheKeyFactory factory, Map<String, Object> properties) {
+        if (factory != this) {
             cacheKeyFactories.bind(factory, properties);
-        }else{
+        } else {
             log.error("Invalid key factory LDAP target string! Self is target(ed)! Breaking up infinite loop. Target: {}", this.cacheKeyFactoriesTarget);
         }
     }
 
-    protected void unbindCacheKeyFactory(CacheKeyFactory factory, Map<String,Object> properties){
-        if(factory != this){
+    protected void unbindCacheKeyFactory(CacheKeyFactory factory, Map<String, Object> properties) {
+        if (factory != this) {
             cacheKeyFactories.unbind(factory, properties);
         }
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/HttpCacheConfigImplConfig.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/HttpCacheConfigImplConfig.java
@@ -149,7 +149,7 @@ public @interface HttpCacheConfigImplConfig {
                     + "(service.pid=" + DEFAULT_KEY_FACTORY_TARGET + ")."
                     + " Mandatory parameter.",
             defaultValue = DEFAULT_KEY_FACTORY_TARGET)
-    String cacheKeyFactory() default DEFAULT_KEY_FACTORY_TARGET;
+    String cacheKeyFactory_target() default DEFAULT_KEY_FACTORY_TARGET;
 
     @AttributeDefinition(name = "HttpCacheConfigImplConfig-specific HttpCacheHandlingRules",
             description = "List of Service pid of HttpCacheHandlingRule applicable for this cache config. Optional "

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/keys/CombinedCacheKey.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/keys/CombinedCacheKey.java
@@ -1,0 +1,134 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.httpcache.config.impl.keys;
+
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;
+import com.adobe.acs.commons.httpcache.exception.HttpCacheKeyCreationException;
+import com.adobe.acs.commons.httpcache.keys.AbstractCacheKey;
+import com.adobe.acs.commons.httpcache.keys.CacheKey;
+import com.adobe.acs.commons.httpcache.keys.CacheKeyFactory;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Combined cache key.
+ * <p>Aggregates multiple cachekeys into 1 master key.</p>
+ */
+public class CombinedCacheKey extends AbstractCacheKey implements CacheKey, Serializable {
+
+    private static final Logger log = LoggerFactory.getLogger(CombinedCacheKey.class);
+
+    private List<CacheKey> cacheKeys;
+
+
+    public CombinedCacheKey(SlingHttpServletRequest request, HttpCacheConfig cacheConfig, List<CacheKeyFactory>  cacheKeyFactories) {
+        super(request, cacheConfig);
+
+        this.cacheKeys = cacheKeyFactories
+                .stream()
+                .map((factory) -> createCacheKey(request, cacheConfig, factory))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    public CombinedCacheKey(String uri, HttpCacheConfig cacheConfig, List<CacheKeyFactory> cacheKeyFactories) {
+        super(uri, cacheConfig);
+
+        this.cacheKeys = cacheKeyFactories
+                .stream()
+                .map((factory) -> createCacheKey(uri, cacheConfig, factory))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        boolean selfCheck = super.equals(o);
+
+        if(!selfCheck){
+            return false;
+        }
+
+        CombinedCacheKey other = (CombinedCacheKey) o;
+
+        for(int i= 0; i<cacheKeys.size();i++){
+            CacheKey otherDelegate = other.getDelegate(i);
+            CacheKey ownDelegate = this.getDelegate(i);
+
+            if(!otherDelegate.equals(ownDelegate)){
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private CacheKey createCacheKey(SlingHttpServletRequest request, HttpCacheConfig cacheConfig, CacheKeyFactory factory) {
+        try {
+            return factory.build(request, cacheConfig);
+        } catch (HttpCacheKeyCreationException e) {
+            log.error("Error creating cache key: ", e);
+        }
+        return null;
+    }
+
+    private CacheKey createCacheKey(String resourcePath, HttpCacheConfig cacheConfig, CacheKeyFactory factory) {
+        try {
+            return factory.build(resourcePath, cacheConfig);
+        } catch (HttpCacheKeyCreationException e) {
+            log.error("Error creating cache key: ", e);
+        }
+        return null;
+    }
+
+    private CacheKey getDelegate(int position){
+        return cacheKeys.get(position);
+    }
+
+    @Override
+    public String toString() {
+        return this.resourcePath + " [CombinedCacheKey]";
+    }
+
+    /** For Serialization **/
+    private void writeObject(ObjectOutputStream o) throws IOException
+    {
+        parentWriteObject(o);
+        o.writeObject(cacheKeys);
+    }
+
+    /** For De serialization **/
+    private void readObject(ObjectInputStream o)
+            throws IOException, ClassNotFoundException {
+
+        parentReadObject(o);
+        cacheKeys = (List<CacheKey>) o.readObject();
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtensionTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtensionTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.config.impl;
 
 import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtensionTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtensionTest.java
@@ -1,0 +1,102 @@
+package com.adobe.acs.commons.httpcache.config.impl;
+
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfigExtension;
+import com.adobe.acs.commons.httpcache.exception.HttpCacheRepositoryAccessException;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.osgi.framework.Constants;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CombinedCacheConfigExtensionTest {
+
+
+    @Mock
+    private HttpCacheConfigExtension extension1;
+    @Mock
+    private HttpCacheConfigExtension extension2;
+    @Mock
+    private HttpCacheConfigExtension extension3;
+    @Mock
+    private HttpCacheConfigExtension extension4;
+    @Mock
+    private SlingHttpServletRequest request;
+    @Mock
+    private HttpCacheConfig config;
+    @Mock
+    private CombinedCacheConfigExtension.Config ocd;
+
+    private final CombinedCacheConfigExtension underTest = new CombinedCacheConfigExtension();
+
+    @Before
+    public void init() throws HttpCacheRepositoryAccessException {
+
+        when(extension1.accepts(request, config)).thenReturn(false);
+        when(extension2.accepts(request, config)).thenReturn(false);
+        when(extension3.accepts(request, config)).thenReturn(true);
+        when(extension4.accepts(request, config)).thenReturn(true);
+
+        underTest.activate(ocd);
+    }
+
+    @Test
+    public void test() throws HttpCacheRepositoryAccessException {
+        underTest.bindCacheConfigExtension(extension1, mockHttpCacheConfigExtension(1L, 1));
+        underTest.bindCacheConfigExtension(extension2, mockHttpCacheConfigExtension(2L, 2));
+
+        boolean accepts = underTest.accepts(request, config);
+
+        assertFalse(accepts);
+
+        verify(extension1, times(1)).accepts(request, config);
+        verify(extension2, never()).accepts(request, config);
+
+        underTest.unbindCacheConfigExtension(extension1, mockHttpCacheConfigExtension(1L, 1));
+        underTest.unbindCacheConfigExtension(extension2, mockHttpCacheConfigExtension(2L, 2));
+
+    }
+
+    @Test
+    public void test_accepts() throws HttpCacheRepositoryAccessException {
+        underTest.bindCacheConfigExtension(extension3, mockHttpCacheConfigExtension(1L, 1));
+        underTest.bindCacheConfigExtension(extension4, mockHttpCacheConfigExtension(2L, 2));
+
+        boolean accepts = underTest.accepts(request, config);
+
+        assertTrue(accepts);
+
+        verify(extension3, times(1)).accepts(request, config);
+        verify(extension4, times(1)).accepts(request, config);
+
+        underTest.unbindCacheConfigExtension(extension3, mockHttpCacheConfigExtension(1L, 1));
+        underTest.unbindCacheConfigExtension(extension4, mockHttpCacheConfigExtension(2L, 2));
+
+
+    }
+
+    private Map<String,Object> mockHttpCacheConfigExtension(long pid, int rank){
+
+        Map<String,Object> properties = new HashMap<>();
+
+        properties.put(Constants.SERVICE_RANKING, rank );
+        properties.put(Constants.SERVICE_ID, pid);
+
+        return properties;
+
+    }
+
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactoryTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.config.impl;
 
 import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactoryTest.java
@@ -1,0 +1,140 @@
+package com.adobe.acs.commons.httpcache.config.impl;
+
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;
+import com.adobe.acs.commons.httpcache.config.impl.keys.CombinedCacheKey;
+import com.adobe.acs.commons.httpcache.exception.HttpCacheKeyCreationException;
+import com.adobe.acs.commons.httpcache.keys.CacheKey;
+import com.adobe.acs.commons.httpcache.keys.CacheKeyFactory;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.osgi.framework.Constants;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CombinedCacheKeyFactoryTest {
+
+
+    public static final String RESOURCE_PATH = "/content/acs-commons/test/jcr:content/component";
+    public static final String URI = "/content/acs-commons/test/jcr:content/component.html";
+
+
+    @Mock
+    private CacheKeyFactory factory1;
+    @Mock
+    private CacheKeyFactory factory2;
+    @Mock
+    private CacheKeyFactory factory3;
+    @Mock
+    private CacheKeyFactory factory4;
+    @Mock
+    private SlingHttpServletRequest request;
+    @Mock
+    private Resource resource;
+    @Mock
+    private HttpCacheConfig config;
+    @Mock
+    private CacheKey key1;
+    @Mock
+    private CacheKey key2;
+    @Mock
+    private CacheKey key3;
+    @Mock
+    private CacheKey key4;
+    @Mock
+    private CombinedCacheKeyFactory.Config ocd;
+
+    private final CombinedCacheKeyFactory underTest = new CombinedCacheKeyFactory();
+
+    private List<CacheKeyFactory> cacheKeyFactoryList = new ArrayList();
+
+    @Before
+    public void init() throws HttpCacheKeyCreationException {
+
+        when(key1.getUri()).thenReturn(URI);
+        when(key2.getUri()).thenReturn(URI);
+        when(key3.getUri()).thenReturn(URI);
+        when(key4.getUri()).thenReturn(URI);
+
+
+
+        when(factory1.build(anyString(), any(HttpCacheConfig.class))).thenReturn(key1);
+        when(factory2.build(anyString(), any(HttpCacheConfig.class))).thenReturn(key2);
+        when(factory3.build(anyString(), any(HttpCacheConfig.class))).thenReturn(key3);
+        when(factory4.build(anyString(), any(HttpCacheConfig.class))).thenReturn(key4);
+
+        when(factory1.build(request, config)).thenReturn(key1);
+        when(factory2.build(request, config)).thenReturn(key2);
+        when(factory3.build(request, config)).thenReturn(key3);
+        when(factory4.build(request, config)).thenReturn(key4);
+
+        when(request.getResource()).thenReturn(resource);
+        when(request.getRequestURI()).thenReturn(URI);
+        //when(request.getRe)
+        when(resource.getPath()).thenReturn(RESOURCE_PATH);
+        underTest.activate(ocd);
+        cacheKeyFactoryList.clear();
+    }
+
+    @Test
+    public void test_no_match() throws HttpCacheKeyCreationException {
+        underTest.bindCacheKeyFactory(factory1, mockHttpCacheConfigExtension(1L, 1));
+        underTest.bindCacheKeyFactory(factory2, mockHttpCacheConfigExtension(2L, 2));
+
+        cacheKeyFactoryList.add(factory3);
+        cacheKeyFactoryList.add(factory4);
+
+        CombinedCacheKey chain = new CombinedCacheKey(request, config, cacheKeyFactoryList);
+        boolean match = underTest.doesKeyMatchConfig(chain, config);
+
+        assertFalse(match);
+
+        underTest.unbindCacheKeyFactory(factory1, mockHttpCacheConfigExtension(1L, 1));
+        underTest.unbindCacheKeyFactory(factory2, mockHttpCacheConfigExtension(2L, 2));
+
+    }
+
+    @Test
+    public void test_match() throws HttpCacheKeyCreationException {
+        underTest.bindCacheKeyFactory(factory3, mockHttpCacheConfigExtension(1L, 1));
+        underTest.bindCacheKeyFactory(factory4, mockHttpCacheConfigExtension(2L, 2));
+
+        cacheKeyFactoryList.add(factory3);
+        cacheKeyFactoryList.add(factory4);
+
+        CombinedCacheKey chain = new CombinedCacheKey(request, config, cacheKeyFactoryList);
+        boolean match = underTest.doesKeyMatchConfig(chain, config);
+
+        assertTrue(match);
+        underTest.unbindCacheKeyFactory(factory3, mockHttpCacheConfigExtension(1L, 1));
+        underTest.unbindCacheKeyFactory(factory4, mockHttpCacheConfigExtension(2L, 2));
+
+
+    }
+
+    private Map<String,Object> mockHttpCacheConfigExtension(long pid, int rank){
+
+        Map<String,Object> properties = new HashMap<>();
+
+        properties.put(Constants.SERVICE_RANKING, rank );
+        properties.put(Constants.SERVICE_ID, pid);
+
+        return properties;
+
+    }
+
+}


### PR DESCRIPTION
Combined Key http cache extension and factory.

Allows you to define multiple extensions and bundle them into 1, so to prevent code duplication in case the logic of multiple extensions / factories are needed.