### PR TITLE
Add tracking for required client libraries for components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1683 - HttpCache: Added OOTB config extension:: request cookie extension
 - #1685 - HttpCache: Added OOTB config extension:: combined extension
 - #1692 - HttpCache: Added OOTB config extension:: request header,parameter, valuemap value extension
+- #1700 - MCP Forms framework now tracks client libraries required for components as needed
 
 ### Fixed
 - #1692 - HttpCache: Refactored resource / group config extensions 

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FieldComponent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FieldComponent.java
@@ -125,12 +125,7 @@ public abstract class FieldComponent {
     }
 
     public void addClientLibrary(String category) {
-        addClientLibrary(category, ClientLibraryType.ALL);
-    }
-
-    public void addClientLibrary(String category, ClientLibraryType type) {
-        Set<String> categories = clientLibraries.getOrDefault(type, new LinkedHashSet<>());
-        categories.add(category);
+        addClientLibraries(ClientLibraryType.ALL, category);
     }
 
     public void addClientLibraries(ClientLibraryType type, String... categories) {

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FieldComponent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FieldComponent.java
@@ -142,7 +142,7 @@ public abstract class FieldComponent {
         }
     }
 
-    public void mergeClientLibraries(FieldComponent component) {
+    public void addClientLibraries(FieldComponent component) {
         component.getClientLibraryCategories().forEach((type, categories) -> {
             if (categories != null) {
                 addClientLibraries(type, categories);

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FieldComponent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FieldComponent.java
@@ -21,7 +21,13 @@ package com.adobe.acs.commons.mcp.form;
 
 import aQute.bnd.annotation.ProviderType;
 import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceMetadata;
@@ -32,6 +38,7 @@ import org.apache.sling.api.scripting.SlingScriptHelper;
  */
 @ProviderType
 public abstract class FieldComponent {
+
     private String name;
     protected FormField formField;
     protected Field javaField;
@@ -41,6 +48,7 @@ public abstract class FieldComponent {
     private String resourceSuperType = "granite/ui/components/coral/foundation/form/field";
     private Resource resource;
     private String path = "/fake/path";
+    private EnumMap<ClientLibraryType, Set<String>> clientLibraries;
 
     public final void setup(String name, Field javaField, FormField field, SlingScriptHelper sling) {
         this.name = name;
@@ -52,32 +60,32 @@ public abstract class FieldComponent {
         componentMetadata.put("fieldDescription", formField.description());
         componentMetadata.put("required", formField.required());
         componentMetadata.put("emptyText", formField.hint());
-        getOption("default").ifPresent(val->componentMetadata.put("value", val));
+        getOption("default").ifPresent(val -> componentMetadata.put("value", val));
         init();
     }
-    
+
     public abstract void init();
-    
+
     public SlingScriptHelper getHelper() {
         return sling;
     }
-    
+
     public void setPath(String path) {
         this.path = path;
     }
-    
+
     public String getPath() {
         return path;
     }
-    
+
     public Field getField() {
         return javaField;
     }
-    
+
     public FormField getFieldDefinition() {
         return formField;
     }
-    
+
     public String getHtml() {
         sling.include(getComponentResource());
         return "";
@@ -91,9 +99,11 @@ public abstract class FieldComponent {
     }
 
     /**
-     * If your component needs child nodes then override this method, call the superclass implementation, and then use addChildren
-     * to add additional nodes to it.
-     * @return 
+     * If your component needs child nodes then override this method, call the
+     * superclass implementation, and then use addChildren to add additional
+     * nodes to it.
+     *
+     * @return
      */
     public Resource buildComponentResource() {
         AbstractResourceImpl res = new AbstractResourceImpl(path, resourceType, resourceSuperType, componentMetadata);
@@ -108,6 +118,41 @@ public abstract class FieldComponent {
      */
     public ResourceMetadata getComponentMetadata() {
         return componentMetadata;
+    }
+
+    public Map<ClientLibraryType, Set<String>> getClientLibraryCategories() {
+        return Collections.unmodifiableMap(clientLibraries);
+    }
+
+    public void addClientLibrary(String category) {
+        addClientLibrary(category, ClientLibraryType.ALL);
+    }
+
+    public void addClientLibrary(String category, ClientLibraryType type) {
+        Set<String> categories = clientLibraries.getOrDefault(type, new LinkedHashSet<>());
+        categories.add(category);
+    }
+
+    public void addClientLibraries(ClientLibraryType type, String... categories) {
+        Set<String> categoriesSet = clientLibraries.getOrDefault(type, new LinkedHashSet<>());
+        for (String category : categories) {
+            categoriesSet.add(category);
+        }
+    }
+
+    public void addClientLibraries(ClientLibraryType type, Collection<String> categories) {
+        Set<String> categoriesSet = clientLibraries.getOrDefault(type, new LinkedHashSet<>());
+        for (String category : categories) {
+            categoriesSet.add(category);
+        }
+    }
+
+    public void mergeClientLibraries(FieldComponent component) {
+        component.getClientLibraryCategories().forEach((type, categories) -> {
+            if (categories != null) {
+                addClientLibraries(type, categories);
+            }
+        });
     }
 
     /**
@@ -150,10 +195,14 @@ public abstract class FieldComponent {
                 .filter(s -> s.equalsIgnoreCase(optionName) || s.startsWith(optionName + "="))
                 .findFirst().isPresent();
     }
-    
+
     public Optional<String> getOption(String option) {
         return Stream.of(formField.options())
-                .filter(s -> s.startsWith(option+"="))
+                .filter(s -> s.startsWith(option + "="))
                 .findFirst().map(o -> o.split("=")[1]);
     }
+
+    public static enum ClientLibraryType {
+        JS, CSS, ALL
+    };
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FieldComponent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FieldComponent.java
@@ -48,7 +48,7 @@ public abstract class FieldComponent {
     private String resourceSuperType = "granite/ui/components/coral/foundation/form/field";
     private Resource resource;
     private String path = "/fake/path";
-    private EnumMap<ClientLibraryType, Set<String>> clientLibraries;
+    private final EnumMap<ClientLibraryType, Set<String>> clientLibraries = new EnumMap<>(ClientLibraryType.class);
 
     public final void setup(String name, Field javaField, FormField field, SlingScriptHelper sling) {
         this.name = name;
@@ -133,6 +133,7 @@ public abstract class FieldComponent {
         for (String category : categories) {
             categoriesSet.add(category);
         }
+        clientLibraries.put(type, categoriesSet);
     }
 
     public void addClientLibraries(ClientLibraryType type, Collection<String> categories) {
@@ -140,6 +141,7 @@ public abstract class FieldComponent {
         for (String category : categories) {
             categoriesSet.add(category);
         }
+        clientLibraries.put(type, categoriesSet);
     }
 
     public void addClientLibraries(FieldComponent component) {

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FieldComponent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FieldComponent.java
@@ -21,6 +21,7 @@ package com.adobe.acs.commons.mcp.form;
 
 import aQute.bnd.annotation.ProviderType;
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -125,22 +126,16 @@ public abstract class FieldComponent {
     }
 
     public void addClientLibrary(String category) {
-        addClientLibraries(ClientLibraryType.ALL, category);
+        addClientLibraries(ClientLibraryType.ALL, Arrays.asList(category));
     }
 
     public void addClientLibraries(ClientLibraryType type, String... categories) {
-        Set<String> categoriesSet = clientLibraries.getOrDefault(type, new LinkedHashSet<>());
-        for (String category : categories) {
-            categoriesSet.add(category);
-        }
-        clientLibraries.put(type, categoriesSet);
+        addClientLibraries(type, Arrays.asList(categories));
     }
 
     public void addClientLibraries(ClientLibraryType type, Collection<String> categories) {
         Set<String> categoriesSet = clientLibraries.getOrDefault(type, new LinkedHashSet<>());
-        for (String category : categories) {
-            categoriesSet.add(category);
-        }
+        categoriesSet.addAll(categories);
         clientLibraries.put(type, categoriesSet);
     }
 
@@ -201,5 +196,5 @@ public abstract class FieldComponent {
 
     public static enum ClientLibraryType {
         JS, CSS, ALL
-    };
+    }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/GeneratedDialog.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/GeneratedDialog.java
@@ -19,8 +19,9 @@
  */
 package com.adobe.acs.commons.mcp.form;
 
-import com.adobe.acs.commons.mcp.form.FieldComponent;
 import com.adobe.acs.commons.mcp.util.AnnotatedFieldDeserializer;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -60,6 +61,27 @@ public class GeneratedDialog {
 
     public Map<String, FieldComponent> getFieldComponents() {
         return fieldComponents;
+    }
+
+    public Collection<String> getAllClientLibraries() {
+        return getClientLibraries(FieldComponent.ClientLibraryType.ALL);
+    }
+
+    public Collection<String> getCssClientLibraries() {
+        return getClientLibraries(FieldComponent.ClientLibraryType.CSS);
+    }
+
+    public Collection<String> getJsClientLibraries() {
+        return getClientLibraries(FieldComponent.ClientLibraryType.JS);
+    }
+
+    private Collection<String> getClientLibraries(FieldComponent.ClientLibraryType type) {
+        LinkedHashSet<String> allLibraries = new LinkedHashSet<>();
+        fieldComponents.values().stream()
+                .map(c -> c.getClientLibraryCategories().get(type))
+                .filter(v -> v != null)
+                .forEach(v -> allLibraries.addAll(v));
+        return allLibraries;
     }
 
     /**

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/MultifieldComponent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/MultifieldComponent.java
@@ -99,6 +99,6 @@ public class MultifieldComponent extends FieldComponent {
             fieldComponents.putAll(AnnotatedFieldDeserializer.getFormFields(clazz, sling));
             isComposite = true;
         }
-        fieldComponents.values().forEach(this::mergeClientLibraries);
+        fieldComponents.values().forEach(this::addClientLibraries);
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/MultifieldComponent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/MultifieldComponent.java
@@ -27,9 +27,9 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceMetadata;
 
 /**
- * Represent multifield with sub-fields based on referenced class.
- * Depending on where this is used, some javascript should be included by the front-end
- * to process the resulting form correctly.
+ * Represent multifield with sub-fields based on referenced class. Depending on
+ * where this is used, some javascript should be included by the front-end to
+ * process the resulting form correctly.
  */
 public class MultifieldComponent extends FieldComponent {
 
@@ -69,7 +69,7 @@ public class MultifieldComponent extends FieldComponent {
                 component.setPath(getPath() + "/field/items/" + component.getName());
                 items.addChild(component.buildComponentResource());
             }
-        } else {            
+        } else {
             for (FieldComponent component : fieldComponents.values()) {
                 component.setPath(getPath() + "/field");
                 Resource comp = component.buildComponentResource();
@@ -89,7 +89,7 @@ public class MultifieldComponent extends FieldComponent {
         fieldComponents = new LinkedHashMap<>();
         if (clazz == String.class) {
             FieldComponent comp = new TextfieldComponent();
-            FormField fieldDef = FormField.Factory.create(getName(), "", null, false, comp.getClass(), null);            
+            FormField fieldDef = FormField.Factory.create(getName(), "", null, false, comp.getClass(), null);
             comp.setup(getName(), null, fieldDef, sling);
             comp.getComponentMetadata().put("title", getName());
             // TODO: Provide a proper mechanism for setting path when creating components
@@ -99,5 +99,6 @@ public class MultifieldComponent extends FieldComponent {
             fieldComponents.putAll(AnnotatedFieldDeserializer.getFormFields(clazz, sling));
             isComposite = true;
         }
+        fieldComponents.values().forEach(this::mergeClientLibraries);
     }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/form/FieldComponentTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/form/FieldComponentTest.java
@@ -23,8 +23,9 @@ import com.adobe.acs.commons.mcp.form.FieldComponent.ClientLibraryType;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Optional;
-import static org.junit.Assert.*;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class FieldComponentTest {
     @Test

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/form/FieldComponentTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/form/FieldComponentTest.java
@@ -19,12 +19,12 @@
  */
 package com.adobe.acs.commons.mcp.form;
 
-import org.junit.Test;
-
+import com.adobe.acs.commons.mcp.form.FieldComponent.ClientLibraryType;
 import java.lang.annotation.Annotation;
+import java.util.Arrays;
 import java.util.Optional;
-
 import static org.junit.Assert.*;
+import org.junit.Test;
 
 public class FieldComponentTest {
     @Test
@@ -42,6 +42,26 @@ public class FieldComponentTest {
         assertEquals("b", testComponent.getOption("a").get());
         assertEquals(Optional.empty(), testComponent.getOption("c"));
         assertEquals(Optional.empty(), testComponent.getOption("z"));
+    }
+
+    @Test
+    public void testClientLibraryTracking() {
+        TestFieldComponent componentA = new TestFieldComponent(null);
+        TestFieldComponent componentB = new TestFieldComponent(null);
+
+        assertNotNull(componentA.getClientLibraryCategories());
+        assertEquals(0, componentA.getClientLibraryCategories().size());
+
+        componentB.addClientLibrary("All-Test1");
+        componentB.addClientLibraries(FieldComponent.ClientLibraryType.JS, "JS-Test1", "JS-Test2");
+        componentB.addClientLibraries(FieldComponent.ClientLibraryType.CSS, Arrays.asList("CSS-Test1", "CSS-Test2"));
+
+        assertArrayEquals(new String[]{"JS-Test1", "JS-Test2"}, componentB.getClientLibraryCategories().get(ClientLibraryType.JS).toArray());
+        assertArrayEquals(new String[]{"CSS-Test1", "CSS-Test2"}, componentB.getClientLibraryCategories().get(ClientLibraryType.CSS).toArray());
+
+        componentA.addClientLibrary("All-Test2");
+        componentA.addClientLibraries(componentB);
+        assertArrayEquals(new String[]{"All-Test2", "All-Test1"}, componentA.getClientLibraryCategories().get(ClientLibraryType.ALL).toArray());
     }
 
     public class TestFieldComponent extends FieldComponent {

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/form/SyntheticDialogTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/form/SyntheticDialogTest.java
@@ -20,9 +20,10 @@
 package com.adobe.acs.commons.mcp.form;
 
 import java.util.List;
-import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * Assert the generation behavior of synthetic dialogs from a java bean -- which

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/form/SyntheticDialogTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/form/SyntheticDialogTest.java
@@ -20,10 +20,9 @@
 package com.adobe.acs.commons.mcp.form;
 
 import java.util.List;
+import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
 
 /**
  * Assert the generation behavior of synthetic dialogs from a java bean -- which
@@ -64,6 +63,7 @@ public class SyntheticDialogTest {
         assertNotNull(component.getFieldComponents().get("subField3"));
         assertNotNull(component.getFieldComponents().get("subField4"));
         assertNotNull(component.getFieldComponents().get("subField5"));
+        assertNotNull(component.getFieldComponents().get("subField6"));
         assertTrue(component.isComposite);
         AbstractResourceImpl res = (AbstractResourceImpl) component.buildComponentResource();
         assertNotNull(res);
@@ -75,6 +75,7 @@ public class SyntheticDialogTest {
         assertNotNull("Should include subfield3 component", res.getChild("field/items/subField3"));
         assertNotNull("Should include subfield4 component", res.getChild("field/items/subField4"));
         assertNotNull("Should include subfield5 component", res.getChild("field/items/subField5"));
+        assertNotNull("Should include subfield5 component", res.getChild("field/items/subField6"));
     }
 
     @Test
@@ -88,8 +89,26 @@ public class SyntheticDialogTest {
         assertNotNull("Multifield node check", res.getChild("field"));
     }
 
-    public class TestPojo extends GeneratedDialog {
+    @Test
+    public void testClientLibraryHandling() {
+        assertEquals(1, testPojo.getAllClientLibraries().size());
+        assertEquals(1, testPojo.getJsClientLibraries().size());
+        assertEquals(1, testPojo.getCssClientLibraries().size());
+        assert(testPojo.getAllClientLibraries().contains("component-all"));
+        assert(testPojo.getJsClientLibraries().contains("component-js"));
+        assert(testPojo.getCssClientLibraries().contains("component-css"));
+    }
 
+    public static class ComponentWithClientLibraries extends FieldComponent {
+        @Override
+        public void init() {
+            addClientLibraries(FieldComponent.ClientLibraryType.JS, "component-js");
+            addClientLibraries(FieldComponent.ClientLibraryType.CSS, "component-css");
+            addClientLibrary("component-all");
+        }
+    }
+
+    public static class TestPojo extends GeneratedDialog {
         @FormField(component = TextfieldComponent.class, name = "Text Field")
         String textField;
 
@@ -109,7 +128,7 @@ public class SyntheticDialogTest {
         String textArea;
     }
 
-    public class TestSubtype {
+    public static class TestSubtype {
 
         @FormField(component = TextfieldComponent.class, name = "Text Field")
         String subField1;
@@ -125,5 +144,8 @@ public class SyntheticDialogTest {
 
         @FormField(component = TextareaComponent.class, name = "Text Area")
         String subField5;
+
+        @FormField(component = ComponentWithClientLibraries.class, name = "Component with client libs")
+        String subField6;
     }
 }


### PR DESCRIPTION
In order to properly generate a form, client libraries should be included.  Most usually this means common libraries but there are some components which require special libraries.  In order to accommodate these, the FieldComponent and GeneratedDialog now handle client libraries so this can be surfaced more easily.