### PR TITLE
shade embedded libraries. fixes #1786

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## [Unreleased]
 
+### Changed
+
+- #1786 - Shade embedded libraries and produce dependency-reduced pom to avoid downstream effects of embedded dependencies.
+
 ## [4.0.0] - 2019-02-20
 
 ### Added

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -64,7 +64,6 @@
                             !android.util.*,
                             *
                         </Import-Package>
-                        <Embed-Dependency>*;scope=compile;inline=true</Embed-Dependency>
                         <Sling-Model-Packages>
                             com.adobe.acs.commons.redirectmaps.models,
                             com.adobe.acs.commons.version.model,
@@ -214,6 +213,78 @@
                                     </includes>
                                 </bannedDependencies>
                             </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createSourcesJar>true</createSourcesJar>
+                            <shadeSourcesContent>true</shadeSourcesContent>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.google.guava:guava</include>
+                                    <include>com.google.guava:failureaccess</include>
+                                    <include>com.jcraft:jsch</include>
+                                    <include>com.jcraft:jzlib</include>
+                                    <include>io.jsonwebtoken:jjwt</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>acscommons.com.google</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.jcraft</pattern>
+                                    <shadedPattern>acscommons.com.jcraft</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.jsonwebtoken</pattern>
+                                    <shadedPattern>acscommons.io.jsonwebtoken</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <filters>
+                                <filter>
+                                    <artifact>com.google.guava:guava</artifact>
+                                    <includes>
+                                        <include>com/google/**</include>
+                                    </includes>
+                                </filter>
+                                <filter>
+                                    <artifact>com.google.guava:failureaccess</artifact>
+                                    <includes>
+                                        <include>com/google/**</include>
+                                    </includes>
+                                </filter>
+                                <filter>
+                                    <artifact>com.jcraft:jsch</artifact>
+                                    <includes>
+                                        <include>com/jcraft/**</include>
+                                    </includes>
+                                </filter>
+                                <filter>
+                                    <artifact>com.jcraft:jzlib</artifact>
+                                    <includes>
+                                        <include>com/jcraft/**</include>
+                                    </includes>
+                                </filter>
+                                <filter>
+                                    <artifact>io.jsonwebtoken:jjwt</artifact>
+                                    <includes>
+                                        <include>io/jsonwebtoken/**</include>
+                                    </includes>
+                                </filter>
+                            </filters>
                         </configuration>
                     </execution>
                 </executions>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -241,8 +241,12 @@
                             </artifactSet>
                             <relocations>
                                 <relocation>
-                                    <pattern>com.google</pattern>
-                                    <shadedPattern>acscommons.com.google</shadedPattern>
+                                    <pattern>com.google.common</pattern>
+                                    <shadedPattern>acscommons.com.google.common</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google.thirdparty</pattern>
+                                    <shadedPattern>acscommons.com.google.thirdparty</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.jcraft</pattern>


### PR DESCRIPTION
This is a potential fix for the issue reported in #1786. With this change, rather than simply embeddeding guava, jsch, etc. we shade (relocate) the embedded packages.

This will need some testing before merging.