### PR TITLE
Introduce checklist fixes for passing builds with cpmp 0.5.24.

### DIFF
--- a/content/pom.xml
+++ b/content/pom.xml
@@ -59,6 +59,7 @@
                 <artifactId>content-package-maven-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
+                    <allowIndexDefinitions>true</allowIndexDefinitions>
                     <group>adobe/consulting</group>
                     <filterSource>src/main/content/META-INF/vault/filter.xml</filterSource>
                     <properties>

--- a/oakpal-checks/src/main/resources/OAKPAL-INF/checklist/acs-internal.json
+++ b/oakpal-checks/src/main/resources/OAKPAL-INF/checklist/acs-internal.json
@@ -61,6 +61,21 @@
   ],
   "forcedRoots": [
     {
+      "path": "/home/users",
+      "primaryType": "rep:AuthorizableFolder",
+      "mixinTypes": ["rep:AccessControllable"]
+    },
+    {
+      "path": "/home/users/system",
+      "primaryType": "rep:AuthorizableFolder",
+      "mixinTypes": ["rep:AccessControllable"]
+    },
+    {
+      "path": "/home/groups",
+      "primaryType": "rep:AuthorizableFolder",
+      "mixinTypes": ["rep:AccessControllable"]
+    },
+    {
       "path": "/libs/screens/player",
       "mixinTypes": [
         "granite:InternalArea"


### PR DESCRIPTION
@badvision This fixes the content module build for content-package-maven-plugin 0.5.24. 