### PR TITLE
Feature/httpcache combiners ldap improved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1786 - Shade embedded libraries and produce dependency-reduced pom to avoid downstream effects of embedded dependencies.
 
 ### Fixed
+- #1819 - Http Cache - Combined extensions : fixed mechanism to use LDAP syntax to bind factories
 - #1528 - Added support for 6.4/6.5 workflow instances location and fixed issue with removing workflows older than.
 - #1709 - Fixes issue with ACS AEM Commons utility page's header bars not rendering properly.
 - #1759 - Fixing the undefined error on limit object in classicui-limit-parsys.js

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
@@ -58,7 +58,7 @@ import static org.apache.commons.lang.StringUtils.EMPTY;
         },
         reference = {
                 @Reference(
-                        name = "cacheConfigExtension",
+                        name = "cacheConfigExtensions",
                         bind = "bindCacheConfigExtension",
                         unbind = "unbindCacheConfigExtension",
                         service = HttpCacheConfigExtension.class,
@@ -82,7 +82,7 @@ public class CombinedCacheConfigExtension implements HttpCacheConfigExtension {
                 name = "HttpCacheConfigExtension service PIDs",
                 description = "Service PIDs of target implementation of HttpCacheConfigExtensions to be combined and used."
         )
-        String[] httpcache_config_extension_combiner_service_pids() default {};
+        String cacheConfigExtensions_target();
 
         @AttributeDefinition(
                 name = "Require all extensions to accept",
@@ -131,9 +131,7 @@ public class CombinedCacheConfigExtension implements HttpCacheConfigExtension {
     }
 
     protected void bindCacheConfigExtension(HttpCacheConfigExtension extension, Map<String, Object> properties) {
-        if (    extension != this
-                && ArrayUtils.contains(cfg.httpcache_config_extension_combiner_service_pids(),properties.get(Constants.SERVICE_PID))
-        )
+        if (extension != this)
         {
             // Only accept extensions whose service.pid's are enumerated in the configuration.
             cacheConfigExtensions.bind(extension, properties);

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
@@ -48,6 +48,14 @@ import static org.apache.commons.lang.StringUtils.EMPTY;
  * Aggregates multiple cache config extensions into one.
  * This is useful when you need functionality of two or more extensions together.
  * Instead of duplicating and merging the multiple extensions / factories into a single class, this factory can be used to combine them.
+ *
+ *  Use as follows in your HTTP cache config to leverage multiple factories:
+ *  cacheConfigExtensions.target="
+ *             (|
+ *                 (&amp;(service.factoryPid=com.adobe.acs.commons.httpcache.config.impl.RequestPathHttpCacheConfigExtension)(config.name=someConfig))
+ *                 (&amp;(service.factoryPid=com.adobe.acs.commons.httpcache.config.impl.ResourceTypeHttpCacheConfigExtension)(config.name=someOtherConfig))
+ *             )
+ *           "
  */
 @Component(
         service = {HttpCacheConfigExtension.class},

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtension.java
@@ -62,7 +62,7 @@ import static org.apache.commons.lang.StringUtils.EMPTY;
         configurationPolicy = ConfigurationPolicy.REQUIRE,
         property = {
                 Constants.SERVICE_RANKING + ":Integer=" + Integer.MIN_VALUE,
-                "webconsole.configurationFactory.nameHint=Service PIDS: [ {httpcache.config.extension.combiner.service.pids} ] Config name: [ config.name ]"
+                "webconsole.configurationFactory.nameHint=Config name: [ config.name ]"
         },
         reference = {
                 @Reference(

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
@@ -30,17 +30,18 @@ import org.apache.sling.commons.osgi.Order;
 import org.apache.sling.commons.osgi.RankedServices;
 import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.metatype.annotations.Designate;
+
 import java.util.Map;
 
 /**
@@ -59,7 +60,7 @@ import java.util.Map;
         },
         reference = {
                 @Reference(
-                        name = "cacheKeyFactory",
+                        name = "cacheKeyFactories",
                         bind = "bindCacheKeyFactory",
                         unbind = "unbindCacheKeyFactory",
                         service = CacheKeyFactory.class,
@@ -85,14 +86,13 @@ public class CombinedCacheKeyFactory implements CacheKeyFactory {
         @AttributeDefinition(name = "CacheKey factory service PIDs",
                 description = "Service PID(s) of target implementation of CacheKeyFactory to be used."
         )
-        String httpcache_config_cachekey_target();
+        String cacheKeyFactories_target();
     }
 
     private static final Logger log = LoggerFactory.getLogger(CombinedCacheKeyFactory.class);
 
     private String configName;
-    private String cacheKeyFactoriesTarget;
-
+   
     private RankedServices<CacheKeyFactory> cacheKeyFactories = new RankedServices<>(Order.ASCENDING);
 
     @Override
@@ -118,7 +118,7 @@ public class CombinedCacheKeyFactory implements CacheKeyFactory {
         if (factory != this) {
             cacheKeyFactories.bind(factory, properties);
         } else {
-            log.error("Invalid key factory LDAP target string! Self is target(ed)! Breaking up infinite loop. Configname: {}  Target: {}", this.configName, this.cacheKeyFactoriesTarget);
+            log.error("Invalid key factory LDAP target string! Self is target(ed)! Breaking up infinite loop. Configname: {}", this.configName);
         }
     }
 
@@ -132,7 +132,6 @@ public class CombinedCacheKeyFactory implements CacheKeyFactory {
     @Modified
     protected void activate(CombinedCacheKeyFactory.Config config) {
         this.configName = config.config_name();
-        this.cacheKeyFactoriesTarget = config.httpcache_config_cachekey_target();
     }
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
@@ -64,7 +64,7 @@ import java.util.Map;
         configurationPolicy = ConfigurationPolicy.REQUIRE,
         property = {
                 Constants.SERVICE_RANKING + ":Integer=" + Integer.MIN_VALUE,
-                "webconsole.configurationFactory.nameHint=Service PIDS: [ {httpcache.config.cachekey.target} ] Config name: [ config.name ]"
+                "webconsole.configurationFactory.nameHint=Config name: [ config.name ]"
         },
         reference = {
                 @Reference(
@@ -100,7 +100,7 @@ public class CombinedCacheKeyFactory implements CacheKeyFactory {
     private static final Logger log = LoggerFactory.getLogger(CombinedCacheKeyFactory.class);
 
     private String configName;
-   
+
     private RankedServices<CacheKeyFactory> cacheKeyFactories = new RankedServices<>(Order.ASCENDING);
 
     @Override

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheKeyFactory.java
@@ -49,6 +49,14 @@ import java.util.Map;
  * This is useful when you need differentiation of 2 cache keys together.
  * Instead of duplicating and merging the 2 extensions / factories into 1 class, you can leverage this class.
  * It will use existing cache key factories to create a key for each one, and put them in a list.
+ *
+ *  Use as follows in your HTTP cache config to leverage multiple factories:
+ *  cacheConfigFactories.target="
+ *             (|
+ *                 (&amp;(service.factoryPid=com.adobe.acs.commons.httpcache.config.impl.RequestPathHttpCacheConfigExtension)(config.name=someConfig))
+ *                 (&amp;(service.factoryPid=com.adobe.acs.commons.httpcache.config.impl.ResourceTypeHttpCacheConfigExtension)(config.name=someOtherConfig))
+ *             )
+ *           "
  */
 
 @Component(

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtensionTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/CombinedCacheConfigExtensionTest.java
@@ -65,13 +65,7 @@ public class CombinedCacheConfigExtensionTest {
         when(extension2.accepts(request, config)).thenReturn(false);
         when(extension3.accepts(request, config)).thenReturn(true);
         when(extension4.accepts(request, config)).thenReturn(true);
-
-        when(ocd.httpcache_config_extension_combiner_service_pids()).thenReturn(new String[]{
-            "extension1",
-            "extension2",
-            "extension3",
-            "extension4"
-        });
+        
         when(ocd.httpcache_config_extension_combiner_require_all_to_accept()).thenReturn(true);
 
         underTest.activate(ocd);


### PR DESCRIPTION
Changed the combined http cache factory / extension combiners to a pure LDAP syntax based solution.
This has the benefit of being able to filter on properties as well leveraging the LDAP syntax and therefore being able to narrow down on properties as well.

Example:

cacheConfigExtensions.target="
            (|
                (&amp;(service.factoryPid=com.adobe.acs.commons.httpcache.config.impl.RequestPathHttpCacheConfigExtension)(config.name=someConfig))
                (&amp;(service.factoryPid=com.adobe.acs.commons.httpcache.config.impl.ResourceTypeHttpCacheConfigExtension)(config.name=someConfig))
            )
          "