### PR TITLE
Added the possibility to replace the existing host in an attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ## [3.19.0] - 2018-11-03
 
 ### Added
+- #1783 - Added the possibility to replace the existing host in an attribute
 - #1410 - Show/Hide fields and tabs based on dropdown and/or checkbox selections
 - #1446 - Renovator combines and replaces previous relocator tools in MCP
 - #1526 - Added a priority to the Action Manager and associated classes so that Actions can executed in order of priority.

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/StaticReferenceRewriteTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/StaticReferenceRewriteTransformerFactory.java
@@ -267,6 +267,10 @@ public final class StaticReferenceRewriteTransformerFactory implements Transform
         this.staticHostPattern = PropertiesUtil.toStringArray(properties.get(PROP_HOST_NAME_PATTERN), null);
         this.staticHostCount = PropertiesUtil.toInteger(properties.get(PROP_HOST_COUNT), DEFAULT_HOST_COUNT);
         this.replaceHost = PropertiesUtil.toBoolean(properties.get(PROP_REPLACE_HOST), false);
+
+        if (!this.replaceHost && !matchingPatterns.values().stream().anyMatch(str -> str.toString().startsWith("^"))) {
+            log.warn("BEWARE! Replace host is false and your regex is not anchored to the start of the string, this may result in a double host.");
+        }
     }
 
     private static Map<String, Pattern> initializeMatchingPatterns(String[] matchingPatternsProp) {

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/StaticReferenceRewriteTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/StaticReferenceRewriteTransformerFactory.java
@@ -107,7 +107,7 @@ public final class StaticReferenceRewriteTransformerFactory implements Transform
             description = "Path prefixes to rewrite.")
     private static final String PROP_PREFIXES = "prefixes";
 
-    @Property(label = "Override existing host", description = "This property allows you to override the existing host in the attribute that has to be rewritten")
+    @Property(label = "Override existing host", description = "This property allows you to override the existing host in the attribute that has to be rewritten", boolValue = false)
     private static final String PROP_REPLACE_HOST = "replaceHost";
 
     private Map<String, String[]> attributes;
@@ -120,7 +120,7 @@ public final class StaticReferenceRewriteTransformerFactory implements Transform
 
     private String[] staticHostPattern;
 
-    private Boolean replaceHost;
+    private boolean replaceHost;
 
     public Transformer createTransformer() {
         return new StaticReferenceRewriteTransformer();
@@ -231,7 +231,7 @@ public final class StaticReferenceRewriteTransformerFactory implements Transform
                     // prepend host
                     url = prependHostName(url);
                     // Added check to determine whether the existing host has to be replaced
-                    if (BooleanUtils.isTrue(this.replaceHost)) {
+                    if (this.replaceHost) {
                         int index = attrValue.indexOf("://");
                         sb.setLength(0);
                         sb.append(attrValue,0, index + 1);
@@ -245,7 +245,7 @@ public final class StaticReferenceRewriteTransformerFactory implements Transform
             }
         }
 
-        if (BooleanUtils.isFalse(this.replaceHost)) {
+        if (!this.replaceHost) {
             m.appendTail(sb);
         }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/StaticReferenceRewriteTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/StaticReferenceRewriteTransformerFactory.java
@@ -230,14 +230,16 @@ public final class StaticReferenceRewriteTransformerFactory implements Transform
                 if (url.startsWith(prefix)) {
                     // prepend host
                     url = prependHostName(url);
-                    m.appendReplacement(sb, Matcher.quoteReplacement(url));
                     // Added check to determine whether the existing host has to be replaced
                     if (BooleanUtils.isTrue(this.replaceHost)) {
-                        int index = attrValue.contains("://") ? attrValue.indexOf("://") + 1 : 0;
-                        sb.setLength(index);
+                        int index = attrValue.indexOf("://");
+                        sb.setLength(0);
+                        sb.append(attrValue,0, index + 1);
                         sb.append(url);
+                    } else {
+                        m.appendReplacement(sb, Matcher.quoteReplacement(url));
+                        // First prefix match wins
                     }
-                    // First prefix match wins
                     break;
                 }
             }

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/StaticReferenceRewriteTransformerFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/StaticReferenceRewriteTransformerFactoryTest.java
@@ -129,7 +129,7 @@ public class StaticReferenceRewriteTransformerFactoryTest {
         ctx.setProperty("attributes", new String[] { "img:src" });
         ctx.setProperty("host.pattern", "static.host.com");
         ctx.setProperty("matchingPatterns", "img:src;(\\/content\\/dam\\/.+?\\.(png|jpg))");
-        ctx.setProperty("replaceHost", "true");
+        ctx.setProperty("replaceHost", true);
 
         StaticReferenceRewriteTransformerFactory factory = new StaticReferenceRewriteTransformerFactory();
         factory.activate(ctx);
@@ -155,7 +155,7 @@ public class StaticReferenceRewriteTransformerFactoryTest {
         ctx.setProperty("attributes", new String[] { "img:src" });
         ctx.setProperty("host.pattern", "static.host.com");
         ctx.setProperty("matchingPatterns", "img:src;(\\/content\\/dam\\/.+?\\.(png|jpg))");
-        ctx.setProperty("replaceHost", "true");
+        ctx.setProperty("replaceHost", true);
 
         StaticReferenceRewriteTransformerFactory factory = new StaticReferenceRewriteTransformerFactory();
         factory.activate(ctx);

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/StaticReferenceRewriteTransformerFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/StaticReferenceRewriteTransformerFactoryTest.java
@@ -122,6 +122,58 @@ public class StaticReferenceRewriteTransformerFactoryTest {
     }
 
     @Test
+    public void test_with_prefix_and_matching_pattern_and_single_host_and_replace_host() throws Exception {
+        MockBundle bundle = new MockBundle(-1);
+        MockComponentContext ctx = new MockComponentContext(bundle);
+        ctx.setProperty("prefixes", new String[] { "/content/dam" });
+        ctx.setProperty("attributes", new String[] { "img:src" });
+        ctx.setProperty("host.pattern", "static.host.com");
+        ctx.setProperty("matchingPatterns", "img:src;(\\/content\\/dam\\/.+?\\.(png|jpg))");
+        ctx.setProperty("replaceHost", "true");
+
+        StaticReferenceRewriteTransformerFactory factory = new StaticReferenceRewriteTransformerFactory();
+        factory.activate(ctx);
+
+        Transformer transformer = factory.createTransformer();
+        transformer.setContentHandler(handler);
+
+        AttributesImpl imageWithJustSrc = new AttributesImpl();
+        imageWithJustSrc.addAttribute(null, "src", null, "CDATA", "https://www.host.com/content/dam/flower.jpg");
+        transformer.startElement(null, "img", null, imageWithJustSrc);
+
+        verify(handler, only()).startElement(isNull(String.class), eq("img"), isNull(String.class),
+                attributesCaptor.capture());
+        List<Attributes> values = attributesCaptor.getAllValues();
+        assertEquals("https://static.host.com/content/dam/flower.jpg", values.get(0).getValue(0));
+    }
+
+    @Test
+    public void test_with_prefix_and_matching_pattern_and_single_host_and_replace_host_without_protocol() throws Exception {
+        MockBundle bundle = new MockBundle(-1);
+        MockComponentContext ctx = new MockComponentContext(bundle);
+        ctx.setProperty("prefixes", new String[] { "/content/dam" });
+        ctx.setProperty("attributes", new String[] { "img:src" });
+        ctx.setProperty("host.pattern", "static.host.com");
+        ctx.setProperty("matchingPatterns", "img:src;(\\/content\\/dam\\/.+?\\.(png|jpg))");
+        ctx.setProperty("replaceHost", "true");
+
+        StaticReferenceRewriteTransformerFactory factory = new StaticReferenceRewriteTransformerFactory();
+        factory.activate(ctx);
+
+        Transformer transformer = factory.createTransformer();
+        transformer.setContentHandler(handler);
+
+        AttributesImpl imageWithJustSrc = new AttributesImpl();
+        imageWithJustSrc.addAttribute(null, "src", null, "CDATA", "//www.host.com/content/dam/flower_2.jpg");
+        transformer.startElement(null, "img", null, imageWithJustSrc);
+
+        verify(handler, only()).startElement(isNull(String.class), eq("img"), isNull(String.class),
+                attributesCaptor.capture());
+        List<Attributes> values = attributesCaptor.getAllValues();
+        assertEquals("//static.host.com/content/dam/flower_2.jpg", values.get(0).getValue(0));
+    }
+
+    @Test
     public void test_with_nostatic_class() throws Exception {
         MockBundle bundle = new MockBundle(-1);
         MockComponentContext ctx = new MockComponentContext(bundle);


### PR DESCRIPTION
In our current project we have the need to rewrite img src attributes where there is already a host present. In the current setup it does not work and it just prepends the desired host before the matched pattern, resulting in two subsequent hosts. This is not correct so we needed the possibility to replace the existing host in the attribute with the desired host.