### PR TITLE
Feature/test user exporter

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -443,6 +443,8 @@
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
         </dependency>
+        
+        
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.mockito</groupId>
@@ -477,6 +479,12 @@
                     <artifactId>xercesImpl</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.6</version>
+            <scope>test</scope>
         </dependency>
         <!--
         needed to override the embedded commons.osgi in org.apache.sling.models.impl

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -442,8 +442,7 @@
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-        </dependency>
-        
+        </dependency>        
         
         <!-- Test Dependencies -->
         <dependency>

--- a/bundle/src/main/java/com/adobe/acs/commons/exporters/impl/users/Parameters.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/exporters/impl/users/Parameters.java
@@ -53,35 +53,45 @@ public class Parameters {
     }
 
     public Parameters(SlingHttpServletRequest request) throws IOException {
-        final JsonObject json = new JsonParser().parse(request.getParameter("params")).getAsJsonObject();
-
-        final List<String> tmpCustomProperties = new ArrayList<String>();
-        final List<String> tmpGroups = new ArrayList<String>();
-
-        groupFilter = getString(json, GROUP_FILTER);
-
-        JsonArray groupsJSON = json.getAsJsonArray(GROUPS);
-        for (int i = 0; i < groupsJSON.size(); i++) {
-            tmpGroups.add(groupsJSON.get(i).getAsString());
-        }
-
-        this.groups = tmpGroups.toArray(new String[tmpGroups.size()]);
-
-        JsonArray customPropertiesJSON = json.getAsJsonArray(CUSTOM_PROPERTIES);
-        for (int i = 0; i < customPropertiesJSON.size(); i++) {
-            JsonObject tmp = customPropertiesJSON.get(i).getAsJsonObject();
-
-            if (tmp.has(RELATIVE_PROPERTY_PATH)) {
-                String relativePropertyPath = getString(tmp, RELATIVE_PROPERTY_PATH);
-                tmpCustomProperties.add(relativePropertyPath);
+        
+        groups = new String[] {};
+        
+        if (request.getParameter("params") != null) {
+            
+            final JsonObject json = new JsonParser().parse(request.getParameter("params")).getAsJsonObject();
+    
+            final List<String> tmpCustomProperties = new ArrayList<String>();
+            final List<String> tmpGroups = new ArrayList<String>();
+    
+            groupFilter = getString(json, GROUP_FILTER);
+    
+            JsonArray groupsJSON = json.getAsJsonArray(GROUPS);
+            for (int i = 0; i < groupsJSON.size(); i++) {
+                tmpGroups.add(groupsJSON.get(i).getAsString());
             }
+    
+            this.groups = tmpGroups.toArray(new String[tmpGroups.size()]);
+    
+            JsonArray customPropertiesJSON = json.getAsJsonArray(CUSTOM_PROPERTIES);
+            for (int i = 0; i < customPropertiesJSON.size(); i++) {
+                JsonObject tmp = customPropertiesJSON.get(i).getAsJsonObject();
+    
+                if (tmp.has(RELATIVE_PROPERTY_PATH)) {
+                    String relativePropertyPath = getString(tmp, RELATIVE_PROPERTY_PATH);
+                    tmpCustomProperties.add(relativePropertyPath);
+                }
+            }
+    
+            this.customProperties = tmpCustomProperties.toArray(new String[tmpCustomProperties.size()]);
         }
-
-        this.customProperties = tmpCustomProperties.toArray(new String[tmpCustomProperties.size()]);
     }
 
     public String[] getCustomProperties() {
-        return Arrays.copyOf(customProperties, customProperties.length);
+        if (customProperties != null) {
+            return Arrays.copyOf(customProperties, customProperties.length);
+        } else {
+            return new String[] {};
+        }
     }
 
     protected JsonArray getCustomPropertiesAsJSON() {

--- a/bundle/src/main/java/com/adobe/acs/commons/exporters/impl/users/UsersExportServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/exporters/impl/users/UsersExportServlet.java
@@ -89,11 +89,6 @@ public class UsersExportServlet extends SlingSafeMethodsServlet {
         final Csv csv = new Csv();
         final Writer writer = response.getWriter();
         csv.writeInit(writer);
-
-        Session session = request.getResourceResolver().adaptTo(Session.class);
-        if (session instanceof JackrabbitSession) {
-            JackrabbitSession jrSession = (JackrabbitSession) session;
-        }
         
         final Iterator<Resource> resources = request.getResourceResolver().findResources(QUERY, Query.JCR_SQL2);
 

--- a/bundle/src/main/java/com/adobe/acs/commons/exporters/impl/users/UsersExportServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/exporters/impl/users/UsersExportServlet.java
@@ -65,7 +65,8 @@ import static com.adobe.acs.commons.exporters.impl.users.Constants.*;
 public class UsersExportServlet extends SlingSafeMethodsServlet {
     private static final Logger log = LoggerFactory.getLogger(UsersExportServlet.class);
 
-    private static final String QUERY = "SELECT * FROM [rep:User] WHERE ISDESCENDANTNODE([/home/users]) ORDER BY [rep:principalName]";
+//    private static final String QUERY = "SELECT * FROM [rep:User] WHERE ISDESCENDANTNODE([/home/users]) ORDER BY [rep:principalName]";
+    private static final String QUERY = "SELECT * FROM [rep:User] ORDER BY [rep:principalName]";
     private static final String GROUP_DELIMITER = "|";
 
     /**

--- a/bundle/src/main/java/com/adobe/acs/commons/exporters/impl/users/UsersExportServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/exporters/impl/users/UsersExportServlet.java
@@ -65,7 +65,6 @@ import static com.adobe.acs.commons.exporters.impl.users.Constants.*;
 public class UsersExportServlet extends SlingSafeMethodsServlet {
     private static final Logger log = LoggerFactory.getLogger(UsersExportServlet.class);
 
-//    private static final String QUERY = "SELECT * FROM [rep:User] WHERE ISDESCENDANTNODE([/home/users]) ORDER BY [rep:principalName]";
     private static final String QUERY = "SELECT * FROM [rep:User] ORDER BY [rep:principalName]";
     private static final String GROUP_DELIMITER = "|";
 

--- a/bundle/src/main/java/com/adobe/acs/commons/exporters/impl/users/UsersExportServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/exporters/impl/users/UsersExportServlet.java
@@ -25,6 +25,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
+import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.Group;
 import org.apache.jackrabbit.api.security.user.UserManager;
@@ -37,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 import javax.jcr.query.Query;
 import javax.servlet.ServletException;
 import java.io.IOException;
@@ -88,6 +90,11 @@ public class UsersExportServlet extends SlingSafeMethodsServlet {
         final Writer writer = response.getWriter();
         csv.writeInit(writer);
 
+        Session session = request.getResourceResolver().adaptTo(Session.class);
+        if (session instanceof JackrabbitSession) {
+            JackrabbitSession jrSession = (JackrabbitSession) session;
+        }
+        
         final Iterator<Resource> resources = request.getResourceResolver().findResources(QUERY, Query.JCR_SQL2);
 
         // Using a HashMap to satisfy issue with duplicate results in AEM 6.1 GA

--- a/bundle/src/main/java/com/adobe/acs/commons/exporters/impl/users/UsersInitServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/exporters/impl/users/UsersInitServlet.java
@@ -50,7 +50,7 @@ import static com.adobe.acs.commons.exporters.impl.users.Constants.*;
         extensions = {"json"}
 )
 public class UsersInitServlet extends SlingSafeMethodsServlet {
-    private static final String QUERY = "SELECT * FROM [rep:Group] WHERE ISDESCENDANTNODE([/home/groups]) ORDER BY [rep:principalName]";
+    private static final String QUERY = "SELECT * FROM [rep:Group]  ORDER BY [rep:principalName]";
     private static final String KEY_TEXT = "text";
     private static final String KEY_VALUE = "value";
 

--- a/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UserExportServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UserExportServletTest.java
@@ -1,0 +1,189 @@
+package com.adobe.acs.commons.exporters.impl.users;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.jackrabbit.api.JackrabbitSession;
+import org.apache.jackrabbit.api.security.user.Group;
+import org.apache.jackrabbit.api.security.user.User;
+import org.apache.jackrabbit.api.security.user.UserManager;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+public class UserExportServletTest {
+
+    Logger LOG = LoggerFactory.getLogger(UserExportServletTest.class);
+
+    @Rule
+    public SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
+
+    UsersExportServlet servlet;
+
+    @Before
+    public void setup() throws RepositoryException, Exception {
+        
+
+        JackrabbitSession session = (JackrabbitSession) context.resourceResolver().adaptTo(Session.class);
+        UserManager um = session.getUserManager();
+        
+        context.registerAdapter(Resource.class, UserManager.class, um);
+
+        Group allUsers = um.createGroup("allusers");
+        Group users = um.createGroup("users");
+        allUsers.addMember(users);
+
+        User bob = um.createUser("bob", "bobspassword");
+        User alice = um.createUser("alice", "alicespassword");
+        User charly = um.createUser("charly", "charlyspassword");
+
+        users.addMember(bob);
+        users.addMember(alice);
+        allUsers.addMember(charly);
+
+        session.save();
+
+        servlet = new UsersExportServlet();
+    }
+
+    @Test
+    public void testWithNoParameterProvidedInRequest() throws Exception {
+        servlet.doGet(context.request(), context.response());
+        assertEquals(context.response().getStatus(), 200);
+        String output = context.response().getOutputAsString();
+        LOG.info("output = {}",output);
+
+        CSVParser parser = CSVParser.parse(output, CSVFormat.DEFAULT.withHeader());
+        
+
+        assertAllUsersPresent(parser.getRecords(), "alice","bob","charly","admin","anonymous");
+    }
+    
+    @Test
+    public void testWithGroupDirectFilter() throws Exception {
+
+        // Build parameters
+        JsonObject params = buildParameterObject("direct", "users");
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("params", params);
+        LOG.info("params = {}",params.toString());
+        
+        context.request().setParameterMap(parameters);
+        servlet.doGet(context.request(), context.response());
+        
+        assertEquals(context.response().getStatus(), 200);
+        String output = context.response().getOutputAsString();
+        LOG.info(output);
+
+        CSVParser parser = CSVParser.parse(output, CSVFormat.DEFAULT.withHeader());
+        assertAllUsersPresent(parser.getRecords(), "alice","bob");
+        
+        
+    }
+    
+    @Test
+    public void testWithGroupIndirectFilter() throws Exception {
+
+        // Build parameters
+        JsonObject params = buildParameterObject("indirect", "allusers");
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("params", params);
+        
+        context.request().setParameterMap(parameters);
+        servlet.doGet(context.request(), context.response());
+        
+        assertEquals(context.response().getStatus(), 200);
+        String output = context.response().getOutputAsString();
+
+        CSVParser parser = CSVParser.parse(output, CSVFormat.DEFAULT.withHeader());
+        assertAllUsersPresent(parser.getRecords(), "alice","bob");
+    }
+    
+    @Test
+    public void testWithGroupBothFIlter() throws Exception {
+
+        // Build parameters
+        JsonObject params = buildParameterObject("", "allusers");
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("params", params);
+        
+        context.request().setParameterMap(parameters);
+        servlet.doGet(context.request(), context.response());
+        
+        assertEquals(context.response().getStatus(), 200);
+        String output = context.response().getOutputAsString();
+
+        CSVParser parser = CSVParser.parse(output, CSVFormat.DEFAULT.withHeader());
+        assertAllUsersPresent(parser.getRecords(), "alice","bob","charly");
+
+    }
+    
+    
+    
+
+    /**
+     * Build the JSON parameter structure
+     * @param groupFilter
+     * @param group
+     * @return
+     */
+    JsonObject buildParameterObject(String groupFilter,String group) {
+        JsonObject params = new JsonObject();
+        params.addProperty("groupFilter", groupFilter);
+        JsonArray groups = new JsonArray();
+        groups.add(new JsonPrimitive(group));
+        params.add("groups", groups);
+
+        JsonArray customProperties = new JsonArray();
+        JsonObject o = new JsonObject();
+        o.addProperty("relPropertyPath", "abc");
+
+        customProperties.add(o);
+        params.add("customProperties", customProperties);
+        
+        return params;
+    }
+    
+    
+    void assertAllUsersPresent (List<CSVRecord> records, String...users) {
+        assertEquals(records.size(), users.length);
+        
+        Set<String> presentUserIds = new HashSet<>();
+        for (CSVRecord item : records) {
+            presentUserIds.add(item.get("User ID"));
+        }
+        
+        for (String id : users) {
+            assertTrue(presentUserIds.contains(id));
+        }
+        
+        
+    }
+    
+    
+
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UserExportServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UserExportServletTest.java
@@ -53,8 +53,6 @@ import com.google.gson.JsonPrimitive;
 
 public class UserExportServletTest {
 
-    private static final Logger LOG = LoggerFactory.getLogger(UserExportServletTest.class);
-
     @Rule
     public SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
 
@@ -63,7 +61,6 @@ public class UserExportServletTest {
     @Before
     public void setup() throws RepositoryException, Exception {
         
-
         JackrabbitSession session = (JackrabbitSession) context.resourceResolver().adaptTo(Session.class);
         UserManager um = session.getUserManager();
         
@@ -82,7 +79,6 @@ public class UserExportServletTest {
         allUsers.addMember(charly);
 
         session.save();
-
         servlet = new UsersExportServlet();
     }
 
@@ -91,11 +87,8 @@ public class UserExportServletTest {
         servlet.doGet(context.request(), context.response());
         assertEquals(context.response().getStatus(), 200);
         String output = context.response().getOutputAsString();
-        LOG.info("output = {}",output);
 
         CSVParser parser = CSVParser.parse(output, CSVFormat.DEFAULT.withHeader());
-        
-
         assertAllUsersPresent(parser.getRecords(), "alice","bob","charly","admin","anonymous");
     }
     
@@ -107,19 +100,15 @@ public class UserExportServletTest {
 
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("params", params);
-        LOG.info("params = {}",params.toString());
         
         context.request().setParameterMap(parameters);
         servlet.doGet(context.request(), context.response());
         
         assertEquals(context.response().getStatus(), 200);
         String output = context.response().getOutputAsString();
-        LOG.info(output);
 
         CSVParser parser = CSVParser.parse(output, CSVFormat.DEFAULT.withHeader());
         assertAllUsersPresent(parser.getRecords(), "alice","bob");
-        
-        
     }
     
     @Test
@@ -158,7 +147,6 @@ public class UserExportServletTest {
 
         CSVParser parser = CSVParser.parse(output, CSVFormat.DEFAULT.withHeader());
         assertAllUsersPresent(parser.getRecords(), "alice","bob","charly");
-
     }
     
     
@@ -200,9 +188,6 @@ public class UserExportServletTest {
             assertTrue(presentUserIds.contains(id));
         }
         
-        
     }
     
-    
-
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UserExportServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UserExportServletTest.java
@@ -151,7 +151,7 @@ public class UserExportServletTest {
      * @param group
      * @return
      */
-    JsonObject buildParameterObject(String groupFilter,String group) {
+    public static JsonObject buildParameterObject(String groupFilter,String group) {
         JsonObject params = new JsonObject();
         params.addProperty("groupFilter", groupFilter);
         JsonArray groups = new JsonArray();

--- a/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UserExportServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UserExportServletTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.exporters.impl.users;
 
 import static org.junit.Assert.assertEquals;
@@ -34,7 +53,7 @@ import com.google.gson.JsonPrimitive;
 
 public class UserExportServletTest {
 
-    Logger LOG = LoggerFactory.getLogger(UserExportServletTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(UserExportServletTest.class);
 
     @Rule
     public SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
@@ -169,7 +188,7 @@ public class UserExportServletTest {
     }
     
     
-    void assertAllUsersPresent (List<CSVRecord> records, String...users) {
+    void assertAllUsersPresent(List<CSVRecord> records, String...users) {
         assertEquals(records.size(), users.length);
         
         Set<String> presentUserIds = new HashSet<>();

--- a/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UsersInitServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UsersInitServletTest.java
@@ -43,13 +43,9 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
 public class UsersInitServletTest {
-
-    private static final Logger LOG = LoggerFactory.getLogger(UsersInitServletTest.class);
     
     @Rule
     public SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
-
-    
     
     @Before
     public void setup() throws Exception {
@@ -67,9 +63,6 @@ public class UsersInitServletTest {
         context.build().resource("/report",props).commit();
         
         context.request().setResource(context.resourceResolver().getResource("/report"));
-        
-        
-        
     }
     
     
@@ -77,7 +70,6 @@ public class UsersInitServletTest {
     public void testGroupExistence() throws Exception {
         UsersInitServlet servlet = new UsersInitServlet();
         servlet.doGet(context.request(), context.response());
-        LOG.info(context.response().getOutputAsString());
         
         JsonObject json = new JsonParser().parse(context.response().getOutputAsString()).getAsJsonObject();
         JsonObject options = json.get("options").getAsJsonObject();
@@ -85,6 +77,5 @@ public class UsersInitServletTest {
         assertEquals(2,groups.size());
         JSONAssert.assertEquals("[allusers, users]", groups.toString(),false);
     }
-    
-    
+     
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UsersInitServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UsersInitServletTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.exporters.impl.users;
 
 import static org.junit.Assert.assertEquals;
@@ -25,7 +44,7 @@ import com.google.gson.JsonParser;
 
 public class UsersInitServletTest {
 
-    Logger LOG = LoggerFactory.getLogger(UsersInitServletTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(UsersInitServletTest.class);
     
     @Rule
     public SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
@@ -58,7 +77,7 @@ public class UsersInitServletTest {
     public void testGroupExistence() throws Exception {
         UsersInitServlet servlet = new UsersInitServlet();
         servlet.doGet(context.request(), context.response());
-        LOG.info (context.response().getOutputAsString());
+        LOG.info(context.response().getOutputAsString());
         
         JsonObject json = new JsonParser().parse(context.response().getOutputAsString()).getAsJsonObject();
         JsonObject options = json.get("options").getAsJsonObject();

--- a/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UsersInitServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UsersInitServletTest.java
@@ -1,0 +1,71 @@
+package com.adobe.acs.commons.exporters.impl.users;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.jcr.Session;
+
+import org.apache.jackrabbit.api.JackrabbitSession;
+import org.apache.jackrabbit.api.security.user.UserManager;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+public class UsersInitServletTest {
+
+    Logger LOG = LoggerFactory.getLogger(UsersInitServletTest.class);
+    
+    @Rule
+    public SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
+
+    
+    
+    @Before
+    public void setup() throws Exception {
+        JackrabbitSession session = (JackrabbitSession) context.resourceResolver().adaptTo(Session.class);
+        UserManager um = session.getUserManager();
+        context.registerAdapter(Resource.class, UserManager.class, um);
+        
+        um.createGroup("allusers");
+        um.createGroup("users");
+        
+        Map<String,Object> props = new HashMap<>();
+        props.put(Constants.CUSTOM_PROPERTIES, "custom_prop");
+        props.put(Constants.GROUPS, "somegroup");
+        props.put(Constants.GROUP_FILTER, "direct");
+        context.build().resource("/report",props).commit();
+        
+        context.request().setResource(context.resourceResolver().getResource("/report"));
+        
+        
+        
+    }
+    
+    
+    @Test
+    public void testGroupExistence() throws Exception {
+        UsersInitServlet servlet = new UsersInitServlet();
+        servlet.doGet(context.request(), context.response());
+        LOG.info (context.response().getOutputAsString());
+        
+        JsonObject json = new JsonParser().parse(context.response().getOutputAsString()).getAsJsonObject();
+        JsonObject options = json.get("options").getAsJsonObject();
+        JsonArray groups = options.get("groups").getAsJsonArray();
+        assertEquals(2,groups.size());
+        JSONAssert.assertEquals("[allusers, users]", groups.toString(),false);
+    }
+    
+    
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UsersSaveServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UsersSaveServletTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.exporters.impl.users;
 
 import static org.junit.Assert.assertEquals;

--- a/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UsersSaveServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UsersSaveServletTest.java
@@ -48,7 +48,6 @@ public class UsersSaveServletTest {
         context.build().resource(PATH, props ).commit();
         Resource resource = context.resourceResolver().getResource(PATH);
         context.request().setResource(resource);
-        
     }
     
     
@@ -71,5 +70,4 @@ public class UsersSaveServletTest {
         assertEquals("abc",vm.get(Constants.CUSTOM_PROPERTIES,"default")); 
         
     }
-
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UsersSaveServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/exporters/impl/users/UsersSaveServletTest.java
@@ -1,0 +1,56 @@
+package com.adobe.acs.commons.exporters.impl.users;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class UsersSaveServletTest {
+    
+    public static final String PATH = "/report";
+    
+    @Rule
+    public SlingContext context = new SlingContext();
+    
+    
+    @Before
+    public void setup() {
+        
+        Map<String,Object> props = new HashMap<String,Object>();
+        props.put(Constants.GROUP_FILTER,"abc");
+        context.build().resource(PATH, props ).commit();
+        Resource resource = context.resourceResolver().getResource(PATH);
+        context.request().setResource(resource);
+        
+    }
+    
+    
+    @Test
+    public void testPost() throws Exception {
+        UsersSaveServlet servlet = new UsersSaveServlet();
+        Map<String,Object> params = new HashMap<>();
+        params.put("params", UserExportServletTest.buildParameterObject("direct", "somegroup"));
+        context.request().setParameterMap(params);
+        servlet.doPost(context.request(), context.response());
+        
+        assertEquals(context.response().getStatus(), 200);
+        
+        context.resourceResolver().refresh();
+        Resource resource = context.resourceResolver().getResource(PATH);
+        ValueMap vm = resource.getValueMap();
+        assertNotNull(vm);
+        assertEquals("direct",vm.get(Constants.GROUP_FILTER,"default"));
+        assertEquals("somegroup",vm.get(Constants.GROUPS,"default"));
+        assertEquals("abc",vm.get(Constants.CUSTOM_PROPERTIES,"default")); 
+        
+    }
+
+}


### PR DESCRIPTION
Added test coverage for the user exporter servlets.

NOTE: I had to change the JCR Queries which are used to find users and groups. It should not make any difference in the result, but the runtime might differ (using indexes or not).

Nevertheless, these queries should be replaced by proper calls to the JCR Usermanager which internally handles this much better than these hand-crafted queries ... 
But that's something for the next PR.

(When merging, consider to squash this PR!)