### PR TITLE
Fix: show/hide widgets features cannot handle complex input fields like Image or FileUpload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1700 - MCP Forms framework now tracks client libraries required for components as needed
 
 ### Fixed
+- Fix: Show/hide widgets: feature can now also show/hide complex fields like Image or FileUpload
 - #1724 - AemEnvironmentIndicatorFilterTest.testDisallowedWcmMode is failed because of caret in windows
 - #1699 - MCP UI doesn't work because of StackOverflowError exception
 - #1692 - HttpCache: Refactored resource / group config extensions 

--- a/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/showhidedialogfields/source/showhidedialogfields.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/showhidedialogfields/source/showhidedialogfields.js
@@ -99,7 +99,7 @@
     
     // unhide the target element that contains the selected value as data-showhidetargetvalue attribute
     function showTarget(target, value){
-    	$(target).filter("[data-showhidetargetvalue*='" + value + "']").each(function() {
+        $(target).filter("[data-showhidetargetvalue*='" + value + "'],:has([data-showhidetargetvalue*='" + value + "'])").each(function() {
             $(this).removeClass('hide');  //If target is a container, unhides the container
             $(this).closest('.coral-Form-fieldwrapper').removeClass('hide'); // Unhides the target field wrapper. Thus, displaying label, quicktip etc.
         });


### PR DESCRIPTION
Currently the show/hide-widgets features works only for simple dialog fields. More complex dialog fields of Coral UI using a wrapper DIV (e.g. Image, FileUpload), and the jQuery selector of show/hide-widgets will hide the field, but never unhides it.

This is because the css-class is assigned to the wrapper DIV, while the "showhidetargetvalue" is rendered at the main input field. I extended the jQuery selector to unhide also dialog-field, when they contain an input-element with showhidetargetvalue.

The following cq:dialog is an example, that works after the fix (and not before).

```
{
  "image": {
    "useHTML5": true,
    "mimeTypes": [
      "image"
    ],
    "name": "./file",
    "fieldLabel": "Image",
    "allowUpload": false,
    "sling:resourceType": "granite/ui/components/foundation/form/fileupload",
    "uploadUrl": "${suffix.path}"
  },
  "altText": {
    "name": "./altText",
    "fieldLabel": "ALT Text",
    "sling:resourceType": "granite/ui/components/foundation/form/textfield"
  },
  "enableSmallImage": {
    "cq-dialog-showhide-target": ".dch-small-image-widget",
    "name": "./enableSmallImage",
    "text": "Enable alternative Image for small screens",
    "sling:resourceType": "granite/ui/components/foundation/form/checkbox",
    "cq-dialog-checkbox-showhide": ""
  },
  "imageSmall": {
    "useHTML5": true,
    "showhidetargetvalue": true,
    "mimeTypes": [
      "image"
    ],
    "name": "./imageSmall/file",
    "class": "dch-small-image-widget",
    "fieldLabel": "Alternative Image (small screens)",
    "allowUpload": false,
    "sling:resourceType": "granite/ui/components/foundation/form/fileupload",
    "uploadUrl": "${suffix.path}"
  },
  "altTextSmall": {
    "showhidetargetvalue": true,
    "name": "./imageSmall/altText",
    "class": "dch-small-image-widget",
    "fieldLabel": "ALT Text (small screens)",
    "sling:resourceType": "granite/ui/components/foundation/form/textfield"
  }
}
```