### PR TITLE
Feature/httpcache combined rewriter + improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1700 - MCP Forms framework now tracks client libraries required for components as needed
 
 ### Fixed
+- #1796 - HttpCache: Added back in CombinedCacheKeyFactory
 - #1733 - Do not throw ReplicationExceptions from Dispatcher Flush Rules Preprocessor
 - #1745 - Show/hide widgets: feature can now also show/hide complex fields like Image or FileUpload
 - #1724 - AemEnvironmentIndicatorFilterTest.testDisallowedWcmMode is failed because of caret in windows

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
@@ -130,8 +130,8 @@ public class CombinedCacheConfigExtension implements HttpCacheConfigExtension {
     }
 
     protected void bindCacheConfigExtension(HttpCacheConfigExtension extension, Map<String, Object> properties) {
-        if (    extension != this &&
-                ArrayUtils.contains(cfg.httpcache_config_extension_combiner_service_pids(),properties.get(Constants.SERVICE_PID))
+        if (    extension != this
+                && ArrayUtils.contains(cfg.httpcache_config_extension_combiner_service_pids(),properties.get(Constants.SERVICE_PID))
         )
         {
             // Only accept extensions whose service.pid's are enumerated in the configuration.

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
@@ -27,9 +27,9 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.commons.osgi.Order;
 import org.apache.sling.commons.osgi.RankedServices;
 import org.osgi.framework.Constants;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.*;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +46,7 @@ import static org.apache.commons.lang.StringUtils.EMPTY;
 
 // TODO This functionality is disabled as it is not working as expected.
 
-/*
+
 @Component(
         service = {HttpCacheConfigExtension.class},
         configurationPolicy = ConfigurationPolicy.REQUIRE,
@@ -67,7 +67,6 @@ import static org.apache.commons.lang.StringUtils.EMPTY;
         ocd = CombinedCacheConfigExtension.Config.class,
         factory = true
 )
-*/
 public class CombinedCacheConfigExtension implements HttpCacheConfigExtension {
     private static final Logger log = LoggerFactory.getLogger(CombinedCacheConfigExtension.class);
 

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
@@ -1,0 +1,144 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.httpcache.config.impl;
+
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfigExtension;
+import com.adobe.acs.commons.httpcache.exception.HttpCacheRepositoryAccessException;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.commons.osgi.Order;
+import org.apache.sling.commons.osgi.RankedServices;
+import org.osgi.framework.Constants;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+import static org.apache.commons.lang.StringUtils.EMPTY;
+
+/**
+ * Aggregates multiple cache config extensions into one.
+ * This is useful when you need functionality of two or more extensions together.
+ * Instead of duplicating and merging the multiple extensions / factories into a single class, this factory can be used to combine them.
+ */
+
+// TODO This functionality is disabled as it is not working as expected.
+
+/*
+@Component(
+        service = {HttpCacheConfigExtension.class},
+        configurationPolicy = ConfigurationPolicy.REQUIRE,
+        property = {
+                Constants.SERVICE_RANKING + ":Integer=" + Integer.MIN_VALUE
+        },
+        reference = {
+                @Reference(
+                        name = "cacheConfigExtension",
+                        bind = "bindCacheConfigExtension",
+                        unbind = "unbindCacheConfigExtension",
+                        service = HttpCacheConfigExtension.class,
+                        policy = ReferencePolicy.DYNAMIC,
+                        cardinality = ReferenceCardinality.AT_LEAST_ONE)
+        }
+)
+@Designate(
+        ocd = CombinedCacheConfigExtension.Config.class,
+        factory = true
+)
+*/
+public class CombinedCacheConfigExtension implements HttpCacheConfigExtension {
+    private static final Logger log = LoggerFactory.getLogger(CombinedCacheConfigExtension.class);
+
+    @ObjectClassDefinition(
+            name = "ACS AEM Commons - HTTP Cache - Extension Combiner",
+            description = "Aggregates multiple extensions into a single referencable extension."
+    )
+    public @interface Config {
+        @AttributeDefinition(
+                name = "HttpCacheConfigExtension service PIDs",
+                description = "Service PIDs of target implementation of HttpCacheConfigExtensions to be combined and used."
+        )
+        String[] httpcache_config_extension_combiner_service_pids() default {};
+
+        @AttributeDefinition(
+                name = "Require all extensions to accept",
+                description = ""
+        )
+        boolean httpcache_config_extension_combiner_require_all_to_accept() default true;
+
+
+        @AttributeDefinition(
+                name = "Config Name"
+        )
+        String config_name() default EMPTY;
+    }
+
+    private RankedServices<HttpCacheConfigExtension> cacheConfigExtensions = new RankedServices<>(Order.ASCENDING);
+
+    private Config cfg;
+
+    @Override
+    public boolean accepts(final SlingHttpServletRequest request, final HttpCacheConfig cacheConfig) throws HttpCacheRepositoryAccessException {
+        if (!cfg.httpcache_config_extension_combiner_require_all_to_accept()) {
+            for (final HttpCacheConfigExtension extension : cacheConfigExtensions) {
+                if (extension.accepts(request, cacheConfig)) {
+                    // Return true as long as AT LEAST one extension accepts.
+                    return true;
+                }
+            }
+            return false;
+        } else {
+            for (final HttpCacheConfigExtension extension : cacheConfigExtensions) {
+                if (!extension.accepts(request, cacheConfig)) {
+                    // Return true as long as AT LEAST one extension accepts.
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    @Activate
+    @Modified
+    protected void activate(CombinedCacheConfigExtension.Config config) {
+        cfg = config;
+    }
+
+    protected void bindCacheConfigExtension(HttpCacheConfigExtension extension, Map<String, Object> properties) {
+        if (extension != this) {
+            if (ArrayUtils.contains(cfg.httpcache_config_extension_combiner_service_pids(),
+                    properties.get(Constants.SERVICE_PID))) {
+                // Only accept extensions whose service.pid's are enumerated in the configuration.
+                cacheConfigExtensions.bind(extension, properties);
+            }
+        }
+    }
+
+    protected void unbindCacheConfigExtension(HttpCacheConfigExtension extension, Map<String, Object> properties) {
+        if (extension != this) {
+            cacheConfigExtensions.unbind(extension, properties);
+        }
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
@@ -53,7 +53,8 @@ import static org.apache.commons.lang.StringUtils.EMPTY;
         service = {HttpCacheConfigExtension.class},
         configurationPolicy = ConfigurationPolicy.REQUIRE,
         property = {
-                Constants.SERVICE_RANKING + ":Integer=" + Integer.MIN_VALUE
+                Constants.SERVICE_RANKING + ":Integer=" + Integer.MIN_VALUE,
+                "webconsole.configurationFactory.nameHint=Service PIDS: [ {httpcache.config.extension.combiner.service.pids} ] Config name: [ config.name ]"
         },
         reference = {
                 @Reference(

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
@@ -115,7 +115,7 @@ public class CombinedCacheKeyFactory implements CacheKeyFactory {
         if (factory != this) {
             cacheKeyFactories.bind(factory, properties);
         } else {
-            log.error("Invalid key factory LDAP target string! Self is target(ed)! Breaking up infinite loop. Target: {}", this.cacheKeyFactoriesTarget);
+            log.error("Invalid key factory LDAP target string! Self is target(ed)! Breaking up infinite loop. Configname:  Target: {}", this.configName, this.cacheKeyFactoriesTarget);
         }
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
@@ -28,13 +28,19 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.commons.osgi.Order;
 import org.apache.sling.commons.osgi.RankedServices;
+import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.metatype.annotations.Designate;
 import java.util.Map;
 
 /**
@@ -44,9 +50,6 @@ import java.util.Map;
  * It will use existing cache key factories to create a key for each one, and put them in a list.
  */
 
-// TODO This functionality is disabled as it is not working as expected.
-
-/*
 @Component(
         service = {CacheKeyFactory.class},
         configurationPolicy = ConfigurationPolicy.REQUIRE,
@@ -68,7 +71,6 @@ import java.util.Map;
         ocd = CombinedCacheKeyFactory.Config.class,
         factory = true
 )
-*/
 public class CombinedCacheKeyFactory implements CacheKeyFactory {
 
     @ObjectClassDefinition(
@@ -115,7 +117,7 @@ public class CombinedCacheKeyFactory implements CacheKeyFactory {
         if (factory != this) {
             cacheKeyFactories.bind(factory, properties);
         } else {
-            log.error("Invalid key factory LDAP target string! Self is target(ed)! Breaking up infinite loop. Configname:  Target: {}", this.configName, this.cacheKeyFactoriesTarget);
+            log.error("Invalid key factory LDAP target string! Self is target(ed)! Breaking up infinite loop. Configname: {}  Target: {}", this.configName, this.cacheKeyFactoriesTarget);
         }
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
@@ -1,0 +1,135 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.httpcache.config.impl;
+
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;
+import com.adobe.acs.commons.httpcache.config.impl.keys.CombinedCacheKey;
+import com.adobe.acs.commons.httpcache.exception.HttpCacheKeyCreationException;
+import com.adobe.acs.commons.httpcache.keys.CacheKey;
+import com.adobe.acs.commons.httpcache.keys.CacheKeyFactory;
+import org.apache.commons.lang.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.commons.osgi.Order;
+import org.apache.sling.commons.osgi.RankedServices;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * Aggregates multiple cache key factories extensions into 1.
+ * This is useful when you need differentiation of 2 cache keys together.
+ * Instead of duplicating and merging the 2 extensions / factories into 1 class, you can leverage this class.
+ * It will use existing cache key factories to create a key for each one, and put them in a list.
+ */
+
+// TODO This functionality is disabled as it is not working as expected.
+
+/*
+@Component(
+        service = {CacheKeyFactory.class},
+        configurationPolicy = ConfigurationPolicy.REQUIRE,
+        property = {
+                Constants.SERVICE_RANKING + ":Integer=" + Integer.MIN_VALUE
+        },
+        reference = {
+                @Reference(
+                        name = "cacheKeyFactory",
+                        bind = "bindCacheKeyFactory",
+                        unbind = "unbindCacheKeyFactory",
+                        service = CacheKeyFactory.class,
+                        policy = ReferencePolicy.DYNAMIC,
+                        cardinality = ReferenceCardinality.MULTIPLE)
+        }
+
+)
+@Designate(
+        ocd = CombinedCacheKeyFactory.Config.class,
+        factory = true
+)
+*/
+public class CombinedCacheKeyFactory implements CacheKeyFactory {
+
+    @ObjectClassDefinition(
+            name = "ACS AEM Commons - HTTP Cache - CacheKeyFactory Combiner",
+            description = "Aggregates multiple extensions into a single cache key")
+    public @interface Config {
+
+        @AttributeDefinition(name = "Config Name")
+        String config_name() default StringUtils.EMPTY;
+
+        @AttributeDefinition(name = "CacheKey factory service PIDs",
+                description = "Service PID(s) of target implementation of CacheKeyFactory to be used."
+        )
+        String httpcache_config_cachekey_target();
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(CombinedCacheKeyFactory.class);
+
+    private String configName;
+    private String cacheKeyFactoriesTarget;
+
+    private RankedServices<CacheKeyFactory> cacheKeyFactories = new RankedServices<>(Order.ASCENDING);
+
+    @Override
+    public CacheKey build(SlingHttpServletRequest request, HttpCacheConfig cacheConfig) throws HttpCacheKeyCreationException {
+        return new CombinedCacheKey(request, cacheConfig, cacheKeyFactories.getList());
+    }
+
+    @Override
+    public CacheKey build(String resourcePath, HttpCacheConfig cacheConfig) throws HttpCacheKeyCreationException {
+        return new CombinedCacheKey(resourcePath, cacheConfig, cacheKeyFactories.getList());
+    }
+
+    @Override
+    public boolean doesKeyMatchConfig(CacheKey key, HttpCacheConfig cacheConfig) throws HttpCacheKeyCreationException {
+        if (!(key instanceof CombinedCacheKey)) {
+            return false;
+        }
+
+        return new CombinedCacheKey(key.getUri(), cacheConfig, cacheKeyFactories.getList()).equals(key);
+    }
+
+    protected void bindCacheKeyFactory(CacheKeyFactory factory, Map<String, Object> properties) {
+        if (factory != this) {
+            cacheKeyFactories.bind(factory, properties);
+        } else {
+            log.error("Invalid key factory LDAP target string! Self is target(ed)! Breaking up infinite loop. Target: {}", this.cacheKeyFactoriesTarget);
+        }
+    }
+
+    protected void unbindCacheKeyFactory(CacheKeyFactory factory, Map<String, Object> properties) {
+        if (factory != this) {
+            cacheKeyFactories.unbind(factory, properties);
+        }
+    }
+
+    @Activate
+    @Modified
+    protected void activate(CombinedCacheKeyFactory.Config config) {
+        this.configName = config.config_name();
+        this.cacheKeyFactoriesTarget = config.httpcache_config_cachekey_target();
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
@@ -55,7 +55,7 @@ import java.util.Map;
         configurationPolicy = ConfigurationPolicy.REQUIRE,
         property = {
                 Constants.SERVICE_RANKING + ":Integer=" + Integer.MIN_VALUE,
-                "webconsole.configurationFactory.nameHint=Service PIDS: [ {httpcache.config.extension.combiner.service.pids} ] Config name: [ config.name ]"
+                "webconsole.configurationFactory.nameHint=Service PIDS: [ {httpcache.config.cachekey.target} ] Config name: [ config.name ]"
         },
         reference = {
                 @Reference(

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
@@ -54,7 +54,8 @@ import java.util.Map;
         service = {CacheKeyFactory.class},
         configurationPolicy = ConfigurationPolicy.REQUIRE,
         property = {
-                Constants.SERVICE_RANKING + ":Integer=" + Integer.MIN_VALUE
+                Constants.SERVICE_RANKING + ":Integer=" + Integer.MIN_VALUE,
+                "webconsole.configurationFactory.nameHint=Service PIDS: [ {httpcache.config.extension.combiner.service.pids} ] Config name: [ config.name ]"
         },
         reference = {
                 @Reference(

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/keys/CombinedCacheKey.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/keys/CombinedCacheKey.java
@@ -1,0 +1,149 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.httpcache.config.impl.keys;
+
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;
+import com.adobe.acs.commons.httpcache.exception.HttpCacheKeyCreationException;
+import com.adobe.acs.commons.httpcache.keys.AbstractCacheKey;
+import com.adobe.acs.commons.httpcache.keys.CacheKey;
+import com.adobe.acs.commons.httpcache.keys.CacheKeyFactory;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Combined cache key.
+ * <p>Aggregates multiple cachekeys into 1 master key.</p>
+ */
+public class CombinedCacheKey extends AbstractCacheKey implements CacheKey, Serializable {
+
+    private static final Logger log = LoggerFactory.getLogger(CombinedCacheKey.class);
+
+    private LinkedList<CacheKey> cacheKeys;
+
+    public CombinedCacheKey(SlingHttpServletRequest request, HttpCacheConfig cacheConfig, List<CacheKeyFactory> cacheKeyFactories) {
+        super(request, cacheConfig);
+
+        this.cacheKeys = cacheKeyFactories
+                .stream()
+                .map((factory) -> createCacheKey(request, cacheConfig, factory))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toCollection(LinkedList::new));
+    }
+
+    public CombinedCacheKey(String uri, HttpCacheConfig cacheConfig, List<CacheKeyFactory> cacheKeyFactories) {
+        super(uri, cacheConfig);
+
+        this.cacheKeys = cacheKeyFactories
+                .stream()
+                .map((factory) -> createCacheKey(uri, cacheConfig, factory))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toCollection(LinkedList::new));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        boolean selfCheck = super.equals(o);
+
+        if (!selfCheck) {
+            return false;
+        }
+
+        CombinedCacheKey other = (CombinedCacheKey) o;
+
+        if (other == null) {
+            return false;
+        }
+
+        for (int i = 0; i < cacheKeys.size(); i++) {
+            CacheKey otherDelegate = other.getDelegate(i);
+            CacheKey ownDelegate = this.getDelegate(i);
+
+            if (!otherDelegate.equals(ownDelegate)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(getUri())
+                .append(getAuthenticationRequirement()).toHashCode();
+    }
+
+    private CacheKey createCacheKey(SlingHttpServletRequest request, HttpCacheConfig cacheConfig, CacheKeyFactory factory) {
+        try {
+            return factory.build(request, cacheConfig);
+        } catch (HttpCacheKeyCreationException e) {
+            log.error("Error creating cache key: ", e);
+        }
+        return null;
+    }
+
+    private CacheKey createCacheKey(String resourcePath, HttpCacheConfig cacheConfig, CacheKeyFactory factory) {
+        try {
+            return factory.build(resourcePath, cacheConfig);
+        } catch (HttpCacheKeyCreationException e) {
+            log.error("Error creating cache key: ", e);
+        }
+        return null;
+    }
+
+    private CacheKey getDelegate(int position) {
+        return cacheKeys.get(position);
+    }
+
+    @Override
+    public String toString() {
+        return this.resourcePath + " [CombinedCacheKey]";
+    }
+
+    /**
+     * For Serialization
+     **/
+    private void writeObject(ObjectOutputStream o) throws IOException {
+        parentWriteObject(o);
+        o.writeObject(cacheKeys);
+    }
+
+    /**
+     * For De serialization
+     **/
+    private void readObject(ObjectInputStream o)
+            throws IOException, ClassNotFoundException {
+
+        parentReadObject(o);
+        cacheKeys = (LinkedList<CacheKey>) o.readObject();
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineMBean.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineMBean.java
@@ -19,7 +19,10 @@
  */
 package com.adobe.acs.commons.httpcache.engine.impl;
 
+import com.adobe.acs.commons.httpcache.exception.HttpCacheKeyCreationException;
+import com.adobe.acs.commons.httpcache.exception.HttpCachePersistenceException;
 import com.adobe.granite.jmx.annotation.Description;
+import com.adobe.granite.jmx.annotation.Name;
 
 import javax.management.openmbean.OpenDataException;
 import javax.management.openmbean.TabularData;
@@ -38,5 +41,8 @@ public interface HttpCacheEngineMBean {
 
     @Description("Registered Persistence Stores")
     TabularData getRegisteredPersistenceStores() throws OpenDataException;
+
+    @Description("Invalidate")
+    void invalidateCache(@Name(value="Path") String path) throws HttpCachePersistenceException, HttpCacheKeyCreationException;
 }
 

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtensionTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtensionTest.java
@@ -66,13 +66,21 @@ public class CombinedCacheConfigExtensionTest {
         when(extension3.accepts(request, config)).thenReturn(true);
         when(extension4.accepts(request, config)).thenReturn(true);
 
+        when(ocd.httpcache_config_extension_combiner_service_pids()).thenReturn(new String[]{
+            "extension1",
+            "extension2",
+            "extension3",
+            "extension4"
+        });
+        when(ocd.httpcache_config_extension_combiner_require_all_to_accept()).thenReturn(true);
+
         underTest.activate(ocd);
     }
 
     @Test
     public void test() throws HttpCacheRepositoryAccessException {
-        underTest.bindCacheConfigExtension(extension1, mockHttpCacheConfigExtension(1L, 1));
-        underTest.bindCacheConfigExtension(extension2, mockHttpCacheConfigExtension(2L, 2));
+        underTest.bindCacheConfigExtension(extension1, mockHttpCacheConfigExtension(1L, 1,"extension1"));
+        underTest.bindCacheConfigExtension(extension2, mockHttpCacheConfigExtension(2L, 2, "extension2"));
 
         boolean accepts = underTest.accepts(request, config);
 
@@ -81,15 +89,15 @@ public class CombinedCacheConfigExtensionTest {
         verify(extension1, times(1)).accepts(request, config);
         verify(extension2, never()).accepts(request, config);
 
-        underTest.unbindCacheConfigExtension(extension1, mockHttpCacheConfigExtension(1L, 1));
-        underTest.unbindCacheConfigExtension(extension2, mockHttpCacheConfigExtension(2L, 2));
+        underTest.unbindCacheConfigExtension(extension1, mockHttpCacheConfigExtension(1L, 1,"extension1"));
+        underTest.unbindCacheConfigExtension(extension2, mockHttpCacheConfigExtension(2L, 2,"extension2"));
 
     }
 
     @Test
     public void test_accepts() throws HttpCacheRepositoryAccessException {
-        underTest.bindCacheConfigExtension(extension3, mockHttpCacheConfigExtension(1L, 1));
-        underTest.bindCacheConfigExtension(extension4, mockHttpCacheConfigExtension(2L, 2));
+        underTest.bindCacheConfigExtension(extension3, mockHttpCacheConfigExtension(1L, 1,"extension3"));
+        underTest.bindCacheConfigExtension(extension4, mockHttpCacheConfigExtension(2L, 2,"extension4"));
 
         boolean accepts = underTest.accepts(request, config);
 
@@ -98,19 +106,19 @@ public class CombinedCacheConfigExtensionTest {
         verify(extension3, times(1)).accepts(request, config);
         verify(extension4, times(1)).accepts(request, config);
 
-        underTest.unbindCacheConfigExtension(extension3, mockHttpCacheConfigExtension(1L, 1));
-        underTest.unbindCacheConfigExtension(extension4, mockHttpCacheConfigExtension(2L, 2));
+        underTest.unbindCacheConfigExtension(extension3, mockHttpCacheConfigExtension(1L, 1, "extension3"));
+        underTest.unbindCacheConfigExtension(extension4, mockHttpCacheConfigExtension(2L, 2,"extension4"));
 
 
     }
 
-    private Map<String, Object> mockHttpCacheConfigExtension(long pid, int rank) {
+    private Map<String, Object> mockHttpCacheConfigExtension(long id, int rank, String pid) {
 
         Map<String, Object> properties = new HashMap<>();
 
         properties.put(Constants.SERVICE_RANKING, rank);
-        properties.put(Constants.SERVICE_ID, pid);
-
+        properties.put(Constants.SERVICE_ID, id);
+        properties.put(Constants.SERVICE_PID, pid);
         return properties;
 
     }

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtensionTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtensionTest.java
@@ -1,0 +1,118 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.httpcache.config.impl;
+
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfigExtension;
+import com.adobe.acs.commons.httpcache.exception.HttpCacheRepositoryAccessException;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.osgi.framework.Constants;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CombinedCacheConfigExtensionTest {
+
+
+    @Mock
+    private HttpCacheConfigExtension extension1;
+    @Mock
+    private HttpCacheConfigExtension extension2;
+    @Mock
+    private HttpCacheConfigExtension extension3;
+    @Mock
+    private HttpCacheConfigExtension extension4;
+    @Mock
+    private SlingHttpServletRequest request;
+    @Mock
+    private HttpCacheConfig config;
+    @Mock
+    private CombinedCacheConfigExtension.Config ocd;
+
+    private final CombinedCacheConfigExtension underTest = new CombinedCacheConfigExtension();
+
+    @Before
+    public void init() throws HttpCacheRepositoryAccessException {
+
+        when(extension1.accepts(request, config)).thenReturn(false);
+        when(extension2.accepts(request, config)).thenReturn(false);
+        when(extension3.accepts(request, config)).thenReturn(true);
+        when(extension4.accepts(request, config)).thenReturn(true);
+
+        underTest.activate(ocd);
+    }
+
+    @Test
+    public void test() throws HttpCacheRepositoryAccessException {
+        underTest.bindCacheConfigExtension(extension1, mockHttpCacheConfigExtension(1L, 1));
+        underTest.bindCacheConfigExtension(extension2, mockHttpCacheConfigExtension(2L, 2));
+
+        boolean accepts = underTest.accepts(request, config);
+
+        assertFalse(accepts);
+
+        verify(extension1, times(1)).accepts(request, config);
+        verify(extension2, never()).accepts(request, config);
+
+        underTest.unbindCacheConfigExtension(extension1, mockHttpCacheConfigExtension(1L, 1));
+        underTest.unbindCacheConfigExtension(extension2, mockHttpCacheConfigExtension(2L, 2));
+
+    }
+
+    @Test
+    public void test_accepts() throws HttpCacheRepositoryAccessException {
+        underTest.bindCacheConfigExtension(extension3, mockHttpCacheConfigExtension(1L, 1));
+        underTest.bindCacheConfigExtension(extension4, mockHttpCacheConfigExtension(2L, 2));
+
+        boolean accepts = underTest.accepts(request, config);
+
+        assertTrue(accepts);
+
+        verify(extension3, times(1)).accepts(request, config);
+        verify(extension4, times(1)).accepts(request, config);
+
+        underTest.unbindCacheConfigExtension(extension3, mockHttpCacheConfigExtension(1L, 1));
+        underTest.unbindCacheConfigExtension(extension4, mockHttpCacheConfigExtension(2L, 2));
+
+
+    }
+
+    private Map<String, Object> mockHttpCacheConfigExtension(long pid, int rank) {
+
+        Map<String, Object> properties = new HashMap<>();
+
+        properties.put(Constants.SERVICE_RANKING, rank);
+        properties.put(Constants.SERVICE_ID, pid);
+
+        return properties;
+
+    }
+
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactoryTest.java
@@ -1,0 +1,158 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.httpcache.config.impl;
+
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;
+import com.adobe.acs.commons.httpcache.config.impl.keys.CombinedCacheKey;
+import com.adobe.acs.commons.httpcache.exception.HttpCacheKeyCreationException;
+import com.adobe.acs.commons.httpcache.keys.CacheKey;
+import com.adobe.acs.commons.httpcache.keys.CacheKeyFactory;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.osgi.framework.Constants;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CombinedCacheKeyFactoryTest {
+
+
+    public static final String RESOURCE_PATH = "/content/acs-commons/test/jcr:content/component";
+    public static final String URI = "/content/acs-commons/test/jcr:content/component.html";
+
+
+    @Mock
+    private CacheKeyFactory factory1;
+    @Mock
+    private CacheKeyFactory factory2;
+    @Mock
+    private CacheKeyFactory factory3;
+    @Mock
+    private CacheKeyFactory factory4;
+    @Mock
+    private SlingHttpServletRequest request;
+    @Mock
+    private Resource resource;
+    @Mock
+    private HttpCacheConfig config;
+    @Mock
+    private CacheKey key1;
+    @Mock
+    private CacheKey key2;
+    @Mock
+    private CacheKey key3;
+    @Mock
+    private CacheKey key4;
+    @Mock
+    private CombinedCacheKeyFactory.Config ocd;
+
+    private final CombinedCacheKeyFactory underTest = new CombinedCacheKeyFactory();
+
+    private List<CacheKeyFactory> cacheKeyFactoryList = new ArrayList();
+
+    @Before
+    public void init() throws HttpCacheKeyCreationException {
+
+        when(key1.getUri()).thenReturn(URI);
+        when(key2.getUri()).thenReturn(URI);
+        when(key3.getUri()).thenReturn(URI);
+        when(key4.getUri()).thenReturn(URI);
+
+
+        when(factory1.build(anyString(), any(HttpCacheConfig.class))).thenReturn(key1);
+        when(factory2.build(anyString(), any(HttpCacheConfig.class))).thenReturn(key2);
+        when(factory3.build(anyString(), any(HttpCacheConfig.class))).thenReturn(key3);
+        when(factory4.build(anyString(), any(HttpCacheConfig.class))).thenReturn(key4);
+
+        when(factory1.build(request, config)).thenReturn(key1);
+        when(factory2.build(request, config)).thenReturn(key2);
+        when(factory3.build(request, config)).thenReturn(key3);
+        when(factory4.build(request, config)).thenReturn(key4);
+
+        when(request.getResource()).thenReturn(resource);
+        when(request.getRequestURI()).thenReturn(URI);
+        //when(request.getRe)
+        when(resource.getPath()).thenReturn(RESOURCE_PATH);
+        underTest.activate(ocd);
+        cacheKeyFactoryList.clear();
+    }
+
+    @Test
+    public void test_no_match() throws HttpCacheKeyCreationException {
+        underTest.bindCacheKeyFactory(factory1, mockHttpCacheConfigExtension(1L, 1));
+        underTest.bindCacheKeyFactory(factory2, mockHttpCacheConfigExtension(2L, 2));
+
+        cacheKeyFactoryList.add(factory3);
+        cacheKeyFactoryList.add(factory4);
+
+        CombinedCacheKey chain = new CombinedCacheKey(request, config, cacheKeyFactoryList);
+        boolean match = underTest.doesKeyMatchConfig(chain, config);
+
+        assertFalse(match);
+
+        underTest.unbindCacheKeyFactory(factory1, mockHttpCacheConfigExtension(1L, 1));
+        underTest.unbindCacheKeyFactory(factory2, mockHttpCacheConfigExtension(2L, 2));
+
+    }
+
+    @Test
+    public void test_match() throws HttpCacheKeyCreationException {
+        underTest.bindCacheKeyFactory(factory3, mockHttpCacheConfigExtension(1L, 1));
+        underTest.bindCacheKeyFactory(factory4, mockHttpCacheConfigExtension(2L, 2));
+
+        cacheKeyFactoryList.add(factory3);
+        cacheKeyFactoryList.add(factory4);
+
+        CombinedCacheKey chain = new CombinedCacheKey(request, config, cacheKeyFactoryList);
+        boolean match = underTest.doesKeyMatchConfig(chain, config);
+
+        assertTrue(match);
+        underTest.unbindCacheKeyFactory(factory3, mockHttpCacheConfigExtension(1L, 1));
+        underTest.unbindCacheKeyFactory(factory4, mockHttpCacheConfigExtension(2L, 2));
+
+
+    }
+
+    private Map<String, Object> mockHttpCacheConfigExtension(long pid, int rank) {
+
+        Map<String, Object> properties = new HashMap<>();
+
+        properties.put(Constants.SERVICE_RANKING, rank);
+        properties.put(Constants.SERVICE_ID, pid);
+
+        return properties;
+
+    }
+
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImplTest.java
@@ -22,7 +22,7 @@ package com.adobe.acs.commons.httpcache.engine.impl;
 import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;
 import com.adobe.acs.commons.httpcache.engine.CacheContent;
 import com.adobe.acs.commons.httpcache.engine.HttpCacheServletResponseWrapper;
-import com.adobe.acs.commons.httpcache.exception.*;
+import com.adobe.acs.commons.httpcache.exception.HttpCacheException;
 import com.adobe.acs.commons.httpcache.keys.CacheKey;
 import com.adobe.acs.commons.httpcache.store.HttpCacheStore;
 import com.adobe.acs.commons.httpcache.store.mem.impl.MemTempSinkImpl;
@@ -111,7 +111,7 @@ public class HttpCacheEngineImplTest {
     }
 
     @Test
-    public void test_get_cache_config() throws HttpCacheRepositoryAccessException, HttpCacheConfigConflictException {
+    public void test_get_cache_config() throws HttpCacheException {
         SlingHttpServletRequest request = new MockSlingHttpServletRequest("/content/acs-commons/home", "my-selector", "html", "", "");
 
         when(jcrCacheConfig.getFilterScope()).thenReturn(HttpCacheConfig.FilterScope.REQUEST);
@@ -121,7 +121,7 @@ public class HttpCacheEngineImplTest {
     }
 
     @Test
-    public void test_cache_hit() throws HttpCacheRepositoryAccessException, HttpCacheConfigConflictException, HttpCacheKeyCreationException, HttpCachePersistenceException {
+    public void test_cache_hit() throws HttpCacheException{
         SlingHttpServletRequest request = new MockSlingHttpServletRequest("/content/acs-commons/home", "my-selector", "html", "", "");
 
         when(jcrCacheConfig.getFilterScope()).thenReturn(HttpCacheConfig.FilterScope.REQUEST);
@@ -139,7 +139,7 @@ public class HttpCacheEngineImplTest {
     }
 
     @Test
-    public void test_deliver_cache_content() throws HttpCacheRepositoryAccessException, HttpCacheConfigConflictException, HttpCacheKeyCreationException, HttpCachePersistenceException, HttpCacheDataStreamException, IOException {
+    public void test_deliver_cache_content() throws HttpCacheException, IOException {
         SlingHttpServletRequest request = new MockSlingHttpServletRequest("/content/acs-commons/home", "my-selector", "html", "", "");
 
         when(jcrCacheConfig.getFilterScope()).thenReturn(HttpCacheConfig.FilterScope.REQUEST);
@@ -166,7 +166,7 @@ public class HttpCacheEngineImplTest {
     }
 
     @Test
-    public void test_deliver_cache_content_outputstream() throws HttpCacheRepositoryAccessException, HttpCacheConfigConflictException, HttpCacheKeyCreationException, HttpCachePersistenceException, HttpCacheDataStreamException, IOException {
+    public void test_deliver_cache_content_outputstream() throws HttpCacheException, IOException {
         SlingHttpServletRequest request = new MockSlingHttpServletRequest("/content/acs-commons/home", "my-selector", "html", "", "");
         when(jcrCacheConfig.getFilterScope()).thenReturn(HttpCacheConfig.FilterScope.REQUEST);
         when(jcrCacheConfig.accepts(request)).thenReturn(true);
@@ -194,7 +194,7 @@ public class HttpCacheEngineImplTest {
     }
 
     @Test
-    public void test_cache_response() throws HttpCachePersistenceException, HttpCacheDataStreamException, HttpCacheKeyCreationException, HttpCacheRepositoryAccessException, HttpCacheConfigConflictException, IOException {
+    public void test_cache_response() throws HttpCacheException, IOException {
 
         SlingHttpServletRequest request = new MockSlingHttpServletRequest("/content/acs-commons/home", "my-selector", "html", "", "");
         SlingHttpServletResponse response = mock(SlingHttpServletResponse.class);

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/engine/impl/HttpCacheEngineImplTest.java
@@ -22,11 +22,7 @@ package com.adobe.acs.commons.httpcache.engine.impl;
 import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;
 import com.adobe.acs.commons.httpcache.engine.CacheContent;
 import com.adobe.acs.commons.httpcache.engine.HttpCacheServletResponseWrapper;
-import com.adobe.acs.commons.httpcache.exception.HttpCacheConfigConflictException;
-import com.adobe.acs.commons.httpcache.exception.HttpCacheDataStreamException;
-import com.adobe.acs.commons.httpcache.exception.HttpCacheKeyCreationException;
-import com.adobe.acs.commons.httpcache.exception.HttpCachePersistenceException;
-import com.adobe.acs.commons.httpcache.exception.HttpCacheRepositoryAccessException;
+import com.adobe.acs.commons.httpcache.exception.*;
 import com.adobe.acs.commons.httpcache.keys.CacheKey;
 import com.adobe.acs.commons.httpcache.store.HttpCacheStore;
 import com.adobe.acs.commons.httpcache.store.mem.impl.MemTempSinkImpl;
@@ -57,14 +53,9 @@ import java.util.Map;
 import static com.adobe.acs.commons.httpcache.store.HttpCacheStore.VALUE_JCR_CACHE_STORE_TYPE;
 import static com.adobe.acs.commons.httpcache.store.HttpCacheStore.VALUE_MEM_CACHE_STORE_TYPE;
 import static java.util.Collections.emptyMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class HttpCacheEngineImplTest {
@@ -101,18 +92,21 @@ public class HttpCacheEngineImplTest {
         when(jcrCacheConfig.isValid()).thenReturn(true);
         when(memCacheConfig.getCacheStoreName()).thenReturn(VALUE_MEM_CACHE_STORE_TYPE);
         when(jcrCacheConfig.getCacheStoreName()).thenReturn(VALUE_JCR_CACHE_STORE_TYPE);
+        when(memCacheStore.getStoreType()).thenReturn(VALUE_MEM_CACHE_STORE_TYPE);
+        when(jcrCacheStore.getStoreType()).thenReturn(VALUE_JCR_CACHE_STORE_TYPE);
+
         systemUnderTest.bindHttpCacheConfig(memCacheConfig, sharedMemConfigProps);
         systemUnderTest.bindHttpCacheConfig(jcrCacheConfig, sharedJcrConfigProps);
-        systemUnderTest.bindHttpCacheStore(memCacheStore, sharedMemConfigProps);
-        systemUnderTest.bindHttpCacheStore(jcrCacheStore, sharedJcrConfigProps);
+        systemUnderTest.bindHttpCacheStore(memCacheStore);
+        systemUnderTest.bindHttpCacheStore(jcrCacheStore);
     }
 
     @After
     public void tearDown() {
         systemUnderTest.unbindHttpCacheConfig(memCacheConfig, sharedMemConfigProps);
         systemUnderTest.unbindHttpCacheConfig(jcrCacheConfig, sharedJcrConfigProps);
-        systemUnderTest.unbindHttpCacheStore(memCacheStore, sharedMemConfigProps);
-        systemUnderTest.unbindHttpCacheStore(jcrCacheStore, sharedJcrConfigProps);
+        systemUnderTest.unbindHttpCacheStore(memCacheStore);
+        systemUnderTest.unbindHttpCacheStore(jcrCacheStore);
         systemUnderTest.deactivate(emptyMap());
     }
 


### PR DESCRIPTION
See: https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/1750

Also added a bugfix regarding the global invalidation rules not being added, and a slight MBean extension.