### PR TITLE
Manage Controlled Process feature doesn't work because of R6 annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1683 - HttpCache: Added OOTB config extension:: request cookie extension
 
 ### Fixed
+- #1691 - Manage Controlled Process feature doesn't work because of R6 annotations
 - #1667 - Refactored the activate methods of all http cache services
 - #1664 - OSGI annotations : fixed default values for various activate methods
 - #1607 - HttpCache: improved the write to response mechanism.

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/ControlledProcessManagerServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/ControlledProcessManagerServlet.java
@@ -52,6 +52,7 @@ import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestParameter;
 import org.apache.sling.api.request.RequestParameterMap;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
@@ -61,14 +62,13 @@ import org.slf4j.LoggerFactory;
  * Servlet for interacting with MCP.
  */
 
-@Component(service=Servlet.class,
-property= {
-SLING_SERVLET_METHODS+"=GET,POST",
-SLING_SERVLET_SELECTORS+"=start,list,status,halt,haltAll,purge",
-SLING_SERVLET_EXTENSIONS+"=json",
-SLING_SERVLET_RESOURCE_TYPES+"=acs-commons/components/utilities/manage-controlled-processes"
-
-})
+@Component(service=Servlet.class)
+@SlingServletResourceTypes(
+        resourceTypes = "acs-commons/components/utilities/manage-controlled-processes",
+        selectors = {"start", "list", "status", "halt", "haltAll", "purge"},
+        methods = {"GET", "POST"},
+        extensions = {"json"}
+)
 public class ControlledProcessManagerServlet extends SlingAllMethodsServlet {
 
     private static final Logger LOG = LoggerFactory.getLogger(ControlledProcessManagerServlet.class);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23450886/51187554-26df6080-18ed-11e9-8cd0-e88177af9836.png)


I have updated ControlledProcessManagerServlet with [R7 annotaitons](https://sling.apache.org/documentation/the-sling-engine/servlets.html#registering-a-servlet-using-java-annotations). Because R6 requires a lot of duplicates during declaring [multi-valued properties](https://osgi.org/javadoc/r6/cmpn/org/osgi/service/component/annotations/Component.html#property())

 

