### PR TITLE
fix BND warnings

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -47,7 +47,6 @@
                         <Bundle-SymbolicName>com.adobe.acs.acs-aem-commons-bundle</Bundle-SymbolicName>
                         <Import-Package>
                             com.adobe.cq.dialogconversion;resolution:=optional,
-                            sun.misc.*;resolution:=optional,
                             com.amazonaws.*;resolution:=optional, <!-- only required for MCP S3 Ingestor -->
                             com.github.jknack.handlebars;resolution:=optional, <!-- only required for Report Builder -->
                             com.day.cq.replication;version="[6.4,7)", <!-- using a wider version range for forward compatibility -->

--- a/bundle/src/main/java/com/adobe/acs/commons/remoteassets/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/remoteassets/package-info.java
@@ -17,5 +17,5 @@
  * limitations under the License.
  * #L%
  */
-@aQute.bnd.annotation.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.0.0")
 package com.adobe.acs.commons.remoteassets;


### PR DESCRIPTION
* remove the unnescessary optional import of sun.misc.* (we don't use it)
* convert an aQute annotation into an OSGI annotation