### PR TITLE
Use dedicated path for WebDAV deployment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1699 - Updated MCP servlet to not serialize known types that would otherwise cause problems
 
 ### Changed
+- #1726 - Deploy the bundle via the dedicated DAV url
 - #1571 - Remove separate twitter bundle and use exception trapping to only register AdapterFactory when Twitter4J is available.
 - #1573 - Tag Creator - automatic detection/support of /etc/tags or /content/cq:tags root paths
 - #1578 - Asset import needs additional configuration inputs

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -85,7 +85,8 @@
                 <groupId>org.apache.sling</groupId>
                 <artifactId>maven-sling-plugin</artifactId>
                 <configuration>
-                    <slingUrl>http://${crx.host}:${crx.port}${crx.contextRoot}/apps/acs-commons/install</slingUrl>
+                    <slingUrl>http://${crx.host}:${crx.port}${crx.contextRoot}/crx/repository/crx.default</slingUrl>
+                    <slingUrlSuffix>/apps/acs-commons/install</slingUrlSuffix>
                     <deploymentMethod>WebDAV</deploymentMethod>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Fixes "Failed getting intermediate path at http://localhost:4502/apps/.
Reason: Forbidden"

This closes #1726