### PR TITLE
HttpCache: Added request path extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1778 - Added folder support to system notifications
 - #1780 - Added a new version of the XSS Taglib to support the sling XSSAPI.
 - #1783 - Added the possibility to replace the existing host in an attribute
+- #1806 - Http Cache: Added RequestPath extension
 
 ### Changed
 - #1539 - Removed unused references to the QueryBuilder API.

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/RequestPathHttpCacheConfigExtension.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/RequestPathHttpCacheConfigExtension.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.config.impl;
 
 import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;
@@ -20,9 +39,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import static java.util.Collections.emptyList;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
 
 @Component(configurationPolicy = ConfigurationPolicy.REQUIRE, service = {HttpCacheConfigExtension.class, CacheKeyFactory.class})
@@ -59,6 +80,9 @@ public class RequestPathHttpCacheConfigExtension implements HttpCacheConfigExten
         )
         String[] httpcache_config_extension_extensions_allowed();
 
+        @AttributeDefinition
+        String webconsole_configurationFactory_nameHint() default "Config name: [ {config.name}  RequestPath: [ {httpcache.config.extension.paths.allowed}]";
+
     }
 
     private static final Logger log = LoggerFactory.getLogger(RequestPathHttpCacheConfigExtension.class);
@@ -78,7 +102,7 @@ public class RequestPathHttpCacheConfigExtension implements HttpCacheConfigExten
                 && matches(selectorPatterns, requestPathInfo.getSelectorString())
                 && matches(extensionPatterns, requestPathInfo.getExtension());
 
-        log.debug("Extension {} : Passed : {} for {}}", configName, match, requestPathInfo.getResourcePath());
+        log.debug("Extension {} : Passed : {} for {}", configName, match, requestPathInfo.getResourcePath());
 
         return match;
     }
@@ -93,7 +117,7 @@ public class RequestPathHttpCacheConfigExtension implements HttpCacheConfigExten
         } else if (CollectionUtils.isNotEmpty(patternList) && StringUtils.isNotBlank(query)) {
             for (Pattern pattern : patternList) {
                 if (pattern.matcher(query).find()) {
-                    log.debug("Extension {} : Passed all patterns: {} for query: {}", patternList, query);
+                    log.debug("Extension {} : Passed all patterns: {} for query: {}",  configName, patternList, query);
                     return true;
                 }
             }
@@ -135,7 +159,7 @@ public class RequestPathHttpCacheConfigExtension implements HttpCacheConfigExten
 
     protected List<Pattern> compileToPatterns(String[] regexes) {
         if (ArrayUtils.isEmpty(regexes)) {
-            return null;
+            return emptyList();
         }
 
         List<Pattern> patterns = new ArrayList<>();

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/RequestPathHttpCacheConfigExtension.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/RequestPathHttpCacheConfigExtension.java
@@ -1,0 +1,151 @@
+package com.adobe.acs.commons.httpcache.config.impl;
+
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfigExtension;
+import com.adobe.acs.commons.httpcache.config.impl.keys.RequestPathCacheKey;
+import com.adobe.acs.commons.httpcache.keys.CacheKey;
+import com.adobe.acs.commons.httpcache.keys.CacheKeyFactory;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.request.RequestPathInfo;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.apache.commons.collections.CollectionUtils.isEmpty;
+
+@Component(configurationPolicy = ConfigurationPolicy.REQUIRE, service = {HttpCacheConfigExtension.class, CacheKeyFactory.class})
+@Designate(ocd = RequestPathHttpCacheConfigExtension.Config.class, factory = true)
+public class RequestPathHttpCacheConfigExtension implements HttpCacheConfigExtension, CacheKeyFactory {
+
+    @ObjectClassDefinition(
+            name = "ResourcePathCacheExtensionConfig - Configuration OCD object for the RequestPathHttpCacheConfigExtension",
+            description = "Extension for the ACS commons HTTP Cache. Based on resource paths, httpcache_config_extension_selectors_allowed and httpcache_config_extension_extensions_allowed."
+    )
+    public @interface Config {
+
+        @AttributeDefinition(
+                name = "Configuration Name",
+                description = "The unique identifier of this extension"
+        )
+        String config_name() default "";
+
+        @AttributeDefinition(
+                name = "Resource path patterns",
+                description = "List of resource path patterns (regex) that will be valid for caching"
+        )
+        String[] httpcache_config_extension_paths_allowed();
+
+        @AttributeDefinition(
+                name = "Selector patterns",
+                description = "List of selector patterns (regex) that will be valid for caching"
+        )
+        String[] httpcache_config_extension_selectors_allowed();
+
+        @AttributeDefinition(
+                name = "Extension patterns",
+                description = "List of extension patterns (regex) that will be valid for caching"
+        )
+        String[] httpcache_config_extension_extensions_allowed();
+
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(RequestPathHttpCacheConfigExtension.class);
+
+    protected List<Pattern> resourcePathPatterns;
+    protected List<Pattern> selectorPatterns;
+    protected List<Pattern> extensionPatterns;
+
+    protected String configName;
+
+    @Override
+    public boolean accepts(SlingHttpServletRequest request, HttpCacheConfig cacheConfig) {
+
+        RequestPathInfo requestPathInfo = request.getRequestPathInfo();
+
+        boolean match =  matches(resourcePathPatterns, requestPathInfo.getResourcePath())
+                && matches(selectorPatterns, requestPathInfo.getSelectorString())
+                && matches(extensionPatterns, requestPathInfo.getExtension());
+
+        log.debug("Extension {} : Passed : {} for {}}", configName, match, requestPathInfo.getResourcePath());
+
+        return match;
+    }
+
+
+
+
+    protected boolean matches(List<Pattern> patternList, String query) {
+        if (isEmpty(patternList)) {
+            log.debug("Extension {} : Non defined patternList {} : skipping check for query: {}", configName, patternList, query);
+            return true;
+        } else if (CollectionUtils.isNotEmpty(patternList) && StringUtils.isNotBlank(query)) {
+            for (Pattern pattern : patternList) {
+                if (pattern.matcher(query).find()) {
+                    log.debug("Extension {} : Passed all patterns: {} for query: {}", patternList, query);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public CacheKey build(SlingHttpServletRequest slingHttpServletRequest, HttpCacheConfig cacheConfig) {
+        return new RequestPathCacheKey(slingHttpServletRequest, cacheConfig);
+    }
+
+
+    @Override
+    public CacheKey build(String resourcePath, HttpCacheConfig httpCacheConfig) {
+        return new RequestPathCacheKey(resourcePath, httpCacheConfig);
+    }
+
+    @Override
+    public boolean doesKeyMatchConfig(CacheKey key, HttpCacheConfig cacheConfig) {
+
+        // Check if key is instance of GroupCacheKey.
+        if (!(key instanceof RequestPathCacheKey)) {
+            return false;
+        }
+
+        RequestPathCacheKey thatKey = (RequestPathCacheKey) key;
+
+        return new RequestPathCacheKey(thatKey.getUri(), cacheConfig).equals(key);
+    }
+
+    @Activate
+    protected void activate(RequestPathHttpCacheConfigExtension.Config config) {
+        this.configName = config.config_name();
+        this.resourcePathPatterns = compileToPatterns(config.httpcache_config_extension_paths_allowed());
+        this.extensionPatterns = compileToPatterns(config.httpcache_config_extension_extensions_allowed());
+        this.selectorPatterns = compileToPatterns(config.httpcache_config_extension_selectors_allowed());
+    }
+
+    protected List<Pattern> compileToPatterns(String[] regexes) {
+        if (ArrayUtils.isEmpty(regexes)) {
+            return null;
+        }
+
+        List<Pattern> patterns = new ArrayList<>();
+        for (String regex : regexes) {
+            if (StringUtils.isNotBlank(regex)) {
+                patterns.add(Pattern.compile(regex));
+            }
+        }
+
+        return patterns;
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/keys/RequestPathCacheKey.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/keys/RequestPathCacheKey.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.config.impl.keys;
 
 import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;
@@ -49,9 +68,9 @@ public class RequestPathCacheKey extends AbstractCacheKey implements CacheKey {
             return false;
         }
         RequestPathCacheKey that = (RequestPathCacheKey) o;
-        return Objects.equal(getSelector(), that.getSelector()) &&
-                Objects.equal(getExtension(), that.getExtension()) &&
-                Objects.equal(getResourcePath(), that.getResourcePath());
+        return Objects.equal(getSelector(), that.getSelector())
+                && Objects.equal(getExtension(), that.getExtension())
+                && Objects.equal(getResourcePath(), that.getResourcePath());
     }
 
     @Override

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/keys/RequestPathCacheKey.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/keys/RequestPathCacheKey.java
@@ -1,0 +1,75 @@
+package com.adobe.acs.commons.httpcache.config.impl.keys;
+
+import com.adobe.acs.commons.httpcache.config.HttpCacheConfig;
+import com.adobe.acs.commons.httpcache.keys.AbstractCacheKey;
+import com.adobe.acs.commons.httpcache.keys.CacheKey;
+import com.day.cq.commons.PathInfo;
+import com.google.common.base.Objects;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.request.RequestPathInfo;
+
+/**
+ * RequestPathCacheKey. Not used currently.
+ * <p>
+ * Generated keys contain resource path, selector and extension.
+ * </p>
+ *
+ * @author niek.raaijkmakers@external.cybercon.de
+ * @since 2018-05-03
+ */
+public class RequestPathCacheKey extends AbstractCacheKey implements CacheKey {
+
+    private static final long serialVersionUID = 1;
+
+    private final String selector;
+    private final String extension;
+
+    public RequestPathCacheKey(SlingHttpServletRequest request, HttpCacheConfig cacheConfig) {
+        super(request, cacheConfig);
+
+        RequestPathInfo pathInfo = request.getRequestPathInfo();
+        selector = pathInfo.getSelectorString();
+        extension = pathInfo.getExtension();
+    }
+
+    public RequestPathCacheKey(String uri, HttpCacheConfig cacheConfig) {
+        super(uri, cacheConfig);
+
+        RequestPathInfo pathInfo = new PathInfo(uri);
+        selector = pathInfo.getSelectorString();
+        extension = pathInfo.getExtension();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RequestPathCacheKey that = (RequestPathCacheKey) o;
+        return Objects.equal(getSelector(), that.getSelector()) &&
+                Objects.equal(getExtension(), that.getExtension()) &&
+                Objects.equal(getResourcePath(), that.getResourcePath());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(getSelector(), getExtension(), getResourcePath());
+    }
+
+    @Override
+    public String toString() {
+        return resourcePath + "." + selector + "." + extension;
+    }
+
+
+    public String getSelector() {
+        return selector;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/RequestPathHttpCacheConfigExtensionTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/RequestPathHttpCacheConfigExtensionTest.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.httpcache.config.impl;
 
 import com.day.cq.commons.PathInfo;
@@ -56,6 +75,11 @@ public class RequestPathHttpCacheConfigExtensionTest {
             return new String[]{
                     "html"
             };
+        }
+
+        @Override
+        public String webconsole_configurationFactory_nameHint() {
+            return null;
         }
     };
 

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/RequestPathHttpCacheConfigExtensionTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/RequestPathHttpCacheConfigExtensionTest.java
@@ -1,0 +1,115 @@
+package com.adobe.acs.commons.httpcache.config.impl;
+
+import com.day.cq.commons.PathInfo;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.lang.annotation.Annotation;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class RequestPathHttpCacheConfigExtensionTest {
+
+    @Mock
+    private SlingHttpServletRequest request;
+
+    @InjectMocks
+    private RequestPathHttpCacheConfigExtension extension;
+
+    RequestPathHttpCacheConfigExtension.Config config = new RequestPathHttpCacheConfigExtension.Config(){
+
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return null;
+        }
+
+        @Override
+        public String config_name() {
+            return "someConfig";
+        }
+
+        @Override
+        public String[] httpcache_config_extension_paths_allowed() {
+            return new String[]{
+                    "/content/acs-commons/(.*)"
+            };
+        }
+
+        @Override
+        public String[] httpcache_config_extension_selectors_allowed() {
+            return new String[]{
+                "content"
+            };
+        }
+
+        @Override
+        public String[] httpcache_config_extension_extensions_allowed() {
+            return new String[]{
+                    "html"
+            };
+        }
+    };
+
+
+
+    @Before
+    public void setUp(){
+        extension.activate(config);
+    }
+
+    @Test
+    public void test_match() {
+
+        prepRequestPathInfo("/content/acs-commons/en/homepage/jcr:content/component.content.html");
+
+        boolean actual = extension.accepts(request, null);
+
+        assertTrue(actual);
+    }
+
+    @Test
+    public void test_no_path_match() {
+
+        prepRequestPathInfo("/content/chuck-norris/en/homepage/jcr:content/component.content.html");
+
+        boolean actual = extension.accepts(request, null);
+
+        assertFalse(actual);
+    }
+
+    @Test
+    public void test_no_selector_match() {
+
+        prepRequestPathInfo("/content/acs-commons/en/homepage/jcr:content/component.body.html");
+
+        boolean actual = extension.accepts(request, null);
+
+        assertFalse(actual);
+    }
+
+    @Test
+    public void test_no_extension_match() {
+
+        prepRequestPathInfo("/content/acs-commons/en/homepage/jcr:content/component.body.json");
+
+        boolean actual = extension.accepts(request, null);
+
+        assertFalse(actual);
+    }
+
+    private void prepRequestPathInfo(String requestPathInfo){
+        PathInfo pathInfo = new PathInfo(requestPathInfo);
+        when(request.getRequestPathInfo()).thenReturn(pathInfo);
+    }
+
+
+}


### PR DESCRIPTION
Allows specifically target something like:

/content/acs-commons/en/home/jcr:content/component.cachedRendition.json

But leave out:

/content/acs-commons/en/home/jcr:content/component.html

