### PR TITLE
Fix for #1699 | MCP UI doesn't work because of StackOverflowError exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1700 - MCP Forms framework now tracks client libraries required for components as needed
 
 ### Fixed
+- #1699 - MCP UI doesn't work because of StackOverflowError exception
 - #1692 - HttpCache: Refactored resource / group config extensions 
 - #1691 - Manage Controlled Process feature doesn't work because of R6 annotations
 - #1667 - Refactored the activate methods of all http cache services

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/ControlledProcessManagerServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/ControlledProcessManagerServlet.java
@@ -28,11 +28,6 @@ import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-import static org.apache.sling.api.servlets.ServletResolverConstants.SLING_SERVLET_EXTENSIONS;
-import static org.apache.sling.api.servlets.ServletResolverConstants.SLING_SERVLET_METHODS;
-import static org.apache.sling.api.servlets.ServletResolverConstants.SLING_SERVLET_RESOURCE_TYPES;
-import static org.apache.sling.api.servlets.ServletResolverConstants.SLING_SERVLET_SELECTORS;
-
 import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/model/Result.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/model/Result.java
@@ -25,18 +25,20 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Model;
 
+import java.io.Serializable;
+
 /**
  * This bean captures the commonly-collected report summary details from a controlled process
  */
 @ProviderType
 @Model(adaptables = Resource.class, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
-public class Result {
+public class Result implements Serializable {
     @Inject
     private int tasksCompleted;
     @Inject
     private Long runtime;
     @Inject
-    private Resource report;
+    private transient Resource report;
 
     /**
      * @return the runtime

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/model/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/model/package-info.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  * #L%
  */
-@Version("4.0.0")
+@Version("4.1.0")
 package com.adobe.acs.commons.mcp.model;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
Make Resource field transient in Result class
Fix for #1699