### PR TITLE
use more lightweight repo implementations when possible

### DIFF
--- a/bundle/src/test/java/com/adobe/acs/commons/dispatcher/impl/PermissionSensitiveCacheServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/dispatcher/impl/PermissionSensitiveCacheServletTest.java
@@ -44,7 +44,7 @@ public class PermissionSensitiveCacheServletTest {
     public static final String TEST_PAGE = "/content/test.html";
 
     @Rule
-    public SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
+    public SlingContext context = new SlingContext(ResourceResolverType.JCR_MOCK);
 
     @InjectMocks
     private PermissionSensitiveCacheServlet servlet = new PermissionSensitiveCacheServlet();

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/AssetFolderCreatorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/AssetFolderCreatorTest.java
@@ -66,7 +66,8 @@ import static org.mockito.Mockito.doAnswer;
 public class AssetFolderCreatorTest {
 
     @Rule
-    public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
+    public final SlingContext context = new SlingContext();
+    
 
     @Mock
     private ActionManager actionManager;

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorTest.java
@@ -72,7 +72,7 @@ public class FileAssetIngestorTest {
     private static final String SFTP_USER_TEST_PASSWORD = "password";
 
     @Rule
-    public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
+    public final SlingContext context = new SlingContext(ResourceResolverType.JCR_MOCK);
 
     @Mock
     private ActionManager actionManager;

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/S3AssetIngestorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/S3AssetIngestorTest.java
@@ -68,7 +68,7 @@ public class S3AssetIngestorTest {
     private S3Mock s3Mock;
 
     @Rule
-    public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
+    public final SlingContext context = new SlingContext(ResourceResolverType.JCR_MOCK);
 
     @Mock
     private ActionManager actionManager;

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/UrlAssetImportTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/UrlAssetImportTest.java
@@ -60,7 +60,7 @@ import static org.mockito.Mockito.mock;
 public class UrlAssetImportTest {
 
     @Rule
-    public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
+    public final SlingContext context = new SlingContext(ResourceResolverType.JCR_MOCK);
 
     @Mock
     private ActionManager actionManager;


### PR DESCRIPTION
In many cases we don't need any JCR semantic in our unit tests, and then we can just use the default repo implementation. And when you just use simple JCR semantics, "JCR_MOCK" is often enough. We have only a few cases where we need the full-blown Oak repo for unittests.

The "problem" with the full Oak implementation is that it's recreated on every test run; and this comes with an overhead, which slows down our unittests.