### PR TITLE
Initial commit of sql2scorer servlet to satisfy #1825.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1780 - Added a new version of the XSS Taglib to support the sling XSSAPI.
 - #1783 - Added the possibility to replace the existing host in an attribute
 - #1806 - Http Cache: Added RequestPath extension
+- #1825 - Added sql2scorer JSON servlet to provide oak:scoreExplanation details for JCR-SQL2 queries.
 
 ### Changed
 - #1539 - Removed unused references to the QueryBuilder API.

--- a/bundle/src/main/java/com/adobe/acs/commons/oak/sql2scorer/impl/servlets/ExplainScoreServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/oak/sql2scorer/impl/servlets/ExplainScoreServlet.java
@@ -73,7 +73,9 @@ import org.osgi.service.component.annotations.Component;
  * possible to treat the score explanation as a special case in the UI.
  * <p>
  * The first element of each row, therefore, contains the text of the score explanation, which is a pre-formatted string
- * with new lines and a 2-space shift-width indent.
+ * with new lines and a 2-space shift-width indent. If a fulltext score is not computed for the query,
+ * i.e. because the statement did not use the 'contains()' function or because the plan selected a non-lucene index, the
+ * first element will contain the JSON null value.
  * <p>
  * For example, if you were to submit the following query:
  * <p>

--- a/bundle/src/main/java/com/adobe/acs/commons/oak/sql2scorer/impl/servlets/ExplainScoreServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/oak/sql2scorer/impl/servlets/ExplainScoreServlet.java
@@ -1,0 +1,262 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2019 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.oak.sql2scorer.impl.servlets;
+
+import static java.util.Optional.ofNullable;
+
+import java.io.IOException;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import javax.jcr.PropertyType;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.query.InvalidQueryException;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryManager;
+import javax.jcr.query.QueryResult;
+import javax.jcr.query.Row;
+import javax.jcr.query.RowIterator;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import org.apache.jackrabbit.util.ISO8601;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * This servlet submits a JCR-SQL2 query with an additional oak:scoreExplanation column that contains the explanation of
+ * the Lucene fulltext score, where applicable. Also executes the "explain" command to provide the index plan used in the
+ * same JSON response.
+ *
+ * The query result is returned as rows, not nodes, which means jcr:path must actually be selected in the query if it is
+ * to be returned as a column.
+ *
+ * This servlet is intended to be used as a tool for development and exploration of oak:index definitions, and is not
+ * designed for running arbitrary queries, since the oak:scoreExplanation column will add considerable cost to each
+ * operation.
+ *
+ * The response JSON object contains 4 properties:
+ * - stmt: the JCR-SQL2 query statement, as executed
+ * - plan: the 'explain' plan, which identifies the index used and the filter expression
+ * - cols: an array of column names specified in the executed query statement
+ * - rows: a 2-dimensional array of query result rows, as in '.rows[result index][column index]'. Each row has as many
+ *         array elements as there are elements in the .cols array. A non-existing value for a row in a particular
+ *         column will be represented by the json {@code null} value.
+ *
+ * The first column will always be 'oak:scoreExplanation', i.e. .cols[0] === 'oak:scoreExplanation', in order to make it
+ * possible to treat the score explanation as a special case in the UI.
+ *
+ * The first element of each row, therefore, contains the text of the score explanation, which is a pre-formatted string
+ * with new lines and a 2-space shift-width indent.
+ *
+ * For example, if you were to submit the following query:
+ *
+ *  select [jcr:path] from [cq:Page] where contains(*, 'we-retail')
+ *
+ * Your plan might be something like:
+ *
+ *  [cq:Page] as [cq:Page] /* lucene:cqPageLucene(/oak:index/cqPageLucene) +:fulltext:we +:fulltext:retail
+ *                            ft:("we-retail") where contains([cq:Page].[*], 'we-retail')
+ *
+ * You might get an explanation similar to this for the first result:
+ *
+ * <pre>
+ * 4.255377 = (MATCH) sum of:
+ *   2.0704787 = (MATCH) weight(:fulltext:we in 80137) [DefaultSimilarity], result of:
+ *     2.0704787 = score(doc=80137,freq=2.0 = termFreq=2.0
+ * ), product of:
+ *       0.6975356 = queryWeight, product of:
+ *         4.1977777 = idf(docFreq=6362, maxDocs=155754)
+ *         0.16616783 = queryNorm
+ *       2.968277 = fieldWeight in 80137, product of:
+ *         1.4142135 = tf(freq=2.0), with freq of:
+ *           2.0 = termFreq=2.0
+ *         4.1977777 = idf(docFreq=6362, maxDocs=155754)
+ *         0.5 = fieldNorm(doc=80137)
+ *   2.1848981 = (MATCH) weight(:fulltext:retail in 80137) [DefaultSimilarity], result of:
+ *     2.1848981 = score(doc=80137,freq=2.0 = termFreq=2.0
+ * ), product of:
+ *       0.7165501 = queryWeight, product of:
+ *         4.312207 = idf(docFreq=5674, maxDocs=155754)
+ *         0.16616783 = queryNorm
+ *       3.049191 = fieldWeight in 80137, product of:
+ *         1.4142135 = tf(freq=2.0), with freq of:
+ *           2.0 = termFreq=2.0
+ *         4.312207 = idf(docFreq=5674, maxDocs=155754)
+ *         0.5 = fieldNorm(doc=80137)
+ * </pre>
+ */
+@Component(property = {
+        "sling.servlet.resourceTypes="+ExplainScoreServlet.RT_SQL2SCORER,
+        "sling.servlet.methods=POST",
+        "sling.servlet.selectors=sql2scorer",
+        "sling.servlet.extensions=json"
+}, service = Servlet.class)
+public class ExplainScoreServlet extends SlingAllMethodsServlet {
+    static final String RT_SQL2SCORER = "acs-commons/components/utilities/sql2scorer";
+    static final String P_STATEMENT = "statement";
+    static final String P_LIMIT = "limit";
+    static final String P_OFFSET = "offset";
+
+    @Override
+    protected void doPost(@Nonnull final SlingHttpServletRequest request,
+                          @Nonnull final SlingHttpServletResponse response) throws ServletException, IOException {
+
+        response.setContentType("application/json;charset=utf-8");
+
+        final long limit = ofNullable(request.getParameter(P_LIMIT))
+                .map(Long::valueOf).orElse(10L);
+        final long offset = ofNullable(request.getParameter(P_OFFSET))
+                .map(Long::valueOf).orElse(0L);
+
+        try {
+            final Session session = request.getResourceResolver().adaptTo(Session.class);
+            if (session == null) {
+                throw new ServletException("failed to get a JCR session from the request");
+            }
+
+            final QueryManager qm = session.getWorkspace().getQueryManager();
+
+            final String rawStatement = request.getParameter(P_STATEMENT);
+            if (rawStatement == null) {
+                JsonObject obj = new JsonObject();
+                obj.addProperty("error", "please submit a valid JCR-SQL2 query in the `statement` parameter.");
+                response.getWriter().write(obj.toString());
+                return;
+            }
+
+            try {
+                Query query = qm.createQuery(rawStatement, Query.JCR_SQL2);
+                query.setLimit(1L);
+                query.execute();
+            } catch (final InvalidQueryException iqe) {
+                JsonObject obj = new JsonObject();
+                obj.addProperty("error", "please submit a valid JCR-SQL2 query in the `statement` parameter: "
+                        + iqe.getMessage());
+                response.getWriter().write(obj.toString());
+                return;
+            }
+
+            final String statement = rawStatement.replaceFirst("(?i)SELECT",
+                    "SELECT [oak:scoreExplanation],");
+
+            final Query query = qm.createQuery(statement, Query.JCR_SQL2);
+
+            query.setLimit(limit);
+            query.setOffset(offset);
+
+            Gson json = new GsonBuilder().registerTypeHierarchyAdapter(Query.class, new QueryExecutingTypeAdapter(qm)).create();
+
+            response.getWriter().write(json.toJson(query));
+        } catch (final RepositoryException e) {
+            JsonObject obj = new JsonObject();
+            obj.addProperty("error", e.getMessage());
+            response.getWriter().write(obj.toString());
+        }
+    }
+
+    class QueryExecutingTypeAdapter extends TypeAdapter<Query> {
+        final QueryManager qm;
+
+        QueryExecutingTypeAdapter(final QueryManager qm) {
+            this.qm = qm;
+        }
+
+        @Override
+        public void write(final JsonWriter jsonWriter, final Query query) throws IOException {
+            try {
+                final QueryResult queryResult = query.execute();
+                final Query explainQuery = qm.createQuery("explain " + query.getStatement(),
+                        Query.JCR_SQL2);
+                final QueryResult explainResult = explainQuery.execute();
+
+                final Optional<Row> planRow = ofNullable(explainResult.getRows())
+                        .filter(RowIterator::hasNext).map(RowIterator::nextRow);
+
+                jsonWriter.beginObject();
+                jsonWriter.name("stmt").value(query.getStatement());
+                if (planRow.isPresent()) {
+                    jsonWriter.name("plan").value(planRow.get().getValue("plan").getString());
+                }
+                jsonWriter.name("cols");
+                jsonWriter.beginArray();
+                for (String column : queryResult.getColumnNames()) {
+                    jsonWriter.value(column);
+                }
+                jsonWriter.endArray();
+                jsonWriter.name("rows");
+                jsonWriter.beginArray();
+                for (RowIterator rowIt = queryResult.getRows(); rowIt.hasNext(); ) {
+                    final Row row = rowIt.nextRow();
+                    jsonWriter.beginArray();
+                    for (Value value : row.getValues()) {
+                        writeValue(jsonWriter, value);
+                    }
+                    jsonWriter.endArray();
+                }
+                jsonWriter.endArray();
+                jsonWriter.endObject();
+            } catch (final RepositoryException e) {
+                throw new IOException(e);
+            }
+        }
+
+        @Override
+        public Query read(final JsonReader jsonReader) throws IOException {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        private void writeValue(JsonWriter writer, Value v) throws IOException, RepositoryException {
+            if (v == null) {
+                writer.nullValue();
+            } else {
+                switch (v.getType()) {
+                    case PropertyType.BINARY:
+                        writer.value("(binary value)");
+                        break;
+                    case PropertyType.BOOLEAN:
+                        writer.value(v.getBoolean());
+                        break;
+                    case PropertyType.DATE:
+                        writer.value(ISO8601.format(v.getDate()));
+                        break;
+                    case PropertyType.LONG:
+                        writer.value(v.getLong());
+                        break;
+                    case PropertyType.DECIMAL:
+                    case PropertyType.DOUBLE:
+                        writer.value(v.getDecimal().toPlainString());
+                        break;
+                    default:
+                        writer.value(v.getString());
+                }
+            }
+        }
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/oak/sql2scorer/impl/servlets/ExplainScoreServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/oak/sql2scorer/impl/servlets/ExplainScoreServlet.java
@@ -153,8 +153,8 @@ public class ExplainScoreServlet extends SlingAllMethodsServlet {
 
         try {
             final Session session = request.getResourceResolver().adaptTo(Session.class);
-            if (session == null) {
-                throw new ServletException("failed to get a JCR session from the request");
+            if (session == null || !session.isLive()) {
+                throw new RepositoryException("failed to get a live JCR session from the request");
             }
 
             final QueryManager qm = session.getWorkspace().getQueryManager();
@@ -239,11 +239,11 @@ public class ExplainScoreServlet extends SlingAllMethodsServlet {
         }
 
         @Override
-        public Query read(final JsonReader jsonReader) throws IOException {
+        public Query read(final JsonReader jsonReader) {
             throw new UnsupportedOperationException("not implemented");
         }
 
-        private void writeValue(JsonWriter writer, Value v) throws IOException, RepositoryException {
+        void writeValue(JsonWriter writer, Value v) throws IOException, RepositoryException {
             if (v == null) {
                 writer.nullValue();
             } else {

--- a/bundle/src/test/java/com/adobe/acs/commons/oak/sql2scorer/impl/servlets/ExplainScoreServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/oak/sql2scorer/impl/servlets/ExplainScoreServletTest.java
@@ -1,0 +1,125 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2019 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.oak.sql2scorer.impl.servlets;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import org.apache.sling.servlethelpers.MockSlingHttpServletRequest;
+import org.apache.sling.servlethelpers.MockSlingHttpServletResponse;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExplainScoreServletTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExplainScoreServletTest.class);
+
+    @Rule
+    public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
+
+    @Test
+    public void test_doPost_noParams() throws Exception {
+        ExplainScoreServlet servlet = new ExplainScoreServlet();
+        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(context.resourceResolver());
+        MockSlingHttpServletResponse response = new MockSlingHttpServletResponse();
+
+        servlet.doPost(request, response);
+        Gson gson = new Gson();
+        JsonObject json = gson.fromJson(response.getOutputAsString(), JsonObject.class);
+        assertTrue("response should have error key", json.has("error"));
+
+        LOGGER.info("response string: {}", json.get("error").getAsString());
+    }
+
+    @Test
+    public void test_doPost_xpath_fail() throws Exception {
+        ExplainScoreServlet servlet = new ExplainScoreServlet();
+        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(context.resourceResolver());
+        MockSlingHttpServletResponse response = new MockSlingHttpServletResponse();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("statement", "//element(*, cq:Page)");
+        request.setParameterMap(params);
+
+        servlet.doPost(request, response);
+        Gson gson = new Gson();
+        JsonObject json = gson.fromJson(response.getOutputAsString(), JsonObject.class);
+        assertTrue("response should have error key", json.has("error"));
+
+        LOGGER.info("response string: {}", json.get("error").getAsString());
+        assertTrue("error should contain 'ParseException'",
+                json.get("error").getAsString().contains("ParseException"));
+    }
+
+    @Test
+    public void test_doPost_sql2_happy_no_score() throws Exception {
+        ExplainScoreServlet servlet = new ExplainScoreServlet();
+        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(context.resourceResolver());
+        MockSlingHttpServletResponse response = new MockSlingHttpServletResponse();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("statement", "select [jcr:path] from [nt:base] where ISSAMENODE([nt:base], '/')");
+        params.put("limit", "1");
+        params.put("offset", "0");
+        request.setParameterMap(params);
+
+        servlet.doPost(request, response);
+        Gson gson = new Gson();
+        JsonObject json = gson.fromJson(response.getOutputAsString(), JsonObject.class);
+        assertFalse("response should not have error key", json.has("error"));
+
+        assertTrue("response should have stmt key", json.has("stmt"));
+        LOGGER.info("stmt: {}", json.get("stmt").getAsString());
+        assertTrue("stmt should contain 'oak:scoreExplanation'",
+                json.get("stmt").getAsString().contains("oak:scoreExplanation"));
+
+        assertTrue("response should have plan key", json.has("plan"));
+        LOGGER.info("plan: {}", json.get("plan").getAsString());
+        assertTrue("plan should contain 'traverse'",
+                json.get("plan").getAsString().contains("traverse"));
+
+        assertTrue("response should have cols key", json.has("cols"));
+        LOGGER.info("cols: {}", json.get("cols"));
+        assertTrue("cols should contain 'oak:scoreExplanation'",
+                json.get("cols").getAsJsonArray().contains(new JsonPrimitive("oak:scoreExplanation")));
+        assertTrue("cols should contain 'jcr:path'",
+                json.get("cols").getAsJsonArray().contains(new JsonPrimitive("jcr:path")));
+
+        assertTrue("response should have rows key", json.has("rows"));
+        LOGGER.info("rows: {}", json.get("rows"));
+        assertTrue("rows should not be empty", json.get("rows").getAsJsonArray().size() > 0);
+        assertTrue("rows[0][0] should contain JsonElement.nullValue()",
+                json.get("rows").getAsJsonArray().get(0).getAsJsonArray().get(0).isJsonNull());
+        assertEquals("rows[0][1] should be the root path", "/",
+                json.get("rows").getAsJsonArray().get(0).getAsJsonArray().get(1).getAsString());
+    }
+
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/oak/sql2scorer/impl/servlets/ExplainScoreServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/oak/sql2scorer/impl/servlets/ExplainScoreServletTest.java
@@ -98,12 +98,13 @@ public class ExplainScoreServletTest {
 
     @Test
     public void test_doPost_sql2_fail_logout() throws Exception {
-        ExplainScoreServlet servlet = new ExplainScoreServlet();
-        MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(context.resourceResolver());
-        MockSlingHttpServletResponse response = new MockSlingHttpServletResponse();
-
-        Map<String, Object> params = new HashMap<>();
+        final Map<String, Object> params = new HashMap<>();
         params.put("statement", "select * from [nt:base]");
+
+        final ExplainScoreServlet servlet = new ExplainScoreServlet();
+        final MockSlingHttpServletRequest request = new MockSlingHttpServletRequest(context.resourceResolver());
+        final MockSlingHttpServletResponse response = new MockSlingHttpServletResponse();
+
         request.setParameterMap(params);
 
         final Session jcr = context.resourceResolver().adaptTo(Session.class);
@@ -171,15 +172,15 @@ public class ExplainScoreServletTest {
         final Query mockQuery = mock(Query.class);
         when(mockQuery.execute()).thenThrow(new RepositoryException("I am a RepositoryException!"));
 
-        boolean caughtIOException = false;
+        boolean caughtException = false;
         try {
             adapter.write(mockWriter, mockQuery);
         } catch (final IOException e) {
-            caughtIOException = true;
+            caughtException = true;
         }
 
         assertTrue("adapter.write() should throw IOException when RepositoryException is encountered",
-                caughtIOException);
+                caughtException);
     }
 
     @Test
@@ -190,15 +191,15 @@ public class ExplainScoreServletTest {
                 servlet.new QueryExecutingTypeAdapter(session.getWorkspace().getQueryManager());
         final JsonReader mockReader = mock(JsonReader.class);
 
-        boolean caughtUOException = false;
+        boolean caughtException = false;
         try {
             adapter.read(mockReader);
         } catch (final UnsupportedOperationException e) {
-            caughtUOException = true;
+            caughtException = true;
         }
 
         assertTrue("adapter.read() should throw UnsupportedOperationException when called",
-                caughtUOException);
+                caughtException);
     }
 
     @Test


### PR DESCRIPTION
Not sure how to begin with a UI for this. Hoping to spark some interest and maybe find a willing collaborator.

```bash
curl -u admin:admin  \
  http://localhost:4502/libs/acs-commons/components/utilities/sql2scorer/sql2scorer.json.POST.servlet \
  -Fstatement="select [jcr:path] from [cq:Page] where contains(*, 'we-retail')" \
  -Flimit=1  | jq .
```
```json
{
  "stmt": "SELECT [oak:scoreExplanation], [jcr:path] from [cq:Page] where contains(*, 'we-retail')",
  "plan": "[cq:Page] as [cq:Page] /* lucene:cqPageLucene(/oak:index/cqPageLucene) +:fulltext:we +:fulltext:retail ft:(\"we-retail\") where contains([cq:Page].[*], 'we-retail') */",
  "cols": [
    "oak:scoreExplanation",
    "jcr:path"
  ],
  "rows": [
    [
      "4.255551 = (MATCH) sum of:\n  2.070566 = (MATCH) weight(:fulltext:we in 80137) [DefaultSimilarity], result of:\n    2.070566 = score(doc=80137,freq=2.0 = termFreq=2.0\n), product of:\n      0.69753605 = queryWeight, product of:\n        4.1979513 = idf(docFreq=6362, maxDocs=155781)\n        0.16616106 = queryNorm\n      2.9683998 = fieldWeight in 80137, product of:\n        1.4142135 = tf(freq=2.0), with freq of:\n          2.0 = termFreq=2.0\n        4.1979513 = idf(docFreq=6362, maxDocs=155781)\n        0.5 = fieldNorm(doc=80137)\n  2.184985 = (MATCH) weight(:fulltext:retail in 80137) [DefaultSimilarity], result of:\n    2.184985 = score(doc=80137,freq=2.0 = termFreq=2.0\n), product of:\n      0.71654975 = queryWeight, product of:\n        4.312381 = idf(docFreq=5674, maxDocs=155781)\n        0.16616106 = queryNorm\n      3.0493135 = fieldWeight in 80137, product of:\n        1.4142135 = tf(freq=2.0), with freq of:\n          2.0 = termFreq=2.0\n        4.312381 = idf(docFreq=5674, maxDocs=155781)\n        0.5 = fieldNorm(doc=80137)\n",
      "/content/screens/we-retail"
    ]
  ]
}
```


```bash
curl -u admin:admin  \
  http://localhost:4502/libs/acs-commons/components/utilities/sql2scorer/sql2scorer.json.POST.servlet \
  -Fstatement="select [jcr:path] from [cq:Page] where contains(*, 'we-retail')" \
  -Flimit=1  | jq --raw-output '.rows[0][0]'
```
```
4.255551 = (MATCH) sum of:
  2.070566 = (MATCH) weight(:fulltext:we in 80137) [DefaultSimilarity], result of:
    2.070566 = score(doc=80137,freq=2.0 = termFreq=2.0
), product of:
      0.69753605 = queryWeight, product of:
        4.1979513 = idf(docFreq=6362, maxDocs=155781)
        0.16616106 = queryNorm
      2.9683998 = fieldWeight in 80137, product of:
        1.4142135 = tf(freq=2.0), with freq of:
          2.0 = termFreq=2.0
        4.1979513 = idf(docFreq=6362, maxDocs=155781)
        0.5 = fieldNorm(doc=80137)
  2.184985 = (MATCH) weight(:fulltext:retail in 80137) [DefaultSimilarity], result of:
    2.184985 = score(doc=80137,freq=2.0 = termFreq=2.0
), product of:
      0.71654975 = queryWeight, product of:
        4.312381 = idf(docFreq=5674, maxDocs=155781)
        0.16616106 = queryNorm
      3.0493135 = fieldWeight in 80137, product of:
        1.4142135 = tf(freq=2.0), with freq of:
          2.0 = termFreq=2.0
        4.312381 = idf(docFreq=5674, maxDocs=155781)
        0.5 = fieldNorm(doc=80137)
```