### PR TITLE
Feature / OSGI Service Based Granite Render Condition

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/rendercondition/Aem64TemplateBasedPagePropertiesCondition.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rendercondition/Aem64TemplateBasedPagePropertiesCondition.java
@@ -1,0 +1,73 @@
+package com.adobe.acs.commons.rendercondition;
+
+import com.adobe.granite.ui.components.Config;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.Template;
+import javax.servlet.http.HttpServletRequest;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Renders page properties Granite Widget based on the current page template.
+ * Assumes that page properties console is under path: /wcm/core/content/sites/properties
+ * and that page path is passed via a request param called "item".
+ * For example, if you open page properties for page: /content/my-company/my-page, the URL would be:
+ * http://localhost:4502/mnt/overlay/wcm/core/content/sites/properties.html?item=/content/my-company/my-page
+ */
+
+@Component(
+    immediate = true,
+    property = {
+        "label=AEM 6.4 Template Based Page Properties Render Condition",
+        "description=Renders Granite Widgets in Page Properties if page template matches tha passed template path"
+    },
+    service = GraniteRenderCondition.class)
+public class Aem64TemplateBasedPagePropertiesCondition implements GraniteRenderCondition {
+
+  private static final Logger log = LoggerFactory.getLogger(Aem64TemplateBasedPagePropertiesCondition.class);
+  private static final String PAGE_PROPERTIES_CONSOLE = "wcm/core/content/sites/properties";
+
+  @Override
+  public boolean evaluate(
+      SlingHttpServletRequest slingHttpServletRequest,
+      HttpServletRequest httpServletRequest,
+      Config cfg,
+      boolean defaultValue) {
+
+    String expectedTemplatePath = cfg.get("templatePath", "");
+
+    if (slingHttpServletRequest == null
+        || httpServletRequest == null
+        || StringUtils.isBlank(expectedTemplatePath)) {
+      throw new IllegalArgumentException("One of the passed parameters is null.");
+    }
+
+    // the open console is the page properties console.
+    if (StringUtils.contains(httpServletRequest.getPathInfo(), PAGE_PROPERTIES_CONSOLE)) {
+
+      // get the actual page path
+      String pagePath = httpServletRequest.getParameter("item");
+
+      ResourceResolver resourceResolver = slingHttpServletRequest.getResourceResolver();
+
+      if (resourceResolver != null) {
+        Resource pageResource = resourceResolver.getResource(pagePath);
+        if (pageResource != null) {
+          Page page = pageResource.adaptTo(Page.class);
+          if (page != null) {
+            Template template = page.getTemplate();
+            if (template != null) {
+              return StringUtils.contains(template.getPath(), expectedTemplatePath);
+            } else log.error("Could not determine template path for page at path: {}.", pagePath);
+          } else log.error("Could not adapt resource at path: {}, to a Page.", pagePath);
+        } else log.error("Could not get page resource at path: {}. Returning default value", pagePath);
+      } else log.error("Could not get Resource Resolver. Returning default.");
+    }
+    return defaultValue;
+  }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/rendercondition/Aem64TemplateBasedPagePropertiesCondition.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rendercondition/Aem64TemplateBasedPagePropertiesCondition.java
@@ -18,13 +18,23 @@ import org.slf4j.LoggerFactory;
  * and that page path is passed via a request param called "item".
  * For example, if you open page properties for page: /content/my-company/my-page, the URL would be:
  * http://localhost:4502/mnt/overlay/wcm/core/content/sites/properties.html?item=/content/my-company/my-page
+ *
+ * Sample render:condition node:
+ *
+ * granite:rendercondition
+ *   - jcr:primaryType: "nt:unstructured",
+ *   - templatePath: "/conf/my-com/settings/wcm/templates/community-page",
+ *   - condition.name: "acs-template-based-page-properties-condition",
+ *   - sling:resourceType: "/apps/acs-commons/granite/ui/components/renderconditions/service"
+ *
  */
 
 @Component(
     immediate = true,
     property = {
         "label=AEM 6.4 Template Based Page Properties Render Condition",
-        "description=Renders Granite Widgets in Page Properties if page template matches tha passed template path"
+        "description=Renders Granite Widgets in Page Properties if page template matches tha passed template path",
+        GraniteRenderCondition.CONDITION_NAME + "=acs-template-based-page-properties-condition"
     },
     service = GraniteRenderCondition.class)
 public class Aem64TemplateBasedPagePropertiesCondition implements GraniteRenderCondition {

--- a/bundle/src/main/java/com/adobe/acs/commons/rendercondition/GraniteRenderCondition.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rendercondition/GraniteRenderCondition.java
@@ -6,12 +6,20 @@ import com.adobe.granite.ui.components.Config;
 
 /**
  * This interface is to be implemented by an OSGI service that wishes to register as a
- * Granite Render Condition. The actual render condition^ will then get the implemented service by PID
+ * Granite Render Condition. The implementation must declare an OSGI property "condition.name".
+ * The actual render condition^ will then get the implemented service by condition.name property
  * and execute the service's evaluate method to determine if the Granite Widget should be rendered.
+ *
+ * See com.adobe.acs.commons.rendercondition.Aem64TemplateBasedPagePropertiesCondition for example.
  *
  * ^Service Render condition: /apps/acs-commons/granite/ui/components/renderconditions/service/service.jsp
  */
 public interface GraniteRenderCondition {
+
+  /**
+   * An OSGI service property name used to find a particular GraniteRenderCondition service.
+   */
+  String CONDITION_NAME = "condition.name";
 
   /**
    *

--- a/bundle/src/main/java/com/adobe/acs/commons/rendercondition/GraniteRenderCondition.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rendercondition/GraniteRenderCondition.java
@@ -1,0 +1,30 @@
+package com.adobe.acs.commons.rendercondition;
+
+import javax.servlet.http.HttpServletRequest;
+import org.apache.sling.api.SlingHttpServletRequest;
+import com.adobe.granite.ui.components.Config;
+
+/**
+ * This interface is to be implemented by an OSGI service that wishes to register as a
+ * Granite Render Condition. The actual render condition^ will then get the implemented service by PID
+ * and execute the service's evaluate method to determine if the Granite Widget should be rendered.
+ *
+ * ^Service Render condition: /apps/acs-commons/granite/ui/components/renderconditions/service/service.jsp
+ */
+public interface GraniteRenderCondition {
+
+  /**
+   *
+   * @param slingHttpServletRequest The sling Request you know and love.
+   * @param httpServletRequest The Servlet Request
+   *        notably used for the method: httpServletRequest#renderedgetPathInfo, which will obtain
+   *        the path of the page where the Granite Widget being evaluated is rendered.
+   * @param componentConfig Contains all the properties on the granite:rendercondition node.
+   * @return true to show the granite widget, false otherwise.
+   */
+  boolean evaluate(
+      SlingHttpServletRequest slingHttpServletRequest,
+      HttpServletRequest httpServletRequest,
+      Config componentConfig,
+      boolean defaultValue);
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/rendercondition/GraniteRenderConditionEvaluator.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rendercondition/GraniteRenderConditionEvaluator.java
@@ -15,9 +15,9 @@ import org.slf4j.LoggerFactory;
  * Called here: /apps/acs-commons/granite/ui/components/renderconditions/service/service.jsp
  * Does the heavy lifting for the Render Condition feature. instead of putting all this code in a JSP.
  */
-public class GraniteRenderConditionUtil {
+public class GraniteRenderConditionEvaluator {
 
-  private static final Logger log = LoggerFactory.getLogger(GraniteRenderConditionUtil.class);
+  private static final Logger log = LoggerFactory.getLogger(GraniteRenderConditionEvaluator.class);
 
   /**
    * All params passed from the JSP in which this method is called.
@@ -34,7 +34,7 @@ public class GraniteRenderConditionUtil {
     Config cfg = cmp.getConfig();
 
     // get properties on the render condition
-    String servicePID = cfg.get("service.pid", null);
+    String servicePID = cfg.get(GraniteRenderCondition.CONDITION_NAME, null);
     boolean defaultValue = cfg.get("default", false);
 
     if (servicePID != null) {
@@ -58,7 +58,7 @@ public class GraniteRenderConditionUtil {
       SlingScriptHelper slingScriptHelper,
       @Nonnull String servicePID) {
 
-    String filter = "(service.pid="+ servicePID +")";
+    String filter = "(" + GraniteRenderCondition.CONDITION_NAME +"="+ servicePID +")";
     GraniteRenderCondition[] services = slingScriptHelper.getServices(GraniteRenderCondition.class, filter);
     if (ArrayUtils.isNotEmpty(services)) {
       return services[0];

--- a/bundle/src/main/java/com/adobe/acs/commons/rendercondition/GraniteRenderConditionUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rendercondition/GraniteRenderConditionUtil.java
@@ -1,0 +1,69 @@
+package com.adobe.acs.commons.rendercondition;
+
+import com.adobe.granite.ui.components.ComponentHelper;
+import com.adobe.granite.ui.components.Config;
+import javax.annotation.Nonnull;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.PageContext;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.scripting.SlingScriptHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Called here: /apps/acs-commons/granite/ui/components/renderconditions/service/service.jsp
+ * Does the heavy lifting for the Render Condition feature. instead of putting all this code in a JSP.
+ */
+public class GraniteRenderConditionUtil {
+
+  private static final Logger log = LoggerFactory.getLogger(GraniteRenderConditionUtil.class);
+
+  /**
+   * All params passed from the JSP in which this method is called.
+   * Tries to get the intended GraniteRenderCondition service and call its evaluate method.
+   * see: /apps/acs-commons/granite/ui/components/renderconditions/service/service.jsp
+   */
+  public static boolean evaluate(
+      SlingHttpServletRequest slingHttpServletRequest,
+      HttpServletRequest httpServletRequest,
+      SlingScriptHelper slingScriptHelper,
+      PageContext pageContext) {
+
+    final ComponentHelper cmp = new ComponentHelper(pageContext);
+    Config cfg = cmp.getConfig();
+
+    // get properties on the render condition
+    String servicePID = cfg.get("service.pid", null);
+    boolean defaultValue = cfg.get("default", false);
+
+    if (servicePID != null) {
+      GraniteRenderCondition condition = getRenderConditionService(slingScriptHelper, servicePID);
+      if (condition != null) {
+        return condition.evaluate(slingHttpServletRequest, httpServletRequest, cfg, defaultValue);
+      } else {
+        log.error("Could not find service with PID: {}", servicePID);
+      }
+    } else {
+      log.error("service.pid cannot be empty for an ACS Commons Service Render Condition. Returning default value: {}", defaultValue);
+    }
+    // return default value
+    return defaultValue;
+  }
+
+  /**
+   * Obtains a GraniteRenderCondition service filtered by passed servicePID string.
+   */
+  private static GraniteRenderCondition getRenderConditionService(
+      SlingScriptHelper slingScriptHelper,
+      @Nonnull String servicePID) {
+
+    String filter = "(service.pid="+ servicePID +")";
+    GraniteRenderCondition[] services = slingScriptHelper.getServices(GraniteRenderCondition.class, filter);
+    if (ArrayUtils.isNotEmpty(services)) {
+      return services[0];
+    } else {
+      return null;
+    }
+  }
+}

--- a/content/src/main/content/jcr_root/apps/acs-commons/granite/ui/components/renderconditions/service/service.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/granite/ui/components/renderconditions/service/service.jsp
@@ -1,7 +1,7 @@
 <%@include file="/libs/foundation/global.jsp"%>
 <%@page session="false"
         import="java.lang.IllegalArgumentException,
-          com.adobe.acs.commons.rendercondition.GraniteRenderConditionUtil,
+          com.adobe.acs.commons.rendercondition.GraniteRenderConditionEvaluator,
           com.adobe.granite.ui.components.rendercondition.RenderCondition,
           com.adobe.granite.ui.components.rendercondition.SimpleRenderCondition"%>
 <%--###
@@ -21,9 +21,9 @@ Template
       [granite:RenderConditionsService]
 
       /**
-       * The service.pid property of an OSGI service that implements com.adobe.acs.commons.rendercondition.GraniteRenderCondition
+       * The condition.name property of an OSGI service that implements com.adobe.acs.commons.rendercondition.GraniteRenderCondition
        */
-      - service.pid (String)
+      - condition.name (String)
 
       /**
        * The default fallback value, if anything fails (class loading, exceptions, or anything else).
@@ -33,7 +33,7 @@ Template
 ###--%>
 <sling:defineObjects/>
 <%
-  // all logic is in GraniteRenderConditionUtil class.
-  boolean vote = GraniteRenderConditionUtil.evaluate(slingRequest, request, sling, pageContext);
+  // all logic is in GraniteRenderConditionEvaluator class.
+  boolean vote = GraniteRenderConditionEvaluator.evaluate(slingRequest, request, sling, pageContext);
   request.setAttribute(RenderCondition.class.getName(), new SimpleRenderCondition(vote));
 %>

--- a/content/src/main/content/jcr_root/apps/acs-commons/granite/ui/components/renderconditions/service/service.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/granite/ui/components/renderconditions/service/service.jsp
@@ -1,0 +1,39 @@
+<%@include file="/libs/foundation/global.jsp"%>
+<%@page session="false"
+        import="java.lang.IllegalArgumentException,
+          com.adobe.acs.commons.rendercondition.GraniteRenderConditionUtil,
+          com.adobe.granite.ui.components.rendercondition.RenderCondition,
+          com.adobe.granite.ui.components.rendercondition.SimpleRenderCondition"%>
+<%--###
+
+Template
+======
+
+.. granite:servercomponent:: /apps/acs-commons/granite/ui/components/renderconditions/service
+   :rendercondition:
+
+   A condition that renders granite widgets based on a regestered service
+
+   It has the following content structure:
+
+   .. gnd:gnd::
+
+      [granite:RenderConditionsService]
+
+      /**
+       * The service.pid property of an OSGI service that implements com.adobe.acs.commons.rendercondition.GraniteRenderCondition
+       */
+      - service.pid (String)
+
+      /**
+       * The default fallback value, if anything fails (class loading, exceptions, or anything else).
+       * true: shows the granite widget. false: hides it.
+       */
+      - default (Boolean:)
+###--%>
+<sling:defineObjects/>
+<%
+  // all logic is in GraniteRenderConditionUtil class.
+  boolean vote = GraniteRenderConditionUtil.evaluate(slingRequest, request, sling, pageContext);
+  request.setAttribute(RenderCondition.class.getName(), new SimpleRenderCondition(vote));
+%>


### PR DESCRIPTION
# OSGI Service Based Granite Render Condition

A [Granite Render Condition ](https://helpx.adobe.com/experience-manager/6-4/sites/developing/using/reference-materials/granite-ui/api/jcr_root/libs/granite/ui/docs/server/rendercondition.html) that allows consumers to implement Render Conditions as an OSGI service with a dead simple API. No more fiddling with JSPs!

## How to use

### `granite:rendercondition` node definition

add a `granite:rendercondition` node under any Granite Widget as explained in the [docs](https://helpx.adobe.com/experience-manager/6-4/sites/developing/using/reference-materials/granite-ui/api/jcr_root/libs/granite/ui/docs/server/rendercondition.html. The node definition is as such:

```
granite:rendercondition: 
    - jcr:primaryType: "nt:unstructured"
    - sampleProperty: "some property value"
    - condition.name: "the-implemented-condition-service"
    - default: true
    - sling:resourceType: "/apps/acs-commons/granite/ui/components/renderconditions/service"
```

Where:

- `condition.name` is a mandatory property corresponding to the same property name on the implemented OSGI service (more on that below)
- `default` (optional) is the default render value if the implemented OSGI service fails and is also passed to the OSGI service (more on that below)
-  `sampleProperty` is just an example property. You can obtain this value in the OSGI service impl (more below)


### Implementing a render condition service

Create a new OSGI service that implements: `com.adobe.acs.commons.rendercondition.GraniteRenderCondition` and declare a property `condition.name` whose value is the name you'll use to reference this condition.

> for complete example, see: `com.adobe.acs.commons.rendercondition.Aem64TemplateBasedPagePropertiesCondition`

simple example:

```
@Component(
    immediate = true,
    property = {
        "label=Simple value-basedrender  condition,
        "description=A render condition that is evaluated based a passed boolean value called 'show'",
        GraniteRenderCondition.CONDITION_NAME + "=simple-value-based-condition"
    },
    service = GraniteRenderCondition.class)
public class SampleValueBasedRenderCondition implements GraniteRenderCondition {

    @Override
    public boolean evaluate(
        SlingHttpServletRequest slingHttpServletRequest,
        HttpServletRequest httpServletRequest,
        Config cfg,
        boolean defaultValue) {
             return cfg.get("show", true);
        }
}
```
 
You can then use that condition in a `granite:rendercondition` node such as:

```
granite:rendercondition:
    - jcr:primaryType: "nt:unstructured"
    - show: true
    - condition.name: "simple-value-based-condition"
    - sling:resourceType: "/apps/acs-commons/granite/ui/components/renderconditions/service"
```

## GraniteRenderCondition#evaluate Params:

the `GraniteRenderCondition#evaluate` method passes a few params:

-  `slingHttpServletRequest`: The sling request you know and love.
- `httpServletRequest`: The Servlet Request
   > notably used for the method: httpServletRequest#renderedgetPathInfo, which will obtain the path of the page where the Granite Widget being evaluated is rendered.
- `componentConfig`: The Component Config instance. Helpful in obtaining any properties defined on the `granite:rendercondition` node.
- `defaultValue`: The value of the `default` property on the `granite:rendercondition` node. `false` if left blank.



