### PR TITLE
Initial implementation of CloseableQueryBuilder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1654 - Added I18nProvider service to support injectors
 - #1648 - Add Smart Tags to XMP Metadata Node Workflow Process
 - #1670 - Added @JsonValueMapValue, @I18N, @HierarchicalPageProperty, and improved @AemObject and @SharedValueMapValue.
+- Added CloseableQueryBuilder service to deal with CQ QueryBuilder's shallow unclosed ResourceResolvers.
 
 ### Fixed
 - #1667 - Refactored the activate methods of all http cache services

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1654 - Added I18nProvider service to support injectors
 - #1648 - Add Smart Tags to XMP Metadata Node Workflow Process
 - #1670 - Added @JsonValueMapValue, @I18N, @HierarchicalPageProperty, and improved @AemObject and @SharedValueMapValue.
-- Added CloseableQueryBuilder service to deal with CQ QueryBuilder's shallow unclosed ResourceResolvers.
+- #1686 - Added CloseableQueryBuilder service to deal with CQ QueryBuilder's shallow unclosed ResourceResolvers.
 - #1683 - HttpCache: Added OOTB config extension:: request cookie extension
 
 ### Fixed

--- a/bundle/src/main/java/com/adobe/acs/commons/search/CloseableQuery.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/search/CloseableQuery.java
@@ -1,0 +1,53 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.search;
+
+import java.io.Closeable;
+import java.util.Iterator;
+
+import javax.jcr.Session;
+
+import com.day.cq.search.Query;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * The CQ Search Query retains a cheap internal {@link org.apache.sling.api.resource.ResourceResolver} that wraps a JCR
+ * session after any iteration over search result Hits, which can produce much stack trace in error.log.
+ *
+ * This extension closes the retained resolver via the {@link Closeable#close()} method for use in a try-with-resources
+ * block.
+ *
+ * Because {@link ResourceResolver#close()} calls {@link Session#logout()} on the underlying session, it is important that
+ * the logout method be guarded by a session wrapper. (This is done automatically by the {@link CloseableQueryBuilder}
+ * service.)
+ */
+@ProviderType
+public interface CloseableQuery extends Query, Closeable {
+
+    @Override
+    default void close() {
+        Iterator<Resource> resourceIterator = getResult().getResources();
+        if (resourceIterator.hasNext()) {
+            resourceIterator.next().getResourceResolver().close();
+        }
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/search/CloseableQueryBuilder.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/search/CloseableQueryBuilder.java
@@ -1,0 +1,131 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.search;
+
+import java.io.IOException;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import com.day.cq.search.PredicateGroup;
+import com.day.cq.search.Query;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * A drop-in replacement for the CQ QueryBuilder service that wraps {@link Query} instances to produce
+ * {@link CloseableQuery} instances, whose {@link CloseableQuery#close()} method cleans up the internal shallow resource
+ * resolver.
+ */
+@ProviderType
+public interface CloseableQueryBuilder {
+
+    /**
+     * Create a closeable query around the provided predicate group.
+     *
+     * @param predicates       the root group of predicates
+     * @param resourceResolver the session to use
+     * @return a closeable query
+     */
+    CloseableQuery createQuery(final PredicateGroup predicates, final ResourceResolver resourceResolver);
+
+    /**
+     * Create a closeable query.
+     *
+     * @param resourceResolver the session to use
+     * @return a closeable query
+     */
+    CloseableQuery createQuery(final ResourceResolver resourceResolver);
+
+    /**
+     * Create a closeable query around the provided predicate group.
+     *
+     * @param predicates the root group of predicates
+     * @param session    the session to use
+     * @return a closeable query
+     */
+    CloseableQuery createQuery(final PredicateGroup predicates, final Session session);
+
+    /**
+     * Create a closeable query.
+     *
+     * @param session the session to use
+     * @return a closeable query
+     */
+    CloseableQuery createQuery(final Session session);
+
+    /**
+     * Load a CQ Search query from a properties file located at the specified path. If the specified path does not exist,
+     * returns null.
+     *
+     * @param path             a repository path to a properties file
+     * @param resourceResolver the resource resolver providing access to the repository
+     * @return a query ready for execution
+     * @throws RepositoryException on JCR failure
+     * @throws IOException         on failure to read properties file
+     */
+    CloseableQuery loadQuery(final String path, final ResourceResolver resourceResolver) throws RepositoryException, IOException;
+
+    /**
+     * Load a CQ Search query from a properties file located at the specified path. If the specified path does not exist,
+     * returns null.
+     *
+     * @param path    a repository path to a properties file
+     * @param session the session providing access to the repository
+     * @return a query ready for execution
+     * @throws RepositoryException on JCR failure
+     * @throws IOException         on failure to read properties file
+     */
+    CloseableQuery loadQuery(final String path, final Session session) throws RepositoryException, IOException;
+
+    /**
+     * Saves the query predicates to a properties file in the repository at the specified path.
+     *
+     * @param query            the query whose predicates should be stored
+     * @param path             the path of the properties file
+     * @param createFile       true to create the file if it doesn't exist already
+     * @param resourceResolver the session to use
+     * @throws RepositoryException on JCR failure
+     * @throws IOException         on failure save properties file
+     */
+    void storeQuery(final Query query,
+                    final String path,
+                    final boolean createFile,
+                    final ResourceResolver resourceResolver) throws RepositoryException, IOException;
+
+    /**
+     * Saves the query predicates to a properties file in the repository at the specified path.
+     *
+     * @param query      the query whose predicates should be stored
+     * @param path       the path of the properties file
+     * @param createFile true to create the file if it doesn't exist already
+     * @param session    the session to use
+     * @throws RepositoryException on JCR failure
+     * @throws IOException         on failure save properties file
+     */
+    void storeQuery(final Query query,
+                    final String path,
+                    final boolean createFile,
+                    final Session session) throws RepositoryException, IOException;
+
+    /**
+     * Clears the QueryBuilder facet cache, in case you need to do that.
+     */
+    void clearFacetCache();
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/search/impl/CloseableQueryBuilderImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/search/impl/CloseableQueryBuilderImpl.java
@@ -1,0 +1,127 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.search.impl;
+
+import java.io.IOException;
+import javax.annotation.Nonnull;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import com.adobe.acs.commons.search.CloseableQuery;
+import com.adobe.acs.commons.search.CloseableQueryBuilder;
+import com.adobe.acs.commons.wrap.cqsearch.QueryIWrap;
+import com.day.cq.search.PredicateGroup;
+import com.day.cq.search.Query;
+import com.day.cq.search.QueryBuilder;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * Service implementing {@link CloseableQueryBuilder}, which is intended to be a drop-in replacement for the
+ * {@link QueryBuilder} service, except for the use of {@link ResourceResolver} arguments in place of {@link Session}s.
+ * The use of {@link ResourceResolver}s is both more convenient for developers, who are working primarily in a Sling API
+ * context, and more convenient for injecting a logout-guarded session wrapper to allow for shallow-closing the
+ * encapsulated ResourceResolver without terminating request Sessions.
+ */
+@Component
+public final class CloseableQueryBuilderImpl implements CloseableQueryBuilder {
+
+    @Reference
+    private QueryBuilder queryBuilder;
+
+    @Override
+    public CloseableQuery createQuery(final PredicateGroup rootPredicateGroup,
+                                      final ResourceResolver resourceResolver) {
+        return createQuery(rootPredicateGroup, resourceResolver.adaptTo(Session.class));
+    }
+
+    @Override
+    public CloseableQuery createQuery(final ResourceResolver resourceResolver) {
+        return createQuery(resourceResolver.adaptTo(Session.class));
+    }
+
+    @Override
+    public CloseableQuery createQuery(final PredicateGroup rootPredicateGroup, final Session session) {
+        return new CloseableQueryImpl(queryBuilder.createQuery(rootPredicateGroup,
+                SessionLogoutGuardFactory.useBestWrapper(session)));
+    }
+
+    @Override
+    public CloseableQuery createQuery(final Session session) {
+        return new CloseableQueryImpl(queryBuilder.createQuery(SessionLogoutGuardFactory
+                .useBestWrapper(session)));
+    }
+
+    @Override
+    public CloseableQuery loadQuery(final String path,
+                                    final ResourceResolver resourceResolver) throws RepositoryException, IOException {
+        return loadQuery(path, resourceResolver.adaptTo(Session.class));
+    }
+
+    @Override
+    public CloseableQuery loadQuery(final String path, final Session session) throws RepositoryException, IOException {
+        final Query query = queryBuilder.loadQuery(path, SessionLogoutGuardFactory.useBestWrapper(session));
+        return query != null ? new CloseableQueryImpl(query) : null;
+    }
+
+    @Override
+    public void storeQuery(final Query query,
+                           final String path,
+                           final boolean createFile,
+                           final ResourceResolver resourceResolver) throws RepositoryException, IOException {
+        storeQuery(query, path, createFile, resourceResolver.adaptTo(Session.class));
+    }
+
+    @Override
+    public void storeQuery(final Query query, final String path, final boolean createFile, final Session session)
+            throws RepositoryException, IOException {
+        queryBuilder.storeQuery(query, path, createFile, session);
+    }
+
+    @Override
+    public void clearFacetCache() {
+        queryBuilder.clearFacetCache();
+    }
+
+    static class CloseableQueryImpl implements QueryIWrap, CloseableQuery {
+
+        final Query wrapped;
+
+        CloseableQueryImpl(final Query wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Nonnull
+        @Override
+        public Query wrapQuery(@Nonnull final Query other) {
+            if (other instanceof CloseableQueryImpl) {
+                return other;
+            }
+            return new CloseableQueryImpl(other);
+        }
+
+        @Nonnull
+        @Override
+        public Query unwrapQuery() {
+            return wrapped;
+        }
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/search/impl/SessionLogoutGuardFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/search/impl/SessionLogoutGuardFactory.java
@@ -1,0 +1,98 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.search.impl;
+
+import javax.annotation.Nonnull;
+import javax.jcr.Session;
+
+import com.adobe.acs.commons.wrap.jackrabbit.JackrabbitSessionIWrap;
+import com.adobe.acs.commons.wrap.jcr.SessionIWrap;
+import org.apache.jackrabbit.api.JackrabbitSession;
+
+/**
+ * It's a factory, for session logout guards.
+ */
+public final class SessionLogoutGuardFactory {
+
+    private SessionLogoutGuardFactory() {
+        /* no construction */
+    }
+
+    /**
+     * Wraps a {@link JackrabbitSession} and implements {@link JackrabbitSession}.
+     */
+    static class JackrabbitWrapper implements JackrabbitSessionIWrap {
+        private final JackrabbitSession wrapped;
+
+        JackrabbitWrapper(@Nonnull final JackrabbitSession wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public void logout() {
+            /* prevent logout by doing nothing */
+        }
+
+        @Nonnull
+        @Override
+        public JackrabbitSession unwrapSession() {
+            return wrapped;
+        }
+    }
+
+    /**
+     * Wraps a generic {@link Session} when it's not also a {@link JackrabbitSession}.
+     */
+    static class JcrWrapper implements SessionIWrap {
+        private final Session wrapped;
+
+        JcrWrapper(@Nonnull final Session wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public void logout() {
+            /* prevent logout by doing nothing */
+        }
+
+        @Nonnull
+        @Override
+        public Session unwrapSession() {
+            return wrapped;
+        }
+    }
+
+    /**
+     * Return the best wrapped version of the provided session.
+     *
+     * @param session the session to wrap
+     * @return a wrapped session
+     */
+    public static Session useBestWrapper(final Session session) {
+        if (session instanceof JackrabbitWrapper || session instanceof JcrWrapper) {
+            return session;
+        } else if (session instanceof JackrabbitSession) {
+            return new JackrabbitWrapper((JackrabbitSession) session);
+        } else if (session != null) {
+            return new JcrWrapper(session);
+        }
+        return null;
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/wrap/cqsearch/QueryIWrap.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wrap/cqsearch/QueryIWrap.java
@@ -1,0 +1,98 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.wrap.cqsearch;
+
+import javax.annotation.Nonnull;
+
+import com.day.cq.search.PredicateGroup;
+import com.day.cq.search.Query;
+import com.day.cq.search.eval.PredicateEvaluator;
+import com.day.cq.search.facets.Bucket;
+import com.day.cq.search.result.SearchResult;
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * Interface for wrappers of CQ Search Query instances.
+ */
+@ProviderType
+public interface QueryIWrap extends Query {
+
+    /**
+     * Return the underlying query. This must be implemented by concrete classes.
+     *
+     * @return the underlying query
+     */
+    Query unwrapQuery();
+
+    default @Nonnull
+    Query wrapQuery(final @Nonnull Query other) {
+        return other;
+    }
+
+    @Override
+    default SearchResult getResult() {
+        return unwrapQuery().getResult();
+    }
+
+    @Override
+    default PredicateGroup getPredicates() {
+        return unwrapQuery().getPredicates();
+    }
+
+    @Override
+    default void registerPredicateEvaluator(final String type, final PredicateEvaluator evaluator) {
+        unwrapQuery().registerPredicateEvaluator(type, evaluator);
+    }
+
+    @Override
+    default Query refine(final Bucket bucket) {
+        return wrapQuery(unwrapQuery().refine(bucket));
+    }
+
+    @Override
+    default void setExcerpt(final boolean excerpt) {
+        unwrapQuery().setExcerpt(excerpt);
+    }
+
+    @Override
+    default boolean getExcerpt() {
+        return unwrapQuery().getExcerpt();
+    }
+
+    @Override
+    default void setStart(final long start) {
+        unwrapQuery().setStart(start);
+    }
+
+    @Override
+    default long getStart() {
+        return unwrapQuery().getStart();
+    }
+
+    @Override
+    default void setHitsPerPage(final long hitsPerPage) {
+        unwrapQuery().setHitsPerPage(hitsPerPage);
+    }
+
+    @Override
+    default long getHitsPerPage() {
+        return unwrapQuery().getHitsPerPage();
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/wrap/jackrabbit/JackrabbitSessionIWrap.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wrap/jackrabbit/JackrabbitSessionIWrap.java
@@ -1,0 +1,77 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.wrap.jackrabbit;
+
+import javax.annotation.Nonnull;
+import javax.jcr.AccessDeniedException;
+import javax.jcr.Item;
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+import javax.jcr.UnsupportedRepositoryOperationException;
+
+import com.adobe.acs.commons.wrap.jcr.BaseSessionIWrap;
+import org.apache.jackrabbit.api.JackrabbitSession;
+import org.apache.jackrabbit.api.security.principal.PrincipalManager;
+import org.apache.jackrabbit.api.security.user.UserManager;
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * Interface for wrappers of JackrabbitSessions.
+ */
+@ProviderType
+public interface JackrabbitSessionIWrap extends BaseSessionIWrap<JackrabbitSession>, JackrabbitSession {
+
+    @Override
+    default boolean hasPermission(final @Nonnull String absPath, final @Nonnull String... actions)
+            throws RepositoryException {
+        return unwrapSession().hasPermission(absPath, actions);
+    }
+
+    @Override
+    default PrincipalManager getPrincipalManager()
+            throws AccessDeniedException, UnsupportedRepositoryOperationException, RepositoryException {
+        return unwrapSession().getPrincipalManager();
+    }
+
+    @Override
+    default UserManager getUserManager()
+            throws AccessDeniedException, UnsupportedRepositoryOperationException, RepositoryException {
+        return unwrapSession().getUserManager();
+    }
+
+    @Override
+    default Item getItemOrNull(final String absPath) throws RepositoryException {
+        Item internal = unwrapSession().getItemOrNull(absPath);
+        return internal != null ? wrapItem(internal) : null;
+    }
+
+    @Override
+    default Property getPropertyOrNull(final String absPath) throws RepositoryException {
+        Property internal = unwrapSession().getPropertyOrNull(absPath);
+        return internal != null ? wrapItem(internal) : null;
+    }
+
+    @Override
+    default Node getNodeOrNull(final String absPath) throws RepositoryException {
+        Node internal = unwrapSession().getNodeOrNull(absPath);
+        return internal != null ? wrapItem(internal) : null;
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/wrap/jcr/BaseSessionIWrap.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wrap/jcr/BaseSessionIWrap.java
@@ -1,0 +1,327 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.wrap.jcr;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.AccessControlException;
+import javax.annotation.Nonnull;
+import javax.jcr.AccessDeniedException;
+import javax.jcr.Credentials;
+import javax.jcr.InvalidItemStateException;
+import javax.jcr.InvalidSerializedDataException;
+import javax.jcr.Item;
+import javax.jcr.ItemExistsException;
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.LoginException;
+import javax.jcr.NamespaceException;
+import javax.jcr.Node;
+import javax.jcr.PathNotFoundException;
+import javax.jcr.Property;
+import javax.jcr.ReferentialIntegrityException;
+import javax.jcr.Repository;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.UnsupportedRepositoryOperationException;
+import javax.jcr.ValueFactory;
+import javax.jcr.Workspace;
+import javax.jcr.lock.LockException;
+import javax.jcr.nodetype.ConstraintViolationException;
+import javax.jcr.nodetype.NoSuchNodeTypeException;
+import javax.jcr.retention.RetentionManager;
+import javax.jcr.security.AccessControlManager;
+import javax.jcr.version.VersionException;
+
+import org.osgi.annotation.versioning.ProviderType;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+
+/**
+ * This is the base interface for {@link SessionIWrap} and
+ * {@link com.adobe.acs.commons.wrap.jackrabbit.JackrabbitSessionIWrap}. Default methods are not only defined for all
+ * {@link Session} methods, but also for a few methods to wrap other JCR types that retain references to the wrapped
+ * session, and which therefore might need to be overridden to keep the integrity of the wrapper API in more complex use
+ * cases.
+ *
+ * @param <S> the type of session that is being wrapped.
+ */
+@ProviderType
+public interface BaseSessionIWrap<S extends Session> extends Session {
+
+    /**
+     * Return the underlying session.
+     *
+     * @return the underlying session
+     */
+    S unwrapSession();
+
+    default @Nonnull
+    <T extends Item> T wrapItem(final @Nonnull T item) {
+        return item;
+    }
+
+    default @Nonnull
+    Session wrapSession(final @Nonnull Session session) {
+        return session;
+    }
+
+    default @Nonnull
+    Workspace wrapWorkspace(final @Nonnull Workspace workspace) {
+        return workspace;
+    }
+
+    @Override
+    default Repository getRepository() {
+        return unwrapSession().getRepository();
+    }
+
+    @Override
+    default String getUserID() {
+        return unwrapSession().getUserID();
+    }
+
+    @Override
+    default String[] getAttributeNames() {
+        return unwrapSession().getAttributeNames();
+    }
+
+    @Override
+    default Object getAttribute(final String name) {
+        return unwrapSession().getAttribute(name);
+    }
+
+    @Override
+    default Workspace getWorkspace() {
+        return wrapWorkspace(unwrapSession().getWorkspace());
+    }
+
+    @Override
+    default Node getRootNode() throws RepositoryException {
+        return unwrapSession().getRootNode();
+    }
+
+    @Override
+    default Session impersonate(final Credentials credentials) throws LoginException, RepositoryException {
+        return wrapSession(unwrapSession().impersonate(credentials));
+    }
+
+    @Override
+    default Node getNodeByUUID(final String uuid) throws ItemNotFoundException, RepositoryException {
+        return wrapItem(unwrapSession().getNodeByUUID(uuid));
+    }
+
+    @Override
+    default Node getNodeByIdentifier(final String id) throws ItemNotFoundException, RepositoryException {
+        return wrapItem(unwrapSession().getNodeByIdentifier(id));
+    }
+
+    @Override
+    default Item getItem(final String absPath) throws PathNotFoundException, RepositoryException {
+        return wrapItem(unwrapSession().getItem(absPath));
+    }
+
+    @Override
+    default Node getNode(final String absPath) throws PathNotFoundException, RepositoryException {
+        return wrapItem(unwrapSession().getNode(absPath));
+    }
+
+    @Override
+    default Property getProperty(final String absPath) throws PathNotFoundException, RepositoryException {
+        return wrapItem(unwrapSession().getProperty(absPath));
+    }
+
+    @Override
+    default boolean itemExists(final String absPath) throws RepositoryException {
+        return unwrapSession().itemExists(absPath);
+    }
+
+    @Override
+    default boolean nodeExists(final String absPath) throws RepositoryException {
+        return unwrapSession().nodeExists(absPath);
+    }
+
+    @Override
+    default boolean propertyExists(final String absPath) throws RepositoryException {
+        return unwrapSession().propertyExists(absPath);
+    }
+
+    @Override
+    default void move(final String srcAbsPath, final String destAbsPath)
+            throws ItemExistsException, PathNotFoundException, VersionException, ConstraintViolationException,
+            LockException, RepositoryException {
+        unwrapSession().move(srcAbsPath, destAbsPath);
+    }
+
+    @Override
+    default void removeItem(final String absPath)
+            throws VersionException, LockException, ConstraintViolationException, AccessDeniedException,
+            RepositoryException {
+        unwrapSession().removeItem(absPath);
+    }
+
+    @Override
+    default void save()
+            throws AccessDeniedException, ItemExistsException, ReferentialIntegrityException,
+            ConstraintViolationException, InvalidItemStateException, VersionException, LockException,
+            NoSuchNodeTypeException, RepositoryException {
+        unwrapSession().save();
+    }
+
+    @Override
+    default void refresh(final boolean keepChanges) throws RepositoryException {
+        unwrapSession().refresh(keepChanges);
+    }
+
+    @Override
+    default boolean hasPendingChanges() throws RepositoryException {
+        return unwrapSession().hasPendingChanges();
+    }
+
+    @Override
+    default ValueFactory getValueFactory() throws UnsupportedRepositoryOperationException, RepositoryException {
+        return unwrapSession().getValueFactory();
+    }
+
+    @Override
+    default boolean hasPermission(final String absPath, final String actions) throws RepositoryException {
+        return unwrapSession().hasPermission(absPath, actions);
+    }
+
+    @Override
+    default void checkPermission(final String absPath, final String actions) throws AccessControlException,
+            RepositoryException {
+        unwrapSession().checkPermission(absPath, actions);
+    }
+
+    @Override
+    default boolean hasCapability(final String methodName, final Object target, final Object[] arguments)
+            throws RepositoryException {
+        return unwrapSession().hasCapability(methodName, target, arguments);
+    }
+
+    @Override
+    default ContentHandler getImportContentHandler(final String parentAbsPath, final int uuidBehavior)
+            throws PathNotFoundException, ConstraintViolationException, VersionException, LockException,
+            RepositoryException {
+        return unwrapSession().getImportContentHandler(parentAbsPath, uuidBehavior);
+    }
+
+    @Override
+    default void importXML(final String parentAbsPath, final InputStream in, final int uuidBehavior)
+            throws IOException, PathNotFoundException, ItemExistsException, ConstraintViolationException,
+            VersionException, InvalidSerializedDataException, LockException, RepositoryException {
+        unwrapSession().importXML(parentAbsPath, in, uuidBehavior);
+    }
+
+    @Override
+    default void exportSystemView(final String absPath,
+                                  final ContentHandler contentHandler,
+                                  final boolean skipBinary,
+                                  final boolean noRecurse)
+            throws PathNotFoundException, SAXException, RepositoryException {
+        unwrapSession().exportSystemView(absPath, contentHandler, skipBinary, noRecurse);
+    }
+
+    @Override
+    default void exportSystemView(final String absPath,
+                                  final OutputStream out,
+                                  final boolean skipBinary,
+                                  final boolean noRecurse)
+            throws IOException, PathNotFoundException, RepositoryException {
+        unwrapSession().exportSystemView(absPath, out, skipBinary, noRecurse);
+    }
+
+    @Override
+    default void exportDocumentView(final String absPath,
+                                    final ContentHandler contentHandler,
+                                    final boolean skipBinary,
+                                    final boolean noRecurse)
+            throws PathNotFoundException, SAXException, RepositoryException {
+        unwrapSession().exportDocumentView(absPath, contentHandler, skipBinary, noRecurse);
+    }
+
+    @Override
+    default void exportDocumentView(final String absPath,
+                                    final OutputStream out,
+                                    final boolean skipBinary,
+                                    final boolean noRecurse)
+            throws IOException, PathNotFoundException, RepositoryException {
+        unwrapSession().exportDocumentView(absPath, out, skipBinary, noRecurse);
+    }
+
+    @Override
+    default void setNamespacePrefix(final String prefix,
+                                    final String uri) throws NamespaceException, RepositoryException {
+        unwrapSession().setNamespacePrefix(prefix, uri);
+    }
+
+    @Override
+    default String[] getNamespacePrefixes() throws RepositoryException {
+        return unwrapSession().getNamespacePrefixes();
+    }
+
+    @Override
+    default String getNamespaceURI(final String prefix) throws NamespaceException, RepositoryException {
+        return unwrapSession().getNamespaceURI(prefix);
+    }
+
+    @Override
+    default String getNamespacePrefix(final String uri) throws NamespaceException, RepositoryException {
+        return unwrapSession().getNamespacePrefix(uri);
+    }
+
+    @Override
+    default void logout() {
+        unwrapSession().logout();
+    }
+
+    @Override
+    default boolean isLive() {
+        return unwrapSession().isLive();
+    }
+
+    @Override
+    default void addLockToken(final String lt) {
+        unwrapSession().addLockToken(lt);
+    }
+
+    @Override
+    default String[] getLockTokens() {
+        return unwrapSession().getLockTokens();
+    }
+
+    @Override
+    default void removeLockToken(final String lt) {
+        unwrapSession().removeLockToken(lt);
+    }
+
+    @Override
+    default AccessControlManager getAccessControlManager()
+            throws UnsupportedRepositoryOperationException, RepositoryException {
+        return unwrapSession().getAccessControlManager();
+    }
+
+    @Override
+    default RetentionManager getRetentionManager()
+            throws UnsupportedRepositoryOperationException, RepositoryException {
+        return unwrapSession().getRetentionManager();
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/wrap/jcr/SessionIWrap.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wrap/jcr/SessionIWrap.java
@@ -1,0 +1,32 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.wrap.jcr;
+
+import javax.jcr.Session;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * Terminal interface for wrappers of generic JCR Session objects.
+ */
+@ProviderType
+public interface SessionIWrap extends BaseSessionIWrap<Session> {
+
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/search/impl/CloseableQueryBuilderImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/search/impl/CloseableQueryBuilderImplTest.java
@@ -1,0 +1,99 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.search.impl;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import javax.jcr.Session;
+
+import com.adobe.acs.commons.search.CloseableQuery;
+import com.day.cq.search.Query;
+import com.day.cq.search.QueryBuilder;
+import com.day.cq.search.result.SearchResult;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CloseableQueryBuilderImplTest {
+
+    @Rule
+    public SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
+
+    private ResourceResolver contextResolver;
+
+    @Mock
+    QueryBuilder mockQueryBuilder;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        context.registerService(QueryBuilder.class, mockQueryBuilder);
+        contextResolver = context.create().resource("/test").getResourceResolver();
+        contextResolver.commit();
+    }
+
+    @Test
+    public void testTryWithResources() throws Exception {
+        ResourceResolver hitResolver = context.resourceResolver().clone(null);
+        Resource hitResource = hitResolver.getResource("/test");
+        assertNotNull("hitResource getResourceResolver() should not be null",
+                hitResource.getResourceResolver());
+        assertNotSame("hitResource getResourceResolver() should not be same as context.resourceResolver()",
+                contextResolver, hitResource.getResourceResolver());
+
+        SearchResult mockSearchResult = mock(SearchResult.class);
+        Session mockSession = hitResolver.adaptTo(Session.class);
+        Query mockQuery = mock(Query.class);
+
+        when(mockSearchResult.getResources()).then((invocation) -> Collections.singletonList(hitResource).iterator());
+        when(mockQuery.getResult()).thenReturn(mockSearchResult);
+        when(mockQueryBuilder.createQuery(any(Session.class))).thenReturn(mockQuery);
+
+        CloseableQueryBuilderImpl cqb = new CloseableQueryBuilderImpl();
+        context.registerInjectActivateService(cqb);
+
+        assertTrue("hitResolver should be live", hitResolver.isLive());
+
+        try (CloseableQuery closeableQuery = cqb.createQuery(mockSession)) {
+            /* should not throw exceptions */
+
+            assertTrue("resource resolver from first hit should be live",
+                    closeableQuery.getResult().getResources().next().getResourceResolver().isLive());
+        }
+
+        assertFalse("hitResolver should not be live", hitResolver.isLive());
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/search/impl/SessionLogoutGuardFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/search/impl/SessionLogoutGuardFactoryTest.java
@@ -1,0 +1,71 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.search.impl;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import javax.jcr.Session;
+
+import com.adobe.acs.commons.wrap.jackrabbit.JackrabbitSessionIWrap;
+import com.adobe.acs.commons.wrap.jcr.SessionIWrap;
+import org.apache.jackrabbit.api.JackrabbitSession;
+import org.junit.Test;
+
+public class SessionLogoutGuardFactoryTest {
+
+    @Test
+    public void testUseBestWrapper() {
+        assertNull("null should pass through", SessionLogoutGuardFactory.useBestWrapper(null));
+
+        JackrabbitSession mockJackSession = mock(JackrabbitSession.class);
+        Session jackWrapper = SessionLogoutGuardFactory.useBestWrapper(mockJackSession);
+        assertNotNull("wrap jackSession should not be null", jackWrapper);
+        assertTrue("jackWrapper instance of JackrabbitSessionIWrap: " + jackWrapper.getClass().getName(),
+                jackWrapper instanceof JackrabbitSessionIWrap);
+        assertNotNull("jackWrapper.unwrapSession() instanceof JackrabbitSession",
+                ((JackrabbitSessionIWrap) jackWrapper).unwrapSession());
+
+        jackWrapper.logout();
+        verify(mockJackSession, times(0)).logout();
+
+        assertSame("jackWrapper should not get rewrapped",
+                jackWrapper, SessionLogoutGuardFactory.useBestWrapper(jackWrapper));
+
+        Session mockJcrSession = mock(Session.class);
+        Session jcrWrapper = SessionLogoutGuardFactory.useBestWrapper(mockJcrSession);
+        assertNotNull("wrap jcrSession should not be null", jcrWrapper);
+        assertTrue("jcrWrapper instance of SessionIWrap: " + jcrWrapper.getClass().getName(),
+                jcrWrapper instanceof SessionIWrap);
+        assertNotNull("jcrWrapper.unwrapSession() instanceof Session",
+                ((SessionIWrap) jcrWrapper).unwrapSession());
+
+        jcrWrapper.logout();
+        verify(mockJcrSession, times(0)).logout();
+
+        assertSame("jcrWrapper should not get rewrapped",
+                jcrWrapper, SessionLogoutGuardFactory.useBestWrapper(jcrWrapper));
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/wrap/cqsearch/QueryIWrapTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wrap/cqsearch/QueryIWrapTest.java
@@ -1,0 +1,71 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.wrap.cqsearch;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import javax.annotation.Nonnull;
+
+import com.day.cq.search.Query;
+import com.day.cq.search.result.SearchResult;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QueryIWrapTest {
+
+    @Mock
+    Query query;
+
+    @Mock
+    SearchResult searchResult;
+
+    long start = 10L;
+
+    @Before
+    public void setUp() throws Exception {
+        when(query.getResult()).thenReturn(searchResult);
+        when(query.getStart()).then((invocation) -> start);
+    }
+
+    @Test
+    public void testQueryWrapper() {
+        WrapQuery wrapQuery = new WrapQuery(query);
+        assertEquals("getStart() should return 10L", 10L, wrapQuery.getStart());
+    }
+
+    static class WrapQuery implements QueryIWrap {
+        final Query wrapped;
+
+        public WrapQuery(final Query wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Nonnull
+        @Override
+        public Query unwrapQuery() {
+            return wrapped;
+        }
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/wrap/jackrabbit/JackrabbitSessionIWrapTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wrap/jackrabbit/JackrabbitSessionIWrapTest.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  * #L%
  */
-package com.adobe.acs.commons.wrap.jcr;
+package com.adobe.acs.commons.wrap.jackrabbit;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;

--- a/bundle/src/test/java/com/adobe/acs/commons/wrap/jcr/BaseSessionIWrapTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wrap/jcr/BaseSessionIWrapTest.java
@@ -23,7 +23,9 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -105,6 +107,7 @@ public class BaseSessionIWrapTest {
         when(session.hasPendingChanges()).thenReturn(true);
         when(session.getValueFactory()).thenReturn(valueFactory);
         when(session.hasPermission(anyString(), anyString())).thenReturn(true);
+        when(session.hasCapability(anyString(), anyObject(), any(Object[].class))).thenReturn(true);
         when(session.getImportContentHandler(anyString(), anyInt())).thenReturn(contentHandler);
         when(session.getNamespacePrefixes()).thenReturn(namespacePrefixes);
         when(session.getNamespaceURI(anyString())).thenReturn("http://someuri/");
@@ -139,6 +142,7 @@ public class BaseSessionIWrapTest {
         assertTrue("hasPendingChanges", wrapper.hasPendingChanges());
         assertSame("getValueFactory", valueFactory, wrapper.getValueFactory());
         assertTrue("hasPermission", wrapper.hasPermission("path", "action"));
+        assertTrue("hasCapability", wrapper.hasCapability("path", "action", new Object[0]));
         assertSame("getImportContentHandler", contentHandler, wrapper.getImportContentHandler("path", 0));
         assertArrayEquals("expect correct namespacePrefixes", namespacePrefixes, wrapper.getNamespacePrefixes());
         assertEquals("getNamespaceURI", "http://someuri/", wrapper.getNamespaceURI("someprefix"));

--- a/bundle/src/test/java/com/adobe/acs/commons/wrap/jcr/BaseSessionIWrapTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wrap/jcr/BaseSessionIWrapTest.java
@@ -1,0 +1,213 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.wrap.jcr;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.OutputStream;
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.Repository;
+import javax.jcr.Session;
+import javax.jcr.ValueFactory;
+import javax.jcr.Workspace;
+import javax.jcr.retention.RetentionManager;
+import javax.jcr.security.AccessControlManager;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.xml.sax.ContentHandler;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BaseSessionIWrapTest {
+
+    @Mock
+    Session session;
+
+    @Mock
+    Session otherSession;
+
+    @Mock
+    Workspace workspace;
+
+    @Mock
+    Repository repository;
+
+    @Mock
+    Node rootNode;
+
+    @Mock
+    Property someProperty;
+
+    @Mock
+    ValueFactory valueFactory;
+
+    @Mock
+    ContentHandler contentHandler;
+
+    @Mock
+    AccessControlManager accessControlManager;
+
+    @Mock
+    RetentionManager retentionManager;
+
+    String[] attributeNames = new String[]{"attrOne", "attrTwo"};
+    String[] namespacePrefixes = new String[]{"jcr", "nt", "sling"};
+    String[] lockTokens = new String[]{"lockOne", "lockTwo"};
+
+    @Before
+    public void setUp() throws Exception {
+        when(session.getRootNode()).thenReturn(rootNode);
+        when(session.getWorkspace()).thenReturn(workspace);
+        when(session.getRepository()).thenReturn(repository);
+        when(session.getUserID()).thenReturn("hal9000");
+        when(session.getAttributeNames()).thenReturn(attributeNames);
+        when(session.getAttribute("attrOne")).thenReturn("valueOne");
+        when(session.impersonate(null)).thenReturn(otherSession);
+        when(session.getNodeByUUID(anyString())).thenReturn(rootNode);
+        when(session.getNodeByIdentifier(anyString())).thenReturn(rootNode);
+        when(session.getItem("/item/node")).thenReturn(rootNode);
+        when(session.getNode("/item/node")).thenReturn(rootNode);
+        when(session.getProperty("/item/property")).thenReturn(someProperty);
+        when(session.itemExists(anyString())).thenReturn(true);
+        when(session.nodeExists(anyString())).thenReturn(true);
+        when(session.propertyExists(anyString())).thenReturn(true);
+
+        when(session.hasPendingChanges()).thenReturn(true);
+        when(session.getValueFactory()).thenReturn(valueFactory);
+        when(session.hasPermission(anyString(), anyString())).thenReturn(true);
+        when(session.getImportContentHandler(anyString(), anyInt())).thenReturn(contentHandler);
+        when(session.getNamespacePrefixes()).thenReturn(namespacePrefixes);
+        when(session.getNamespaceURI(anyString())).thenReturn("http://someuri/");
+        when(session.getNamespacePrefix(anyString())).thenReturn("someprefix");
+        when(session.isLive()).thenReturn(true);
+        when(session.getLockTokens()).thenReturn(lockTokens);
+        when(session.getAccessControlManager()).thenReturn(accessControlManager);
+        when(session.getRetentionManager()).thenReturn(retentionManager);
+    }
+
+    @Test
+    public void testGets() throws Exception {
+        SessionWrapper wrapper = new SessionWrapper(session);
+        assertSame("wrapItem(rootNode) should be same as mock", rootNode, wrapper.wrapItem(rootNode));
+        assertSame("wrapWorkspace(workspace) should be same as mock", workspace, wrapper.wrapWorkspace(workspace));
+        assertSame("wrapSession(session) should be same as mock", otherSession, wrapper.wrapSession(otherSession));
+        assertSame("root node should be same as mock", rootNode, wrapper.getRootNode());
+        assertSame("repository should be same as mock", repository, wrapper.getRepository());
+        assertEquals("expect correct userId", "hal9000", wrapper.getUserID());
+        assertArrayEquals("expect correct attributeNames", attributeNames, wrapper.getAttributeNames());
+        assertEquals("expect correct attribute", "valueOne", wrapper.getAttribute("attrOne"));
+        assertSame("expect same workspace", workspace, wrapper.getWorkspace());
+        assertSame("expect other session on impersonate", otherSession, wrapper.impersonate(null));
+        assertSame("get root node by uuid", rootNode, wrapper.getNodeByUUID("some-uuid"));
+        assertSame("get root node by identifier", rootNode, wrapper.getNodeByIdentifier("some-uuid"));
+        assertSame("getItem()", rootNode, wrapper.getItem("/item/node"));
+        assertSame("getNode()", rootNode, wrapper.getNode("/item/node"));
+        assertSame("getProperty()", someProperty, wrapper.getProperty("/item/property"));
+        assertTrue("itemExists", wrapper.itemExists("/item/node"));
+        assertTrue("nodeExists", wrapper.nodeExists("/item/node"));
+        assertTrue("propertyExists", wrapper.propertyExists("/item/property"));
+        assertTrue("hasPendingChanges", wrapper.hasPendingChanges());
+        assertSame("getValueFactory", valueFactory, wrapper.getValueFactory());
+        assertTrue("hasPermission", wrapper.hasPermission("path", "action"));
+        assertSame("getImportContentHandler", contentHandler, wrapper.getImportContentHandler("path", 0));
+        assertArrayEquals("expect correct namespacePrefixes", namespacePrefixes, wrapper.getNamespacePrefixes());
+        assertEquals("getNamespaceURI", "http://someuri/", wrapper.getNamespaceURI("someprefix"));
+        assertEquals("getNamespacePrefix", "someprefix", wrapper.getNamespacePrefix("http://someuri/"));
+        assertTrue("isLive", wrapper.isLive());
+        assertArrayEquals("getLockTokens", lockTokens, wrapper.getLockTokens());
+        assertSame("getAccessControlManager", accessControlManager, wrapper.getAccessControlManager());
+        assertSame("getRetentionManager", retentionManager, wrapper.getRetentionManager());
+    }
+
+    @Test
+    public void testVoids() throws Exception {
+        SessionWrapper wrapper = new SessionWrapper(session);
+        wrapper.move("/from", "/to");
+        verify(session, times(1)).move("/from", "/to");
+        wrapper.removeItem("/item");
+        verify(session, times(1)).removeItem("/item");
+        wrapper.save();
+        verify(session, times(1)).save();
+        wrapper.refresh(true);
+        verify(session, times(1)).refresh(true);
+        wrapper.refresh(false);
+        verify(session, times(1)).refresh(false);
+        wrapper.checkPermission("/path", "actions");
+        verify(session, times(1)).checkPermission("/path", "actions");
+        wrapper.importXML("/path", null, 42);
+
+        final OutputStream mockOs = mock(OutputStream.class);
+        verify(session, times(1)).importXML("/path", null, 42);
+        wrapper.exportSystemView("/path", contentHandler, true, false);
+        verify(session, times(1)).exportSystemView("/path", contentHandler, true, false);
+        wrapper.exportSystemView("/path", contentHandler, false, true);
+        verify(session, times(1)).exportSystemView("/path", contentHandler, false, true);
+        wrapper.exportSystemView("/pathos", mockOs, true, false);
+        verify(session, times(1)).exportSystemView("/pathos", mockOs, true, false);
+        wrapper.exportSystemView("/pathos", mockOs, false, true);
+        verify(session, times(1)).exportSystemView("/pathos", mockOs, false, true);
+        wrapper.exportDocumentView("/path", contentHandler, true, false);
+        verify(session, times(1)).exportDocumentView("/path", contentHandler, true, false);
+        wrapper.exportDocumentView("/path", contentHandler, false, true);
+        verify(session, times(1)).exportDocumentView("/path", contentHandler, false, true);
+        wrapper.exportDocumentView("/pathos", mockOs, true, false);
+        verify(session, times(1)).exportDocumentView("/pathos", mockOs, true, false);
+        wrapper.exportDocumentView("/pathos", mockOs, false, true);
+        verify(session, times(1)).exportDocumentView("/pathos", mockOs, false, true);
+
+        wrapper.setNamespacePrefix("someprefix", "http://someuri/");
+        verify(session, times(1)).setNamespacePrefix("someprefix", "http://someuri/");
+
+        wrapper.logout();
+        verify(session, times(1)).logout();
+
+        wrapper.addLockToken("lockToken");
+        verify(session, times(1)).addLockToken("lockToken");
+        wrapper.removeLockToken("lockToken");
+        verify(session, times(1)).removeLockToken("lockToken");
+
+    }
+
+    static class SessionWrapper implements BaseSessionIWrap<Session> {
+        final Session wrapped;
+
+        public SessionWrapper(final Session wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public Session unwrapSession() {
+            return wrapped;
+        }
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/wrap/jcr/JackrabbitSessionIWrapTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wrap/jcr/JackrabbitSessionIWrapTest.java
@@ -1,0 +1,67 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.wrap.jcr;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.when;
+
+import com.adobe.acs.commons.wrap.jackrabbit.JackrabbitSessionIWrap;
+import org.apache.jackrabbit.api.JackrabbitSession;
+import org.apache.jackrabbit.api.security.user.UserManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JackrabbitSessionIWrapTest {
+
+    @Mock
+    JackrabbitSession session;
+
+    @Mock
+    UserManager userManager;
+
+    @Before
+    public void setUp() throws Exception {
+        when(session.getUserManager()).thenReturn(userManager);
+    }
+
+    @Test
+    public void testGetUserManager() throws Exception {
+        JackrabbitSession wrapper = new JackrabbitSessionWrapper(session);
+        UserManager mockUserMan = wrapper.getUserManager();
+        assertSame("user manager should be same as mocked", userManager, mockUserMan);
+    }
+
+    static class JackrabbitSessionWrapper implements JackrabbitSessionIWrap {
+        final JackrabbitSession session;
+
+        public JackrabbitSessionWrapper(final JackrabbitSession session) {
+            this.session = session;
+        }
+
+        @Override
+        public JackrabbitSession unwrapSession() {
+            return session;
+        }
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/wrap/jcr/SessionIWrapTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wrap/jcr/SessionIWrapTest.java
@@ -19,17 +19,33 @@
  */
 package com.adobe.acs.commons.wrap.jcr;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.OutputStream;
 import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.Repository;
 import javax.jcr.Session;
+import javax.jcr.ValueFactory;
+import javax.jcr.Workspace;
+import javax.jcr.retention.RetentionManager;
+import javax.jcr.security.AccessControlManager;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.xml.sax.ContentHandler;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SessionIWrapTest {
@@ -38,18 +54,148 @@ public class SessionIWrapTest {
     Session session;
 
     @Mock
+    Session otherSession;
+
+    @Mock
+    Workspace workspace;
+
+    @Mock
+    Repository repository;
+
+    @Mock
     Node rootNode;
+
+    @Mock
+    Property someProperty;
+
+    @Mock
+    ValueFactory valueFactory;
+
+    @Mock
+    ContentHandler contentHandler;
+
+    @Mock
+    AccessControlManager accessControlManager;
+
+    @Mock
+    RetentionManager retentionManager;
+
+    String[] attributeNames = new String[]{"attrOne", "attrTwo"};
+    String[] namespacePrefixes = new String[]{"jcr", "nt", "sling"};
+    String[] lockTokens = new String[]{"lockOne", "lockTwo"};
 
     @Before
     public void setUp() throws Exception {
         when(session.getRootNode()).thenReturn(rootNode);
+        when(session.getWorkspace()).thenReturn(workspace);
+        when(session.getRepository()).thenReturn(repository);
+        when(session.getUserID()).thenReturn("hal9000");
+        when(session.getAttributeNames()).thenReturn(attributeNames);
+        when(session.getAttribute("attrOne")).thenReturn("valueOne");
+        when(session.impersonate(null)).thenReturn(otherSession);
+        when(session.getNodeByUUID(anyString())).thenReturn(rootNode);
+        when(session.getNodeByIdentifier(anyString())).thenReturn(rootNode);
+        when(session.getItem("/item/node")).thenReturn(rootNode);
+        when(session.getNode("/item/node")).thenReturn(rootNode);
+        when(session.getProperty("/item/property")).thenReturn(someProperty);
+        when(session.itemExists(anyString())).thenReturn(true);
+        when(session.nodeExists(anyString())).thenReturn(true);
+        when(session.propertyExists(anyString())).thenReturn(true);
+
+        when(session.hasPendingChanges()).thenReturn(true);
+        when(session.getValueFactory()).thenReturn(valueFactory);
+        when(session.hasPermission(anyString(), anyString())).thenReturn(true);
+        when(session.getImportContentHandler(anyString(), anyInt())).thenReturn(contentHandler);
+        when(session.getNamespacePrefixes()).thenReturn(namespacePrefixes);
+        when(session.getNamespaceURI(anyString())).thenReturn("http://someuri/");
+        when(session.getNamespacePrefix(anyString())).thenReturn("someprefix");
+        when(session.isLive()).thenReturn(true);
+        when(session.getLockTokens()).thenReturn(lockTokens);
+        when(session.getAccessControlManager()).thenReturn(accessControlManager);
+        when(session.getRetentionManager()).thenReturn(retentionManager);
     }
 
     @Test
-    public void testGetRootNode() throws Exception {
+    public void testGets() throws Exception {
         SessionWrapper wrapper = new SessionWrapper(session);
-        Node wrappedRootNode = wrapper.getRootNode();
-        assertSame("root node should be same as mock", rootNode, wrappedRootNode);
+        assertSame("wrapItem(rootNode) should be same as mock", rootNode, wrapper.wrapItem(rootNode));
+        assertSame("wrapWorkspace(workspace) should be same as mock", workspace, wrapper.wrapWorkspace(workspace));
+        assertSame("wrapSession(session) should be same as mock", otherSession, wrapper.wrapSession(otherSession));
+        assertSame("root node should be same as mock", rootNode, wrapper.getRootNode());
+        assertSame("repository should be same as mock", repository, wrapper.getRepository());
+        assertEquals("expect correct userId", "hal9000", wrapper.getUserID());
+        assertArrayEquals("expect correct attributeNames", attributeNames, wrapper.getAttributeNames());
+        assertEquals("expect correct attribute", "valueOne", wrapper.getAttribute("attrOne"));
+        assertSame("expect same workspace", workspace, wrapper.getWorkspace());
+        assertSame("expect other session on impersonate", otherSession, wrapper.impersonate(null));
+        assertSame("get root node by uuid", rootNode, wrapper.getNodeByUUID("some-uuid"));
+        assertSame("get root node by identifier", rootNode, wrapper.getNodeByIdentifier("some-uuid"));
+        assertSame("getItem()", rootNode, wrapper.getItem("/item/node"));
+        assertSame("getNode()", rootNode, wrapper.getNode("/item/node"));
+        assertSame("getProperty()", someProperty, wrapper.getProperty("/item/property"));
+        assertTrue("itemExists", wrapper.itemExists("/item/node"));
+        assertTrue("nodeExists", wrapper.nodeExists("/item/node"));
+        assertTrue("propertyExists", wrapper.propertyExists("/item/property"));
+        assertTrue("hasPendingChanges", wrapper.hasPendingChanges());
+        assertSame("getValueFactory", valueFactory, wrapper.getValueFactory());
+        assertTrue("hasPermission", wrapper.hasPermission("path", "action"));
+        assertSame("getImportContentHandler", contentHandler, wrapper.getImportContentHandler("path", 0));
+        assertArrayEquals("expect correct namespacePrefixes", namespacePrefixes, wrapper.getNamespacePrefixes());
+        assertEquals("getNamespaceURI", "http://someuri/", wrapper.getNamespaceURI("someprefix"));
+        assertEquals("getNamespacePrefix", "someprefix", wrapper.getNamespacePrefix("http://someuri/"));
+        assertTrue("isLive", wrapper.isLive());
+        assertArrayEquals("getLockTokens", lockTokens, wrapper.getLockTokens());
+        assertSame("getAccessControlManager", accessControlManager, wrapper.getAccessControlManager());
+        assertSame("getRetentionManager", retentionManager, wrapper.getRetentionManager());
+    }
+
+    @Test
+    public void testVoids() throws Exception {
+        SessionWrapper wrapper = new SessionWrapper(session);
+        wrapper.move("/from", "/to");
+        verify(session, times(1)).move("/from", "/to");
+        wrapper.removeItem("/item");
+        verify(session, times(1)).removeItem("/item");
+        wrapper.save();
+        verify(session, times(1)).save();
+        wrapper.refresh(true);
+        verify(session, times(1)).refresh(true);
+        wrapper.refresh(false);
+        verify(session, times(1)).refresh(false);
+        wrapper.checkPermission("/path", "actions");
+        verify(session, times(1)).checkPermission("/path", "actions");
+        wrapper.importXML("/path", null, 42);
+
+        OutputStream mockOs = mock(OutputStream.class);
+        verify(session, times(1)).importXML("/path", null, 42);
+        wrapper.exportSystemView("/path", contentHandler, true, false);
+        verify(session, times(1)).exportSystemView("/path", contentHandler, true, false);
+        wrapper.exportSystemView("/path", contentHandler, false, true);
+        verify(session, times(1)).exportSystemView("/path", contentHandler, false, true);
+        wrapper.exportSystemView("/pathos", mockOs, true, false);
+        verify(session, times(1)).exportSystemView("/pathos", mockOs, true, false);
+        wrapper.exportSystemView("/pathos", mockOs, false, true);
+        verify(session, times(1)).exportSystemView("/pathos", mockOs, false, true);
+        wrapper.exportDocumentView("/path", contentHandler, true, false);
+        verify(session, times(1)).exportDocumentView("/path", contentHandler, true, false);
+        wrapper.exportDocumentView("/path", contentHandler, false, true);
+        verify(session, times(1)).exportDocumentView("/path", contentHandler, false, true);
+        wrapper.exportDocumentView("/pathos", mockOs, true, false);
+        verify(session, times(1)).exportDocumentView("/pathos", mockOs, true, false);
+        wrapper.exportDocumentView("/pathos", mockOs, false, true);
+        verify(session, times(1)).exportDocumentView("/pathos", mockOs, false, true);
+
+        wrapper.setNamespacePrefix("someprefix", "http://someuri/");
+        verify(session, times(1)).setNamespacePrefix("someprefix", "http://someuri/");
+
+        wrapper.logout();
+        verify(session, times(1)).logout();
+
+        wrapper.addLockToken("lockToken");
+        verify(session, times(1)).addLockToken("lockToken");
+        wrapper.removeLockToken("lockToken");
+        verify(session, times(1)).removeLockToken("lockToken");
+
     }
 
     static class SessionWrapper implements SessionIWrap {

--- a/bundle/src/test/java/com/adobe/acs/commons/wrap/jcr/SessionIWrapTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wrap/jcr/SessionIWrapTest.java
@@ -166,7 +166,7 @@ public class SessionIWrapTest {
         verify(session, times(1)).checkPermission("/path", "actions");
         wrapper.importXML("/path", null, 42);
 
-        OutputStream mockOs = mock(OutputStream.class);
+        final OutputStream mockOs = mock(OutputStream.class);
         verify(session, times(1)).importXML("/path", null, 42);
         wrapper.exportSystemView("/path", contentHandler, true, false);
         verify(session, times(1)).exportSystemView("/path", contentHandler, true, false);

--- a/bundle/src/test/java/com/adobe/acs/commons/wrap/jcr/SessionIWrapTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wrap/jcr/SessionIWrapTest.java
@@ -1,0 +1,67 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.wrap.jcr;
+
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.when;
+
+import javax.jcr.Node;
+import javax.jcr.Session;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SessionIWrapTest {
+
+    @Mock
+    Session session;
+
+    @Mock
+    Node rootNode;
+
+    @Before
+    public void setUp() throws Exception {
+        when(session.getRootNode()).thenReturn(rootNode);
+    }
+
+    @Test
+    public void testGetRootNode() throws Exception {
+        SessionWrapper wrapper = new SessionWrapper(session);
+        Node wrappedRootNode = wrapper.getRootNode();
+        assertSame("root node should be same as mock", rootNode, wrappedRootNode);
+    }
+
+    static class SessionWrapper implements SessionIWrap {
+        final Session wrapped;
+
+        public SessionWrapper(final Session wrapped) {
+            this.wrapped = wrapped;
+        }
+
+        @Override
+        public Session unwrapSession() {
+            return wrapped;
+        }
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/wrap/jcr/SessionIWrapTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wrap/jcr/SessionIWrapTest.java
@@ -19,183 +19,25 @@
  */
 package com.adobe.acs.commons.wrap.jcr;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import java.io.OutputStream;
-import javax.jcr.Node;
-import javax.jcr.Property;
-import javax.jcr.Repository;
 import javax.jcr.Session;
-import javax.jcr.ValueFactory;
-import javax.jcr.Workspace;
-import javax.jcr.retention.RetentionManager;
-import javax.jcr.security.AccessControlManager;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.xml.sax.ContentHandler;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SessionIWrapTest {
 
     @Mock
-    Session session;
-
-    @Mock
-    Session otherSession;
-
-    @Mock
-    Workspace workspace;
-
-    @Mock
-    Repository repository;
-
-    @Mock
-    Node rootNode;
-
-    @Mock
-    Property someProperty;
-
-    @Mock
-    ValueFactory valueFactory;
-
-    @Mock
-    ContentHandler contentHandler;
-
-    @Mock
-    AccessControlManager accessControlManager;
-
-    @Mock
-    RetentionManager retentionManager;
-
-    String[] attributeNames = new String[]{"attrOne", "attrTwo"};
-    String[] namespacePrefixes = new String[]{"jcr", "nt", "sling"};
-    String[] lockTokens = new String[]{"lockOne", "lockTwo"};
-
-    @Before
-    public void setUp() throws Exception {
-        when(session.getRootNode()).thenReturn(rootNode);
-        when(session.getWorkspace()).thenReturn(workspace);
-        when(session.getRepository()).thenReturn(repository);
-        when(session.getUserID()).thenReturn("hal9000");
-        when(session.getAttributeNames()).thenReturn(attributeNames);
-        when(session.getAttribute("attrOne")).thenReturn("valueOne");
-        when(session.impersonate(null)).thenReturn(otherSession);
-        when(session.getNodeByUUID(anyString())).thenReturn(rootNode);
-        when(session.getNodeByIdentifier(anyString())).thenReturn(rootNode);
-        when(session.getItem("/item/node")).thenReturn(rootNode);
-        when(session.getNode("/item/node")).thenReturn(rootNode);
-        when(session.getProperty("/item/property")).thenReturn(someProperty);
-        when(session.itemExists(anyString())).thenReturn(true);
-        when(session.nodeExists(anyString())).thenReturn(true);
-        when(session.propertyExists(anyString())).thenReturn(true);
-
-        when(session.hasPendingChanges()).thenReturn(true);
-        when(session.getValueFactory()).thenReturn(valueFactory);
-        when(session.hasPermission(anyString(), anyString())).thenReturn(true);
-        when(session.getImportContentHandler(anyString(), anyInt())).thenReturn(contentHandler);
-        when(session.getNamespacePrefixes()).thenReturn(namespacePrefixes);
-        when(session.getNamespaceURI(anyString())).thenReturn("http://someuri/");
-        when(session.getNamespacePrefix(anyString())).thenReturn("someprefix");
-        when(session.isLive()).thenReturn(true);
-        when(session.getLockTokens()).thenReturn(lockTokens);
-        when(session.getAccessControlManager()).thenReturn(accessControlManager);
-        when(session.getRetentionManager()).thenReturn(retentionManager);
-    }
+    Session mockSession;
 
     @Test
-    public void testGets() throws Exception {
-        SessionWrapper wrapper = new SessionWrapper(session);
-        assertSame("wrapItem(rootNode) should be same as mock", rootNode, wrapper.wrapItem(rootNode));
-        assertSame("wrapWorkspace(workspace) should be same as mock", workspace, wrapper.wrapWorkspace(workspace));
-        assertSame("wrapSession(session) should be same as mock", otherSession, wrapper.wrapSession(otherSession));
-        assertSame("root node should be same as mock", rootNode, wrapper.getRootNode());
-        assertSame("repository should be same as mock", repository, wrapper.getRepository());
-        assertEquals("expect correct userId", "hal9000", wrapper.getUserID());
-        assertArrayEquals("expect correct attributeNames", attributeNames, wrapper.getAttributeNames());
-        assertEquals("expect correct attribute", "valueOne", wrapper.getAttribute("attrOne"));
-        assertSame("expect same workspace", workspace, wrapper.getWorkspace());
-        assertSame("expect other session on impersonate", otherSession, wrapper.impersonate(null));
-        assertSame("get root node by uuid", rootNode, wrapper.getNodeByUUID("some-uuid"));
-        assertSame("get root node by identifier", rootNode, wrapper.getNodeByIdentifier("some-uuid"));
-        assertSame("getItem()", rootNode, wrapper.getItem("/item/node"));
-        assertSame("getNode()", rootNode, wrapper.getNode("/item/node"));
-        assertSame("getProperty()", someProperty, wrapper.getProperty("/item/property"));
-        assertTrue("itemExists", wrapper.itemExists("/item/node"));
-        assertTrue("nodeExists", wrapper.nodeExists("/item/node"));
-        assertTrue("propertyExists", wrapper.propertyExists("/item/property"));
-        assertTrue("hasPendingChanges", wrapper.hasPendingChanges());
-        assertSame("getValueFactory", valueFactory, wrapper.getValueFactory());
-        assertTrue("hasPermission", wrapper.hasPermission("path", "action"));
-        assertSame("getImportContentHandler", contentHandler, wrapper.getImportContentHandler("path", 0));
-        assertArrayEquals("expect correct namespacePrefixes", namespacePrefixes, wrapper.getNamespacePrefixes());
-        assertEquals("getNamespaceURI", "http://someuri/", wrapper.getNamespaceURI("someprefix"));
-        assertEquals("getNamespacePrefix", "someprefix", wrapper.getNamespacePrefix("http://someuri/"));
-        assertTrue("isLive", wrapper.isLive());
-        assertArrayEquals("getLockTokens", lockTokens, wrapper.getLockTokens());
-        assertSame("getAccessControlManager", accessControlManager, wrapper.getAccessControlManager());
-        assertSame("getRetentionManager", retentionManager, wrapper.getRetentionManager());
-    }
-
-    @Test
-    public void testVoids() throws Exception {
-        SessionWrapper wrapper = new SessionWrapper(session);
-        wrapper.move("/from", "/to");
-        verify(session, times(1)).move("/from", "/to");
-        wrapper.removeItem("/item");
-        verify(session, times(1)).removeItem("/item");
-        wrapper.save();
-        verify(session, times(1)).save();
-        wrapper.refresh(true);
-        verify(session, times(1)).refresh(true);
-        wrapper.refresh(false);
-        verify(session, times(1)).refresh(false);
-        wrapper.checkPermission("/path", "actions");
-        verify(session, times(1)).checkPermission("/path", "actions");
-        wrapper.importXML("/path", null, 42);
-
-        final OutputStream mockOs = mock(OutputStream.class);
-        verify(session, times(1)).importXML("/path", null, 42);
-        wrapper.exportSystemView("/path", contentHandler, true, false);
-        verify(session, times(1)).exportSystemView("/path", contentHandler, true, false);
-        wrapper.exportSystemView("/path", contentHandler, false, true);
-        verify(session, times(1)).exportSystemView("/path", contentHandler, false, true);
-        wrapper.exportSystemView("/pathos", mockOs, true, false);
-        verify(session, times(1)).exportSystemView("/pathos", mockOs, true, false);
-        wrapper.exportSystemView("/pathos", mockOs, false, true);
-        verify(session, times(1)).exportSystemView("/pathos", mockOs, false, true);
-        wrapper.exportDocumentView("/path", contentHandler, true, false);
-        verify(session, times(1)).exportDocumentView("/path", contentHandler, true, false);
-        wrapper.exportDocumentView("/path", contentHandler, false, true);
-        verify(session, times(1)).exportDocumentView("/path", contentHandler, false, true);
-        wrapper.exportDocumentView("/pathos", mockOs, true, false);
-        verify(session, times(1)).exportDocumentView("/pathos", mockOs, true, false);
-        wrapper.exportDocumentView("/pathos", mockOs, false, true);
-        verify(session, times(1)).exportDocumentView("/pathos", mockOs, false, true);
-
-        wrapper.setNamespacePrefix("someprefix", "http://someuri/");
-        verify(session, times(1)).setNamespacePrefix("someprefix", "http://someuri/");
-
-        wrapper.logout();
-        verify(session, times(1)).logout();
-
-        wrapper.addLockToken("lockToken");
-        verify(session, times(1)).addLockToken("lockToken");
-        wrapper.removeLockToken("lockToken");
-        verify(session, times(1)).removeLockToken("lockToken");
-
+    public void testConstructImpl() {
+        SessionWrapper wrapper = new SessionWrapper(mockSession);
+        assertSame("unwrapSession to same as mock", mockSession, wrapper.unwrapSession());
     }
 
     static class SessionWrapper implements SessionIWrap {


### PR DESCRIPTION
The QueryBuilder isn't Closeable, the Queries are.

The idea for progressive conversion of usages of QueryBuilder to CloseableQueryBuilder is you start with changing:

```java
@Reference
private QueryBuilder queryBuilder;
```

to 

```java
@Reference
private CloseableQueryBuilder queryBuilder;
```

Since the point of the `CloseableQuery` is to simply add a `close()` method to the `Query` interface, you will probably want to call that method, and the right place to do it with existing logic is _immediately after you are finished using the last `Hit`'s `Resource`_.

```java
Query myQuery = queryBuilder.createQuery(predicates, session);
SearchResult result = myQuery.getResult();
for (Hit hit : result.getHits()) {
  /* do stuff with Hit resources within the try block */ 
}
```

becomes


```java
CloseableQuery myQuery = queryBuilder.createQuery(predicates, session);
SearchResult result = myQuery.getResult();
for (Hit hit : result.getHits()) {
  /* do stuff with Hit resources within the try block */ 
}

myQuery.close();
// don't use Hit Resources from this result anymore.
```

CloseableQueryBuilderImpl wraps a reference to QueryBuilder and passes through all the expected arguments to `createQuery()`, and then wraps the returned `Query` type with the `CloseableQuery` type, which also passes through all the Query interface methods. 

The difference is that `CloseableQuery` implements `java.io.Closeable`, so that the next step after conversion would be to encapsulate all the `Query` logic into a _try-with-resources_ block, like so:

```java
try (CloseableQuery query = queryBuilder.createQuery(predicates, session)) {
  SearchResult result = query.getResult();
  for (Hit hit : result.getHits()) {
    /* do stuff with Hit resources within the try block */
  }
}

/* once the try block exits, the query's internal ResourceResolver will be closed */
```

The `CloseableQueryBuilder` also adds convenient `ResourceResolver` overloads for all the `QueryBuilder` methods that take `Session` arguments, so that you don't have to adapt your `ResourceResolver` to a `Session`.