### PR TITLE
Issue #1774 Upgraded oakpal to v1.2.0 for OSGi compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## [Unreleased]
 
+### Changed
+- #1774 - Upgraded oakpal dependency to 1.2.0 to support execution in an AEM OSGi runtime.
+
 ## [4.0.0] - 2019-02-20
 
 ### Added

--- a/oakpal-checks/pom.xml
+++ b/oakpal-checks/pom.xml
@@ -25,18 +25,34 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-maven-plugin</artifactId>
+                <version>4.1.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>bnd-process</goal>
+                        </goals>
+                        <configuration>
+                            <bnd><![CDATA[
+                                Bundle-SymbolicName: com.adobe.acs.acs-aem-commons-oakpal-checks
+                                Oakpal-ModuleName: com.adobe.acs.acs-aem-commons-oakpal-checks
+                                Oakpal-Checklist: OAKPAL-INF/checklist/acs-internal.json,\
+                                    OAKPAL-INF/checklist/acs-commons-integrators.json
+                                Export-Package: com.adobe.acs.commons.oakpal.checks
+                                Import-Package: org.json;version="[20090211,20180813]",*
+                            ]]></bnd>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.1.0</version>
                 <configuration>
                     <archive>
-                        <manifestEntries>
-                            <Oakpal-ModuleName>com.adobe.acs.acs-aem-commons-oakpal-checks</Oakpal-ModuleName>
-                            <Oakpal-Checklist>
-                                OAKPAL-INF/checklist/acs-internal.json,
-                                OAKPAL-INF/checklist/acs-commons-integrators.json
-                            </Oakpal-Checklist>
-                        </manifestEntries>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
             </plugin>

--- a/oakpal-checks/src/main/java/com/adobe/acs/commons/oakpal/checks/AcsCommonsAuthorizableCompatibilityCheck.java
+++ b/oakpal-checks/src/main/java/com/adobe/acs/commons/oakpal/checks/AcsCommonsAuthorizableCompatibilityCheck.java
@@ -19,9 +19,12 @@
  */
 package com.adobe.acs.commons.oakpal.checks;
 
+import static net.adamcin.oakpal.core.JavaxJson.arrayOrEmpty;
+
 import java.util.List;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
+import javax.json.JsonObject;
 
 import net.adamcin.oakpal.core.ProgressCheck;
 import net.adamcin.oakpal.core.ProgressCheckFactory;
@@ -32,7 +35,6 @@ import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.UserManager;
 import org.apache.jackrabbit.vault.packaging.PackageId;
-import org.json.JSONObject;
 
 /**
  * Checks the authorizableId of imported {@link Authorizable} nodes to ensure they do not begin with "acs-commons".
@@ -44,9 +46,15 @@ import org.json.JSONObject;
  * compatibility check.</dd>
  * </dl>
  */
-public final class AcsCommonsAuthorizableCompatibilityCheck implements ProgressCheckFactory {
+public final class AcsCommonsAuthorizableCompatibilityCheck extends CompatBaseFactory implements ProgressCheckFactory {
     public static final String NT_REP_AUTHORIZABLE = "rep:Authorizable";
     public static final String CONFIG_SCOPE_IDS = "scopeIds";
+
+    @Override
+    public ProgressCheck newInstance(final JsonObject config) {
+        final List<Rule> scopeIds = Rule.fromJsonArray(arrayOrEmpty(config, CONFIG_SCOPE_IDS));
+        return new Check(scopeIds);
+    }
 
     static final class Check extends SimpleProgressCheck {
         private final List<Rule> scopeIds;
@@ -88,11 +96,5 @@ public final class AcsCommonsAuthorizableCompatibilityCheck implements ProgressC
                 }
             }
         }
-    }
-
-    @Override
-    public ProgressCheck newInstance(final JSONObject config) {
-        final List<Rule> scopeIds = Rule.fromJSON(config.optJSONArray(CONFIG_SCOPE_IDS));
-        return new Check(scopeIds);
     }
 }

--- a/oakpal-checks/src/main/java/com/adobe/acs/commons/oakpal/checks/CompatBaseFactory.java
+++ b/oakpal-checks/src/main/java/com/adobe/acs/commons/oakpal/checks/CompatBaseFactory.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 - 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.oakpal.checks;
 
 import javax.json.JsonObject;
@@ -16,6 +35,11 @@ import org.slf4j.LoggerFactory;
  */
 @Deprecated
 abstract class CompatBaseFactory implements ProgressCheckFactory {
+
+    /**
+     * Private subclass logger to make it clear which concrete class' deprecated method is being called.
+     */
+    @SuppressWarnings("PMD.LoggerIsNotStaticFinal")
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     /**

--- a/oakpal-checks/src/main/java/com/adobe/acs/commons/oakpal/checks/CompatBaseFactory.java
+++ b/oakpal-checks/src/main/java/com/adobe/acs/commons/oakpal/checks/CompatBaseFactory.java
@@ -11,10 +11,24 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Temporary Shim to facilitate deprecation of usages of org.json in favor of javax.json.
+ *
+ * @deprecated 4.0.0 this base class will be removed after oakpal-core drops support for org.json
  */
+@Deprecated
 abstract class CompatBaseFactory implements ProgressCheckFactory {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
+    /**
+     * Create a new instance of a ProgressCheck using the provided config object.
+     * <p>
+     * Legacy method implementation which indicates the deprecation in the logger and delegates to
+     * {@link #newInstance(JsonObject)}.
+     *
+     * @param config the org.json.JSONObject config
+     * @return the new ProgressCheck
+     * @deprecated 4.0.0 migrate usages of {@link #newInstance(JSONObject)} to {@link #newInstance(JsonObject)}
+     */
+    @Deprecated
     @Override
     public final ProgressCheck newInstance(final JSONObject config) {
         logger.info("ProgressCheckFactory.newInstance(org.json.JSONObject config) is deprecated as of 1.2.0.");
@@ -22,6 +36,15 @@ abstract class CompatBaseFactory implements ProgressCheckFactory {
         return newInstance(JavaxJson.wrap(config.toMap()).asJsonObject());
     }
 
+    /**
+     * Create a new instance of a ProgressCheck using the provided config object.
+     * <p>
+     * Overrides default interface method, which currently exists solely to facilitate deprecation of org.json, to force
+     * implementation in our own subclasses.
+     *
+     * @param config the config object
+     * @return the new ProgressCheck
+     */
     @Override
     public abstract ProgressCheck newInstance(final JsonObject config);
 

--- a/oakpal-checks/src/main/java/com/adobe/acs/commons/oakpal/checks/CompatBaseFactory.java
+++ b/oakpal-checks/src/main/java/com/adobe/acs/commons/oakpal/checks/CompatBaseFactory.java
@@ -1,0 +1,28 @@
+package com.adobe.acs.commons.oakpal.checks;
+
+import javax.json.JsonObject;
+
+import net.adamcin.oakpal.core.JavaxJson;
+import net.adamcin.oakpal.core.ProgressCheck;
+import net.adamcin.oakpal.core.ProgressCheckFactory;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Temporary Shim to facilitate deprecation of usages of org.json in favor of javax.json.
+ */
+abstract class CompatBaseFactory implements ProgressCheckFactory {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public final ProgressCheck newInstance(final JSONObject config) {
+        logger.info("ProgressCheckFactory.newInstance(org.json.JSONObject config) is deprecated as of 1.2.0.");
+        logger.info("Please use newInstance(javax.json.JsonObject config) instead.");
+        return newInstance(JavaxJson.wrap(config.toMap()).asJsonObject());
+    }
+
+    @Override
+    public abstract ProgressCheck newInstance(final JsonObject config);
+
+}

--- a/oakpal-checks/src/main/java/com/adobe/acs/commons/oakpal/checks/RecommendEnsureAuthorizable.java
+++ b/oakpal-checks/src/main/java/com/adobe/acs/commons/oakpal/checks/RecommendEnsureAuthorizable.java
@@ -19,9 +19,14 @@
  */
 package com.adobe.acs.commons.oakpal.checks;
 
+import static net.adamcin.oakpal.core.JavaxJson.arrayOrEmpty;
+import static net.adamcin.oakpal.core.JavaxJson.optArray;
+
+import java.util.Collections;
 import java.util.List;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
+import javax.json.JsonObject;
 
 import net.adamcin.oakpal.core.ProgressCheck;
 import net.adamcin.oakpal.core.ProgressCheckFactory;
@@ -33,7 +38,6 @@ import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.User;
 import org.apache.jackrabbit.api.security.user.UserManager;
 import org.apache.jackrabbit.vault.packaging.PackageId;
-import org.json.JSONObject;
 
 /**
  * Report explicitly-imported rep:SystemUser and rep:Group nodes as violations, to encourage migration to ACS AEM Commons
@@ -50,7 +54,7 @@ import org.json.JSONObject;
  * <dd>(default: {@link #DEFAULT_RECOMMENDATION}) provide a recommendation message.</dd>
  * </dl>
  */
-public final class RecommendEnsureAuthorizable implements ProgressCheckFactory {
+public final class RecommendEnsureAuthorizable extends CompatBaseFactory implements ProgressCheckFactory {
     public static final String NT_REP_AUTHORIZABLE = "rep:Authorizable";
     public static final String CONFIG_SEVERITY = "severity";
     public static final String CONFIG_RECOMMENDATION = "recommendation";
@@ -58,11 +62,11 @@ public final class RecommendEnsureAuthorizable implements ProgressCheckFactory {
     public static final String DEFAULT_RECOMMENDATION = "We recommend using Ensure Authorizable instead. https://adobe-consulting-services.github.io/acs-aem-commons/features/ensure-service-users/index.html";
 
     @Override
-    public ProgressCheck newInstance(final JSONObject config) throws Exception {
-        final Violation.Severity severity = Violation.Severity.valueOf(config.optString(CONFIG_SEVERITY,
+    public ProgressCheck newInstance(final JsonObject config) {
+        final Violation.Severity severity = Violation.Severity.valueOf(config.getString(CONFIG_SEVERITY,
                 Violation.Severity.MINOR.name()).toUpperCase());
-        final String recommendation = config.optString(CONFIG_RECOMMENDATION, DEFAULT_RECOMMENDATION);
-        final List<Rule> scopeIds = Rule.fromJSON(config.optJSONArray(CONFIG_SCOPE_IDS));
+        final String recommendation = config.getString(CONFIG_RECOMMENDATION, DEFAULT_RECOMMENDATION);
+        final List<Rule> scopeIds = Rule.fromJsonArray(arrayOrEmpty(config, CONFIG_SCOPE_IDS));
         return new Check(severity, recommendation, scopeIds);
     }
 

--- a/oakpal-checks/src/main/java/com/adobe/acs/commons/oakpal/checks/RecommendEnsureOakIndex.java
+++ b/oakpal-checks/src/main/java/com/adobe/acs/commons/oakpal/checks/RecommendEnsureOakIndex.java
@@ -19,9 +19,12 @@
  */
 package com.adobe.acs.commons.oakpal.checks;
 
+import static net.adamcin.oakpal.core.JavaxJson.arrayOrEmpty;
+
 import java.util.List;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
+import javax.json.JsonObject;
 
 import net.adamcin.oakpal.core.ProgressCheck;
 import net.adamcin.oakpal.core.ProgressCheckFactory;
@@ -29,7 +32,6 @@ import net.adamcin.oakpal.core.SimpleProgressCheck;
 import net.adamcin.oakpal.core.Violation;
 import net.adamcin.oakpal.core.checks.Rule;
 import org.apache.jackrabbit.vault.packaging.PackageId;
-import org.json.JSONObject;
 
 /**
  * Report explicitly-imported oak:index nodes as violations to encourage migration to ACS AEM Commons - Ensure Oak Index.
@@ -47,7 +49,7 @@ import org.json.JSONObject;
  * <dd>(default: {@link #DEFAULT_RECOMMENDATION}) provide a recommendation message.</dd>
  * </dl>
  */
-public final class RecommendEnsureOakIndex implements ProgressCheckFactory {
+public final class RecommendEnsureOakIndex extends CompatBaseFactory implements ProgressCheckFactory {
     public static final String NN_OAK_INDEX = "oak:index";
     public static final String CONFIG_SEVERITY = "severity";
     public static final String CONFIG_RECOMMENDATION = "recommendation";
@@ -55,11 +57,11 @@ public final class RecommendEnsureOakIndex implements ProgressCheckFactory {
     public static final String DEFAULT_RECOMMENDATION = "We recommend using Ensure Oak Index instead. https://adobe-consulting-services.github.io/acs-aem-commons/features/ensure-oak-index/index.html";
 
     @Override
-    public ProgressCheck newInstance(final JSONObject config) throws Exception {
-        final Violation.Severity severity = Violation.Severity.valueOf(config.optString(CONFIG_SEVERITY,
+    public ProgressCheck newInstance(final JsonObject config) {
+        final Violation.Severity severity = Violation.Severity.valueOf(config.getString(CONFIG_SEVERITY,
                 Violation.Severity.MINOR.name()).toUpperCase());
-        final String recommendation = config.optString(CONFIG_RECOMMENDATION, DEFAULT_RECOMMENDATION);
-        final List<Rule> scopePaths = Rule.fromJSON(config.optJSONArray(CONFIG_SCOPE_PATHS));
+        final String recommendation = config.getString(CONFIG_RECOMMENDATION, DEFAULT_RECOMMENDATION);
+        final List<Rule> scopePaths = Rule.fromJsonArray(arrayOrEmpty(config, CONFIG_SCOPE_PATHS));
         return new Check(severity, recommendation, scopePaths);
     }
 

--- a/oakpal-checks/src/test/java/com/adobe/acs/commons/oakpal/checks/RecommendEnsureAuthorizableTest.java
+++ b/oakpal-checks/src/test/java/com/adobe/acs/commons/oakpal/checks/RecommendEnsureAuthorizableTest.java
@@ -30,7 +30,6 @@ import net.adamcin.oakpal.core.CheckReport;
 import net.adamcin.oakpal.core.ProgressCheck;
 import net.adamcin.oakpal.core.checks.Rule;
 import net.adamcin.oakpal.testing.TestPackageUtil;
-import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <license.addJavaLicenseAfterPackage>false</license.addJavaLicenseAfterPackage>
         <sl4fj.version>1.7.21</sl4fj.version>
         <scr.plugin.version>1.26.0</scr.plugin.version>
-        <oakpal.version>1.1.13</oakpal.version>
+        <oakpal.version>1.2.0</oakpal.version>
     </properties>
 
     <build>


### PR DESCRIPTION
* added bnd-maven-plugin to oakpal-checks to make MANIFEST.MF compatible with OSGi installation
* deprecated `ProgressCheckFactory.newInstance(org.json.JSONObject)` methods in implementations and converted logic to use javax.json.JsonObject.

Resolves #1774 