### PR TITLE
Make remote asset sync always use the US locale for parsing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1805 - Fixing the unit tests of the Variant class that may fail on unusual OS locale settings
 - #1833 - Fixes issue with ACS AEM Commons utility report page's header bar not rendering properly.
 - #1840 - Fixed UI issue with User Exporter to allow removal of all properties.
+- #1855 - Remote asset sync functionality couldn't sync date properties unless the OS language was set to English.
 
 ## [4.0.0] - 2019-02-20
 

--- a/bundle/src/main/java/com/adobe/acs/commons/remoteassets/impl/RemoteAssetsNodeSyncImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/remoteassets/impl/RemoteAssetsNodeSyncImpl.java
@@ -68,6 +68,7 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -84,7 +85,7 @@ public class RemoteAssetsNodeSyncImpl implements RemoteAssetsNodeSync {
     private static final Logger LOG = LoggerFactory.getLogger(RemoteAssetsNodeSyncImpl.class);
     private static final Pattern DATE_REGEX = Pattern
             .compile("[A-Za-z]{3}\\s[A-Za-z]{3}\\s\\d\\d\\s\\d\\d\\d\\d\\s\\d\\d:\\d\\d:\\d\\d\\sGMT[-+]\\d\\d\\d\\d");
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("EEE MMM dd yyyy HH:mm:ss 'GMT'Z");
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("EEE MMM dd yyyy HH:mm:ss 'GMT'Z", Locale.US);
     private static final Pattern DECIMAL_REGEX = Pattern.compile("-?\\d+\\.\\d+");
     private static final String ASSET_FILE_PREFIX = "remoteassets/remote_asset";
     private static final Set<String> PROTECTED_PROPERTIES = new HashSet<>(Arrays.asList(


### PR DESCRIPTION
The server side will default to US for date formatting, so parsing with the default OS locale won't work in general.

I noticed this issue while running the unit tests. My OS is set to Hungarian, causing RemoteAssetsNodeSyncImplTest to fail.