### PR TITLE
Fix broken Report page header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1791 - Fixed Asset Folder Creator to support non-string cell types (ie. Numeric)
 - #1800 - Make sure all pending changes are committed in Fast Action Manager when saveInterval isn't 1
 - #1805 - Fixing the unit tests of the Variant class that may fail on unusual OS locale settings
+- #1833 - Fixes issue with ACS AEM Commons utility report page's header bar not rendering properly.
 
 ## [4.0.0] - 2019-02-20
 

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/page-compare/page-compare.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/page-compare/page-compare.jsp
@@ -53,7 +53,7 @@
         <coral-shell-header-home class="globalnav-toggle"
                                  data-globalnav-toggle-href="/"
                                  role="heading"
-                                 aria-level="2"
+                                 aria-level="2">
             <a is="coral-shell-homeanchor"
                style="display: inline-block; padding-right: 0;"
                icon="adobeExperienceManagerColor"

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/report-builder/report-page/report-page.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/report-builder/report-page/report-page.jsp
@@ -59,9 +59,26 @@
     </head>
 
     <body class="acs-commons-page coral--light">
+        <coral-shell-header
+                class="coral--dark granite-shell-header coral3-Shell-header"
+                role="region"
+                aria-label="Header Bar"
+                aria-hidden="false">
+            <coral-shell-header-home class="globalnav-toggle"
+                                     data-globalnav-toggle-href="/"
+                                     role="heading"
+                                     aria-level="2">
+                <a is="coral-shell-homeanchor"
+                   style="display: inline-block; padding-right: 0;"
+                   icon="adobeExperienceManagerColor"
+                   href="/"
+                   class="coral3-Shell-homeAnchor"><coral-icon class="coral3-Icon coral3-Shell-homeAnchor-icon coral3-Icon--sizeM coral3-Icon--adobeExperienceManagerColor" icon="adobeExperienceManagerColor" size="M" role="img" aria-label="adobe experience manager color"></coral-icon>
+                    <coral-shell-homeanchor-label>Adobe Experience Manager</coral-shell-homeanchor-label>
+                </a>
+                <span style="line-height: 2.375rem;">/ ACS AEM Commons / Reports / ${pageTitle}</span>
+            </coral-shell-header-home>
+        </coral-shell-header>
         <div id="acs-commons-${component.name}-app">
-            <header acs-coral-tools-header data-context-path="${request.contextPath}" data-page-path="${pagePath}.html" data-title="${pageTitle}"></header>
-
             <cq:include script="includes/notifications.jsp"/>
 
             <div class="page" role="main">


### PR DESCRIPTION
Same as in https://github.com/Adobe-Consulting-Services/acs-aem-commons/pull/1785 but for a single report page.