### PR TITLE
Allow uniform download links in JCR Compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1839 - Fixed editing page for system notifications
 - #1881 - Fixed issue where ReflectionUtil.isAssignableFrom() returned false positive result.
 - #1888 - Fixed issues with Stylesheet Inliner.
+- #1836 - Allow uniform download links in JCR Compare
 
 ## [4.0.0] - 2019-02-20
 

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/jcr-compare/includes/tab-download-json.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/jcr-compare/includes/tab-download-json.jsp
@@ -5,7 +5,7 @@
         <li     ng-repeat="host in hosts track by $index"
                 ng-if="validHost(host)"
                 class="coral-List-item">
-            <a download
+            <a download target="_blank"
                class="coral-Link"
                href="{{ host.uri }}/bin/acs-commons/jcr-compare.dump.json?{{ configAsParams(config) }}"
                x-cq-linkchecker="skip">{{ host.name }}</a>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/jcr-compare/includes/tab-download-json.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/jcr-compare/includes/tab-download-json.jsp
@@ -5,7 +5,8 @@
         <li     ng-repeat="host in hosts track by $index"
                 ng-if="validHost(host)"
                 class="coral-List-item">
-            <a download target="_blank"
+            <a download
+               target="_blank"
                class="coral-Link"
                href="{{ host.uri }}/bin/acs-commons/jcr-compare.dump.json?{{ configAsParams(config) }}"
                x-cq-linkchecker="skip">{{ host.name }}</a>


### PR DESCRIPTION
Fix for [1836](https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/1836).