### PR TITLE
Cleanups: Fix broken paint connections in Version Compare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1881 - Fixed issue where ReflectionUtil.isAssignableFrom() returned false positive result.
 - #1888 - Fixed issues with Stylesheet Inliner.
 - #1836 - Allow uniform download links in JCR Compare
+- #1835 - all options work together now and do not break the connections placement anymore
 
 ## [4.0.0] - 2019-02-20
 

--- a/bundle/src/main/java/com/adobe/acs/commons/version/Evolution.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/Evolution.java
@@ -40,8 +40,4 @@ public interface Evolution {
      */
     List<EvolutionEntry> getVersionEntries();
 
-    Evolution getPrev();
-
-    Evolution getNext();
-
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/Evolution.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/Evolution.java
@@ -40,4 +40,8 @@ public interface Evolution {
      */
     List<EvolutionEntry> getVersionEntries();
 
+    Evolution getPrev();
+
+    Evolution getNext();
+
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/EvolutionAnalyser.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/EvolutionAnalyser.java
@@ -33,6 +33,6 @@ public interface EvolutionAnalyser {
      * 
      * @return the evolution context
      */
-    public EvolutionContext getEvolutionContext(Resource resource);
+    EvolutionContext getEvolutionContext(Resource resource);
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/EvolutionEntry.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/EvolutionEntry.java
@@ -45,6 +45,10 @@ public interface EvolutionEntry {
 
     boolean isWillBeRemoved();
 
+    EvolutionEntry getPrev();
+
+    EvolutionEntry getNext();
+
     /**
      * The available entry types.
      */

--- a/bundle/src/main/java/com/adobe/acs/commons/version/EvolutionEntry.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/EvolutionEntry.java
@@ -45,10 +45,6 @@ public interface EvolutionEntry {
 
     boolean isWillBeRemoved();
 
-    EvolutionEntry getPrev();
-
-    EvolutionEntry getNext();
-
     /**
      * The available entry types.
      */

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionEntryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionEntryImpl.java
@@ -19,12 +19,14 @@
  */
 package com.adobe.acs.commons.version.impl;
 
-import com.adobe.acs.commons.version.EvolutionEntry;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+
 import org.apache.sling.api.resource.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.jcr.Property;
+import com.adobe.acs.commons.version.EvolutionEntry;
 
 public final class CurrentEvolutionEntryImpl implements EvolutionEntry {
 
@@ -37,10 +39,8 @@ public final class CurrentEvolutionEntryImpl implements EvolutionEntry {
     private Object value;
     private int depth;
     private String path;
-    private EvolutionConfig config;
 
-    public CurrentEvolutionEntryImpl(final Resource resource, final EvolutionConfig config) {
-        this.config = config;
+    public CurrentEvolutionEntryImpl(final Resource resource) {
         this.type = EvolutionEntryType.RESOURCE;
         this.name = resource.getName();
         this.depth = EvolutionPathUtil.getLastDepthForPath(resource.getPath());
@@ -48,15 +48,14 @@ public final class CurrentEvolutionEntryImpl implements EvolutionEntry {
         this.value = null;
     }
 
-    public CurrentEvolutionEntryImpl(final Property property, final EvolutionConfig config) {
+    public CurrentEvolutionEntryImpl(final Property property) {
+        this.type = EvolutionEntryType.PROPERTY;
+        this.value = EvolutionConfig.printProperty(property);
         try {
-            this.config = config;
-            this.type = EvolutionEntryType.PROPERTY;
             this.name = property.getName();
             this.depth = EvolutionPathUtil.getLastDepthForPath(property.getPath());
             this.path = property.getParent().getName();
-            this.value = EvolutionConfig.printProperty(property);
-        } catch (final Exception e) {
+        } catch (final RepositoryException e) {
             log.error("Could not inititalize VersionEntry", e);
         }
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionEntryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionEntryImpl.java
@@ -34,7 +34,7 @@ public final class CurrentEvolutionEntryImpl extends EvolutionEntryImplBase {
 
     public CurrentEvolutionEntryImpl(final Property property)
             throws AccessDeniedException, ItemNotFoundException, RepositoryException {
-        super(property,    EvolutionPathUtil.getLastDepthForPath(property.getPath()));
+        super(property, EvolutionPathUtil.getLastDepthForPath(property.getPath()));
     }
 
     @Override

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionEntryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionEntryImpl.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.jcr.Property;
 
-public class CurrentEvolutionEntryImpl implements EvolutionEntry {
+public final class CurrentEvolutionEntryImpl implements EvolutionEntry {
 
     private static final Logger log = LoggerFactory.getLogger(CurrentEvolutionEntryImpl.class);
 
@@ -39,7 +39,7 @@ public class CurrentEvolutionEntryImpl implements EvolutionEntry {
     private String path;
     private EvolutionConfig config;
 
-    public CurrentEvolutionEntryImpl(Resource resource, EvolutionConfig config) {
+    public CurrentEvolutionEntryImpl(final Resource resource, final EvolutionConfig config) {
         this.config = config;
         this.type = EvolutionEntryType.RESOURCE;
         this.name = resource.getName();
@@ -48,15 +48,15 @@ public class CurrentEvolutionEntryImpl implements EvolutionEntry {
         this.value = null;
     }
 
-    public CurrentEvolutionEntryImpl(Property property, EvolutionConfig config) {
+    public CurrentEvolutionEntryImpl(final Property property, final EvolutionConfig config) {
         try {
             this.config = config;
             this.type = EvolutionEntryType.PROPERTY;
             this.name = property.getName();
             this.depth = EvolutionPathUtil.getLastDepthForPath(property.getPath());
             this.path = property.getParent().getName();
-            this.value = config.printProperty(property);
-        } catch (Exception e) {
+            this.value = EvolutionConfig.printProperty(property);
+        } catch (final Exception e) {
             log.error("Could not inititalize VersionEntry", e);
         }
     }
@@ -83,15 +83,16 @@ public class CurrentEvolutionEntryImpl implements EvolutionEntry {
 
     @Override
     public String getValueString() {
-        return config.printObject(value);
+        return EvolutionConfig.printObject(value);
     }
 
     @Override
     public String getValueStringShort() {
-        String tmpValue = getValueString();
+    	final String tmpValue = getValueString();
         if (tmpValue.length() > MAX_CHARS) {
             return tmpValue.substring(0, MAX_CHARS) + "...";
         }
+
         return tmpValue;
     }
 
@@ -129,7 +130,6 @@ public class CurrentEvolutionEntryImpl implements EvolutionEntry {
 
     @Override
     public boolean isWillBeRemoved() {
-
         return false;
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionEntryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionEntryImpl.java
@@ -29,12 +29,12 @@ import org.apache.sling.api.resource.Resource;
 public final class CurrentEvolutionEntryImpl extends EvolutionEntryImplBase {
 
     public CurrentEvolutionEntryImpl(final Resource resource) {
-    	super(resource, EvolutionPathUtil.getLastDepthForPath(resource.getPath()));
+        super(resource, EvolutionPathUtil.getLastDepthForPath(resource.getPath()));
     }
 
     public CurrentEvolutionEntryImpl(final Property property)
-    		throws AccessDeniedException, ItemNotFoundException, RepositoryException {
-    	super(property,	EvolutionPathUtil.getLastDepthForPath(property.getPath()));
+            throws AccessDeniedException, ItemNotFoundException, RepositoryException {
+        super(property,    EvolutionPathUtil.getLastDepthForPath(property.getPath()));
     }
 
     @Override

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionImpl.java
@@ -35,7 +35,8 @@ public final class CurrentEvolutionImpl extends EvolutionImplBase {
     public static final String LATEST_VERSION = "Latest";
 
     public CurrentEvolutionImpl(final Resource resource, final EvolutionConfig config) {
-    	super(resource, config);
+    	super(resource);
+        populate(config);
     }
 
     @Override
@@ -53,12 +54,20 @@ public final class CurrentEvolutionImpl extends EvolutionImplBase {
         return new Date();
     }
 
-	protected EvolutionEntry createEntry(final Resource resource) {
-		return new CurrentEvolutionEntryImpl(resource);
+	protected String getRelativeName(final Property property) throws RepositoryException {
+		return EvolutionPathUtil.getLastRelativePropertyName(property.getPath());
 	}
 
 	protected EvolutionEntry createEntry(final Property property)
 			throws AccessDeniedException, ItemNotFoundException, RepositoryException {
 		return new CurrentEvolutionEntryImpl(property);
+	}
+
+	protected String getRelativeName(final Resource resource) {
+		return EvolutionPathUtil.getLastRelativeResourceName(resource.getPath());
+	}
+
+	protected EvolutionEntry createEntry(final Resource resource) {
+		return new CurrentEvolutionEntryImpl(resource);
 	}
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionImpl.java
@@ -58,13 +58,13 @@ public final class CurrentEvolutionImpl extends EvolutionImplBase {
         return EvolutionPathUtil.getLastRelativePropertyName(property.getPath());
     }
 
+    protected String getRelativeName(final Resource resource) {
+        return EvolutionPathUtil.getLastRelativeResourceName(resource.getPath());
+    }
+
     protected EvolutionEntry createEntry(final Property property)
             throws AccessDeniedException, ItemNotFoundException, RepositoryException {
         return new CurrentEvolutionEntryImpl(property);
-    }
-
-    protected String getRelativeName(final Resource resource) {
-        return EvolutionPathUtil.getLastRelativeResourceName(resource.getPath());
     }
 
     protected EvolutionEntry createEntry(final Resource resource) {

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionImpl.java
@@ -36,7 +36,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
-public class CurrentEvolutionImpl implements Evolution {
+public final class CurrentEvolutionImpl implements Evolution {
 
     public static final String LATEST_VERSION = "Latest";
 

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionImpl.java
@@ -28,6 +28,8 @@ import javax.jcr.RepositoryException;
 
 import org.apache.sling.api.resource.Resource;
 
+import com.adobe.acs.commons.version.EvolutionEntry;
+
 public final class CurrentEvolutionImpl extends EvolutionImplBase {
 
     public static final String LATEST_VERSION = "Latest";
@@ -56,7 +58,7 @@ public final class CurrentEvolutionImpl extends EvolutionImplBase {
 		return EvolutionPathUtil.getLastRelativePropertyName(property.getPath());
 	}
 
-	protected EvolutionEntryImplBase createEntry(final Property property)
+	protected EvolutionEntry createEntry(final Property property)
 			throws AccessDeniedException, ItemNotFoundException, RepositoryException {
 		return new CurrentEvolutionEntryImpl(property);
 	}
@@ -65,7 +67,7 @@ public final class CurrentEvolutionImpl extends EvolutionImplBase {
 		return EvolutionPathUtil.getLastRelativeResourceName(resource.getPath());
 	}
 
-	protected EvolutionEntryImplBase createEntry(final Resource resource) {
+	protected EvolutionEntry createEntry(final Resource resource) {
 		return new CurrentEvolutionEntryImpl(resource);
 	}
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionImpl.java
@@ -84,7 +84,7 @@ public final class CurrentEvolutionImpl implements Evolution {
             Property property = r.adaptTo(Node.class).getProperty(key);
             String relPath = EvolutionPathUtil.getLastRelativePropertyName(property.getPath());
             if (config.handleProperty(relPath)) {
-                versionEntries.add(new CurrentEvolutionEntryImpl(property, config));
+                versionEntries.add(new CurrentEvolutionEntryImpl(property));
             }
         }
         Iterator<Resource> iter = r.getChildren().iterator();
@@ -93,7 +93,7 @@ public final class CurrentEvolutionImpl implements Evolution {
             Resource child = iter.next();
             String relPath = EvolutionPathUtil.getLastRelativeResourceName(child.getPath());
             if (config.handleResource(relPath)) {
-                versionEntries.add(new CurrentEvolutionEntryImpl(child, config));
+                versionEntries.add(new CurrentEvolutionEntryImpl(child));
                 populate(child, depth);
             }
             depth--;

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionImpl.java
@@ -76,27 +76,26 @@ public final class CurrentEvolutionImpl implements Evolution {
         return this.versionEntries;
     }
 
-    private void populate(Resource r, int depth) throws PathNotFoundException, RepositoryException {
-        ValueMap map = r.getValueMap();
-        List<String> keys = new ArrayList<String>(map.keySet());
+    private void populate(final Resource r, final int depth) throws PathNotFoundException, RepositoryException {
+    	final ValueMap map = r.getValueMap();
+    	final List<String> keys = new ArrayList<String>(map.keySet());
         Collections.sort(keys);
-        for (String key : keys) {
-            Property property = r.adaptTo(Node.class).getProperty(key);
-            String relPath = EvolutionPathUtil.getLastRelativePropertyName(property.getPath());
+        for (final String key : keys) {
+        	final Property property = r.adaptTo(Node.class).getProperty(key);
+        	final String relPath = EvolutionPathUtil.getLastRelativePropertyName(property.getPath());
             if (config.handleProperty(relPath)) {
                 versionEntries.add(new CurrentEvolutionEntryImpl(property));
             }
         }
+
         Iterator<Resource> iter = r.getChildren().iterator();
         while (iter.hasNext()) {
-            depth++;
-            Resource child = iter.next();
-            String relPath = EvolutionPathUtil.getLastRelativeResourceName(child.getPath());
+        	final Resource child = iter.next();
+        	final String relPath = EvolutionPathUtil.getLastRelativeResourceName(child.getPath());
             if (config.handleResource(relPath)) {
                 versionEntries.add(new CurrentEvolutionEntryImpl(child));
-                populate(child, depth);
+                populate(child, depth + 1);
             }
-            depth--;
         }
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionImpl.java
@@ -28,8 +28,6 @@ import javax.jcr.RepositoryException;
 
 import org.apache.sling.api.resource.Resource;
 
-import com.adobe.acs.commons.version.EvolutionEntry;
-
 public final class CurrentEvolutionImpl extends EvolutionImplBase {
 
     public static final String LATEST_VERSION = "Latest";
@@ -58,7 +56,7 @@ public final class CurrentEvolutionImpl extends EvolutionImplBase {
 		return EvolutionPathUtil.getLastRelativePropertyName(property.getPath());
 	}
 
-	protected EvolutionEntry createEntry(final Property property)
+	protected EvolutionEntryImplBase createEntry(final Property property)
 			throws AccessDeniedException, ItemNotFoundException, RepositoryException {
 		return new CurrentEvolutionEntryImpl(property);
 	}
@@ -67,7 +65,7 @@ public final class CurrentEvolutionImpl extends EvolutionImplBase {
 		return EvolutionPathUtil.getLastRelativeResourceName(resource.getPath());
 	}
 
-	protected EvolutionEntry createEntry(final Resource resource) {
+	protected EvolutionEntryImplBase createEntry(final Resource resource) {
 		return new CurrentEvolutionEntryImpl(resource);
 	}
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/CurrentEvolutionImpl.java
@@ -35,7 +35,7 @@ public final class CurrentEvolutionImpl extends EvolutionImplBase {
     public static final String LATEST_VERSION = "Latest";
 
     public CurrentEvolutionImpl(final Resource resource, final EvolutionConfig config) {
-    	super(resource);
+        super(resource);
         populate(config);
     }
 
@@ -54,20 +54,20 @@ public final class CurrentEvolutionImpl extends EvolutionImplBase {
         return new Date();
     }
 
-	protected String getRelativeName(final Property property) throws RepositoryException {
-		return EvolutionPathUtil.getLastRelativePropertyName(property.getPath());
-	}
+    protected String getRelativeName(final Property property) throws RepositoryException {
+        return EvolutionPathUtil.getLastRelativePropertyName(property.getPath());
+    }
 
-	protected EvolutionEntry createEntry(final Property property)
-			throws AccessDeniedException, ItemNotFoundException, RepositoryException {
-		return new CurrentEvolutionEntryImpl(property);
-	}
+    protected EvolutionEntry createEntry(final Property property)
+            throws AccessDeniedException, ItemNotFoundException, RepositoryException {
+        return new CurrentEvolutionEntryImpl(property);
+    }
 
-	protected String getRelativeName(final Resource resource) {
-		return EvolutionPathUtil.getLastRelativeResourceName(resource.getPath());
-	}
+    protected String getRelativeName(final Resource resource) {
+        return EvolutionPathUtil.getLastRelativeResourceName(resource.getPath());
+    }
 
-	protected EvolutionEntry createEntry(final Resource resource) {
-		return new CurrentEvolutionEntryImpl(resource);
-	}
+    protected EvolutionEntry createEntry(final Resource resource) {
+        return new CurrentEvolutionEntryImpl(resource);
+    }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionAnalyserImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionAnalyserImpl.java
@@ -43,7 +43,7 @@ import com.adobe.acs.commons.version.EvolutionContext;
         @Property(label = "Ignored resource names",
                 description = "Resource names (regex possible) listed here will be excluded from the version compare feature.",
                 name = EvolutionAnalyserImpl.RESOURCE_IGNORES, value = { "" }, cardinality = Integer.MAX_VALUE) })
-public class EvolutionAnalyserImpl implements EvolutionAnalyser {
+public final class EvolutionAnalyserImpl implements EvolutionAnalyser {
 
     private static final Logger log = LoggerFactory.getLogger(EvolutionAnalyserImpl.class);
 

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionConfig.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionConfig.java
@@ -246,8 +246,8 @@ public final class EvolutionConfig {
             if (delegatee == null) {
                 try {
                     delegatee = value.getBinary().getStream();
-                } catch (final RepositoryException re) {
-                    throw new IOException(re.getMessage(), re);
+                } catch (final RepositoryException e) {
+                    throw new IOException(e.getMessage(), e);
                 }
             }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionConfig.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionConfig.java
@@ -34,36 +34,38 @@ import javax.jcr.Value;
 
 import org.apache.commons.lang3.ArrayUtils;
 
-public class EvolutionConfig {
+public final class EvolutionConfig {
 
-    private String[] ignoreProperties;
-    private String[] ignoreResources;
+    private final String[] ignoreProperties;
+    private final String[] ignoreResources;
 
-    public EvolutionConfig(String[] ignoreProperties, String[] ignoreResources) {
+    public EvolutionConfig(final String[] ignoreProperties, final String[] ignoreResources) {
         this.ignoreProperties = ArrayUtils.clone(ignoreProperties);
         this.ignoreResources = ArrayUtils.clone(ignoreResources);
     }
 
 
-    public boolean handleProperty(String name) {
+    public boolean handleProperty(final String name) {
         for (String entry : ignoreProperties) {
             if (Pattern.matches(entry, name)) {
                 return false;
             }
         }
+
         return true;
     }
 
-    public boolean handleResource(String name) {
-        for (String entry : ignoreResources) {
+    public boolean handleResource(final String name) {
+        for (final String entry : ignoreResources) {
             if (Pattern.matches(entry, name)) {
                 return false;
             }
         }
+
         return true;
     }
 
-    public static String printProperty(javax.jcr.Property property) {
+    public static String printProperty(final javax.jcr.Property property) {
         try {
             return printObject(propertyToJavaObject(property));
         } catch (RepositoryException e1) {
@@ -71,15 +73,16 @@ public class EvolutionConfig {
         }
     }
 
-    public static String printObject(Object obj) {
+    public static String printObject(final Object obj) {
         if (obj == null) {
             return "";
         }
+
         if (obj instanceof String) {
             return (String) obj;
         } else if (obj instanceof String[]) {
-            String[] values = (String[]) obj;
-            StringBuilder result = new StringBuilder();
+        	final String[] values = (String[]) obj;
+        	final StringBuilder result = new StringBuilder();
             result.append("[");
             for (int i = 0; i < values.length; i++) {
                 result.append(values[i]);
@@ -87,11 +90,12 @@ public class EvolutionConfig {
                     result.append(", ");
                 }
             }
+
             result.append("]");
             return result.toString();
         } else if (obj instanceof Calendar) {
-            Calendar value = (Calendar) obj;
-            DateFormat dateFormat = DateFormat.getDateTimeInstance();
+        	final Calendar value = (Calendar) obj;
+        	final DateFormat dateFormat = DateFormat.getDateTimeInstance();
             dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
             return dateFormat.format(value.getTime());
         } else {
@@ -100,11 +104,11 @@ public class EvolutionConfig {
     }
 
     @SuppressWarnings("squid:S3776")
-    private static Object propertyToJavaObject(Property property)
+    private static Object propertyToJavaObject(final Property property)
             throws RepositoryException {
         // multi-value property: return an array of values
         if (property.isMultiple()) {
-            Value[] values = property.getValues();
+        	final Value[] values = property.getValues();
             final Object firstValue = values.length > 0 ? valueToJavaObject(values[0]) : null;
             final Object[] result;
             if ( firstValue instanceof Boolean ) {
@@ -122,12 +126,14 @@ public class EvolutionConfig {
             } else {
                 result = new String[values.length];
             }
+
             for (int i = 0; i < values.length; i++) {
-                Value value = values[i];
+            	final Value value = values[i];
                 if (value != null) {
                     result[i] = valueToJavaObject(value);
                 }
             }
+
             return result;
         }
 
@@ -135,7 +141,7 @@ public class EvolutionConfig {
         return valueToJavaObject(property.getValue());
     }
 
-    private static Object valueToJavaObject(Value value) throws RepositoryException {
+    private static Object valueToJavaObject(final Value value) throws RepositoryException {
         switch (value.getType()) {
             case PropertyType.DECIMAL:
                 return value.getDecimal();
@@ -163,7 +169,7 @@ public class EvolutionConfig {
      * Lazily acquired InputStream which only accesses the JCR Value InputStream if
      * data is to be read from the stream.
      */
-    private static class LazyInputStream extends InputStream {
+    private static final class LazyInputStream extends InputStream {
 
         /** The JCR Value from which the input stream is requested on demand */
         private final Value value;
@@ -171,7 +177,7 @@ public class EvolutionConfig {
         /** The inputstream created on demand, null if not used */
         private InputStream delegatee;
 
-        public LazyInputStream(Value value) {
+        public LazyInputStream(final Value value) {
             this.value = value;
         }
 
@@ -196,17 +202,17 @@ public class EvolutionConfig {
         }
 
         @Override
-        public int read(byte[] b) throws IOException {
+        public int read(final byte[] b) throws IOException {
             return getStream().read(b);
         }
 
         @Override
-        public int read(byte[] b, int off, int len) throws IOException {
+        public int read(final byte[] b, final int off, final int len) throws IOException {
             return getStream().read(b, off, len);
         }
 
         @Override
-        public long skip(long n) throws IOException {
+        public long skip(final long n) throws IOException {
             return getStream().skip(n);
         }
 
@@ -217,11 +223,12 @@ public class EvolutionConfig {
             } catch (IOException ioe) {
                 // ignore
             }
+
             return false;
         }
 
         @Override
-        public synchronized void mark(int readlimit) {
+        public synchronized void mark(final int readlimit) {
             try {
                 getStream().mark(readlimit);
             } catch (IOException ioe) {
@@ -239,10 +246,11 @@ public class EvolutionConfig {
             if (delegatee == null) {
                 try {
                     delegatee = value.getBinary().getStream();
-                } catch (RepositoryException re) {
-                    throw (IOException) new IOException(re.getMessage()).initCause(re);
+                } catch (final RepositoryException re) {
+                    throw new IOException(re.getMessage(), re);
                 }
             }
+
             return delegatee;
         }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionConfig.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionConfig.java
@@ -81,8 +81,8 @@ public final class EvolutionConfig {
         if (obj instanceof String) {
             return (String) obj;
         } else if (obj instanceof String[]) {
-        	final String[] values = (String[]) obj;
-        	final StringBuilder result = new StringBuilder();
+            final String[] values = (String[]) obj;
+            final StringBuilder result = new StringBuilder();
             result.append("[");
             for (int i = 0; i < values.length; i++) {
                 result.append(values[i]);
@@ -94,8 +94,8 @@ public final class EvolutionConfig {
             result.append("]");
             return result.toString();
         } else if (obj instanceof Calendar) {
-        	final Calendar value = (Calendar) obj;
-        	final DateFormat dateFormat = DateFormat.getDateTimeInstance();
+            final Calendar value = (Calendar) obj;
+            final DateFormat dateFormat = DateFormat.getDateTimeInstance();
             dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
             return dateFormat.format(value.getTime());
         } else {
@@ -108,7 +108,7 @@ public final class EvolutionConfig {
             throws RepositoryException {
         // multi-value property: return an array of values
         if (property.isMultiple()) {
-        	final Value[] values = property.getValues();
+            final Value[] values = property.getValues();
             final Object firstValue = values.length > 0 ? valueToJavaObject(values[0]) : null;
             final Object[] result;
             if ( firstValue instanceof Boolean ) {
@@ -128,7 +128,7 @@ public final class EvolutionConfig {
             }
 
             for (int i = 0; i < values.length; i++) {
-            	final Value value = values[i];
+                final Value value = values[i];
                 if (value != null) {
                     result[i] = valueToJavaObject(value);
                 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionContextImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionContextImpl.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
@@ -44,8 +45,8 @@ public final class EvolutionContextImpl implements EvolutionContext {
 
     private static final Logger log = LoggerFactory.getLogger(EvolutionContext.class);
 
-    private final List<Evolution> versions = new ArrayList<Evolution>();
-    private final List<Evolution> evolutionItems = new ArrayList<Evolution>();
+    private final List<EvolutionImplBase> versions = new ArrayList<EvolutionImplBase>();
+    private final List<EvolutionImplBase> evolutionItems = new ArrayList<EvolutionImplBase>();
 
     public EvolutionContextImpl(final Resource resource, final EvolutionConfig config) {
         final ResourceResolver resolver = resource.getResourceResolver();
@@ -74,21 +75,30 @@ public final class EvolutionContextImpl implements EvolutionContext {
 
         evolutionItems.addAll(versions);
         evolutionItems.add(new CurrentEvolutionImpl(versionedResource, config));
-    
+
+        connectPrevNext();
     }
 
 	private String getWarnMessage(final Resource resource) {
 		return String.format("Could not find versions for resource=%s", resource.getPath());
 	}
 
+	private void connectPrevNext() {
+		for (int i = evolutionItems.size() - 2; i > 1; i--) {
+			final EvolutionImplBase current = evolutionItems.get(i);
+			current.setPrev(evolutionItems.get(i - 1));
+			current.setNext(evolutionItems.get(i + 1));
+		}
+	}
+
     @Override
     public List<Evolution> getEvolutionItems() {
-        return evolutionItems;
+        return evolutionItems.stream().collect(Collectors.toList());
     }
 
     @Override
     public List<Evolution> getVersions() {
-        return versions;
+        return versions.stream().collect(Collectors.toList());
     }
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionContextImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionContextImpl.java
@@ -76,7 +76,7 @@ public final class EvolutionContextImpl implements EvolutionContext {
                 log.debug("Version={} added to EvolutionItem", next.getName());
             }
         } catch (final UnsupportedRepositoryOperationException e) {
-            log.warn("Could not find version for resource={}", resource.getPath());
+            log.warn("Could not find versions for resource={}", resource.getPath());
         } catch (final Exception e) {
             log.error("Could not find versions", e);
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionContextImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionContextImpl.java
@@ -60,7 +60,7 @@ public final class EvolutionContextImpl implements EvolutionContext {
             final VersionManager versionManager = workspace.get().getVersionManager();
             final VersionHistory history = versionManager.getVersionHistory(versionedResource.getPath());
             @SuppressWarnings("unchecked")
-			final Iterator<Version> iter = history.getAllVersions();
+            final Iterator<Version> iter = history.getAllVersions();
             while (iter.hasNext()) {
                 final Version next = iter.next();
                 final String versionPath = next.getFrozenNode().getPath();
@@ -77,9 +77,9 @@ public final class EvolutionContextImpl implements EvolutionContext {
     
     }
 
-	private String getWarnMessage(final Resource resource) {
-		return String.format("Could not find versions for resource=%s", resource.getPath());
-	}
+    private String getWarnMessage(final Resource resource) {
+        return String.format("Could not find versions for resource=%s", resource.getPath());
+    }
 
     @Override
     public List<Evolution> getEvolutionItems() {

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionContextImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionContextImpl.java
@@ -40,17 +40,15 @@ public final class EvolutionContextImpl implements EvolutionContext {
     private static final Logger log = LoggerFactory.getLogger(EvolutionContext.class);
 
     private final Resource resource;
-    private VersionHistory history;
-    private final ResourceResolver resolver;
-    private VersionManager versionManager;
+    private final EvolutionConfig config;
     private final List<Evolution> versions = new ArrayList<Evolution>();
     private final List<Evolution> evolutionItems = new ArrayList<Evolution>();
-    private final EvolutionConfig config;
+    private VersionManager versionManager;
+    private VersionHistory history;
 
     public EvolutionContextImpl(final Resource resource, final EvolutionConfig config) {
         this.resource = resource.isResourceType("cq:Page") ? resource.getChild("jcr:content") : resource;
         this.config = config;
-        resolver = resource.getResourceResolver();
         populateEvolutions();
     }
 
@@ -65,6 +63,7 @@ public final class EvolutionContextImpl implements EvolutionContext {
     }
 
     private void populateEvolutions() {
+        final ResourceResolver resolver = resource.getResourceResolver();
         try {
             versionManager = resolver.adaptTo(Session.class).getWorkspace().getVersionManager();
             history = versionManager.getVersionHistory(resource.getPath());
@@ -83,7 +82,7 @@ public final class EvolutionContextImpl implements EvolutionContext {
         }
 
         evolutionItems.addAll(versions);
-        evolutionItems.add(new CurrentEvolutionImpl(this.resource, this.config));
+        evolutionItems.add(new CurrentEvolutionImpl(resource, config));
     }
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionContextImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionContextImpl.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
@@ -45,8 +44,8 @@ public final class EvolutionContextImpl implements EvolutionContext {
 
     private static final Logger log = LoggerFactory.getLogger(EvolutionContext.class);
 
-    private final List<EvolutionImplBase> versions = new ArrayList<EvolutionImplBase>();
-    private final List<EvolutionImplBase> evolutionItems = new ArrayList<EvolutionImplBase>();
+    private final List<Evolution> versions = new ArrayList<Evolution>();
+    private final List<Evolution> evolutionItems = new ArrayList<Evolution>();
 
     public EvolutionContextImpl(final Resource resource, final EvolutionConfig config) {
         final ResourceResolver resolver = resource.getResourceResolver();
@@ -75,30 +74,21 @@ public final class EvolutionContextImpl implements EvolutionContext {
 
         evolutionItems.addAll(versions);
         evolutionItems.add(new CurrentEvolutionImpl(versionedResource, config));
-
-        connectPrevNext();
+    
     }
 
 	private String getWarnMessage(final Resource resource) {
 		return String.format("Could not find versions for resource=%s", resource.getPath());
 	}
 
-	private void connectPrevNext() {
-		for (int i = evolutionItems.size() - 2; i > 1; i--) {
-			final EvolutionImplBase current = evolutionItems.get(i);
-			current.setPrev(evolutionItems.get(i - 1));
-			current.setNext(evolutionItems.get(i + 1));
-		}
-	}
-
     @Override
     public List<Evolution> getEvolutionItems() {
-        return evolutionItems.stream().collect(Collectors.toList());
+        return evolutionItems;
     }
 
     @Override
     public List<Evolution> getVersions() {
-        return versions.stream().collect(Collectors.toList());
+        return versions;
     }
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionContextImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionContextImpl.java
@@ -74,7 +74,6 @@ public final class EvolutionContextImpl implements EvolutionContext {
 
         evolutionItems.addAll(versions);
         evolutionItems.add(new CurrentEvolutionImpl(versionedResource, config));
-    
     }
 
     private String getWarnMessage(final Resource resource) {

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImpl.java
@@ -51,7 +51,7 @@ public final class EvolutionEntryImpl implements EvolutionEntry {
     private Property property;
     private EvolutionConfig config;
 
-    public EvolutionEntryImpl(Resource resource, Version version, EvolutionConfig config) {
+    public EvolutionEntryImpl(final Resource resource, final Version version, final EvolutionConfig config) {
         this.config = config;
         this.type = EvolutionEntryType.RESOURCE;
         this.name = resource.getName();
@@ -62,7 +62,7 @@ public final class EvolutionEntryImpl implements EvolutionEntry {
         this.relativePath = EvolutionPathUtil.getRelativeResourceName(resource.getPath());
     }
 
-    public EvolutionEntryImpl(Property property, Version version, EvolutionConfig config) {
+    public EvolutionEntryImpl(final Property property, final Version version, final EvolutionConfig config) {
         try {
             this.config = config;
             this.property = property;
@@ -71,7 +71,7 @@ public final class EvolutionEntryImpl implements EvolutionEntry {
             this.depth = EvolutionPathUtil.getDepthForPath(property.getPath());
             this.version = version;
             this.path = property.getParent().getName();
-            this.value = config.printProperty(property);
+            this.value = EvolutionConfig.printProperty(property);
             this.relativePath = EvolutionPathUtil.getRelativePropertyName(property.getPath());
         } catch (Exception e) {
             log.error("Could not inititalize VersionEntry", e);
@@ -100,15 +100,16 @@ public final class EvolutionEntryImpl implements EvolutionEntry {
 
     @Override
     public String getValueString() {
-        return config.printObject(value);
+        return EvolutionConfig.printObject(value);
     }
 
     @Override
     public String getValueStringShort() {
-        String tempValue = getValueString();
+    	final String tempValue = getValueString();
         if (tempValue.length() > MAX_CHARS) {
             return tempValue.substring(0, MAX_CHARS) + "...";
         }
+
         return tempValue;
     }
 
@@ -120,7 +121,7 @@ public final class EvolutionEntryImpl implements EvolutionEntry {
     @Override
     public boolean isCurrent() {
         try {
-            Version[] successors = version.getSuccessors();
+        	final Version[] successors = version.getSuccessors();
             if (successors == null || successors.length == 0) {
                 return true;
             }
@@ -160,6 +161,7 @@ public final class EvolutionEntryImpl implements EvolutionEntry {
         } catch (Exception e) {
             // no-op
         }
+
         return true;
     }
 
@@ -169,16 +171,18 @@ public final class EvolutionEntryImpl implements EvolutionEntry {
             if (isCurrent()) {
                 return false;
             }
+
             if (isResource()) {
-                Node node = version.getLinearSuccessor().getFrozenNode().getNode(relativePath);
+            	final Node node = version.getLinearSuccessor().getFrozenNode().getNode(relativePath);
                 return node == null;
             } else {
-                Property prop = version.getLinearSuccessor().getFrozenNode().getProperty(relativePath);
+            	final Property prop = version.getLinearSuccessor().getFrozenNode().getProperty(relativePath);
                 return prop == null;
             }
         } catch (Exception e) {
             // no-op
         }
+
         return true;
     }
 
@@ -188,13 +192,14 @@ public final class EvolutionEntryImpl implements EvolutionEntry {
             if (isResource()) {
                 return false;
             }
-            Property prop = version.getLinearPredecessor().getFrozenNode().getProperty(relativePath);
-            String currentValue = config.printProperty(prop);
-            String oldValue = config.printProperty(property);
+            final Property prop = version.getLinearPredecessor().getFrozenNode().getProperty(relativePath);
+            final String currentValue = EvolutionConfig.printProperty(prop);
+            final String oldValue = EvolutionConfig.printProperty(property);
             return !currentValue.equals(oldValue);
         } catch (Exception e) {
             log.error("Unable to check changed status", e);
         }
+
         return false;
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImpl.java
@@ -65,7 +65,7 @@ public final class EvolutionEntryImpl extends EvolutionEntryImplBase {
             if (successors == null || successors.length == 0) {
                 return true;
             }
-        } catch (RepositoryException e) {
+        } catch (final RepositoryException e) {
             // no-op
         }
 
@@ -82,7 +82,7 @@ public final class EvolutionEntryImpl extends EvolutionEntryImplBase {
                 Property prop = version.getLinearPredecessor().getFrozenNode().getProperty(relativePath);
                 return prop == null;
             }
-        } catch (Exception e) {
+        } catch (final RepositoryException e) {
             // no-op
         }
 
@@ -103,7 +103,7 @@ public final class EvolutionEntryImpl extends EvolutionEntryImplBase {
                 final Property prop = version.getLinearSuccessor().getFrozenNode().getProperty(relativePath);
                 return prop == null;
             }
-        } catch (Exception e) {
+        } catch (final RepositoryException e) {
             // no-op
         }
 
@@ -121,7 +121,7 @@ public final class EvolutionEntryImpl extends EvolutionEntryImplBase {
             final String currentValue = EvolutionConfig.printProperty(prop);
             final String oldValue = EvolutionConfig.printProperty(property);
             return !currentValue.equals(oldValue);
-        } catch (Exception e) {
+        } catch (final RepositoryException e) {
             log.error("Unable to check changed status", e);
         }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImpl.java
@@ -39,15 +39,15 @@ public final class EvolutionEntryImpl extends EvolutionEntryImplBase {
     private final Property property;
 
     public EvolutionEntryImpl(final Resource resource, final Version version) {
-    	super(resource, EvolutionPathUtil.getDepthForPath(resource.getPath()));
-    	property = null;
+        super(resource, EvolutionPathUtil.getDepthForPath(resource.getPath()));
+        property = null;
         this.version = version;
         relativePath = EvolutionPathUtil.getRelativeResourceName(resource.getPath());
     }
 
     public EvolutionEntryImpl(final Property property, final Version version)
-    		throws AccessDeniedException, ItemNotFoundException, RepositoryException {
-    	super(property, EvolutionPathUtil.getDepthForPath(property.getPath()));
+            throws AccessDeniedException, ItemNotFoundException, RepositoryException {
+        super(property, EvolutionPathUtil.getDepthForPath(property.getPath()));
         this.property = property;
         this.version = version;
         relativePath = EvolutionPathUtil.getRelativePropertyName(property.getPath());
@@ -61,7 +61,7 @@ public final class EvolutionEntryImpl extends EvolutionEntryImplBase {
     @Override
     public boolean isCurrent() {
         try {
-        	final Version[] successors = version.getSuccessors();
+            final Version[] successors = version.getSuccessors();
             if (successors == null || successors.length == 0) {
                 return true;
             }
@@ -97,10 +97,10 @@ public final class EvolutionEntryImpl extends EvolutionEntryImplBase {
             }
 
             if (isResource()) {
-            	final Node node = version.getLinearSuccessor().getFrozenNode().getNode(relativePath);
+                final Node node = version.getLinearSuccessor().getFrozenNode().getNode(relativePath);
                 return node == null;
             } else {
-            	final Property prop = version.getLinearSuccessor().getFrozenNode().getProperty(relativePath);
+                final Property prop = version.getLinearSuccessor().getFrozenNode().getProperty(relativePath);
                 return prop == null;
             }
         } catch (Exception e) {

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImpl.java
@@ -49,31 +49,29 @@ public final class EvolutionEntryImpl implements EvolutionEntry {
     private Version version;
     private String relativePath;
     private Property property;
-    private EvolutionConfig config;
 
-    public EvolutionEntryImpl(final Resource resource, final Version version, final EvolutionConfig config) {
-        this.config = config;
-        this.type = EvolutionEntryType.RESOURCE;
-        this.name = resource.getName();
-        this.depth = EvolutionPathUtil.getDepthForPath(resource.getPath());
-        this.path = resource.getParent().getName();
+    public EvolutionEntryImpl(final Resource resource, final Version version) {
+        type = EvolutionEntryType.RESOURCE;
+        name = resource.getName();
+        depth = EvolutionPathUtil.getDepthForPath(resource.getPath());
+        path = resource.getParent().getName();
         this.version = version;
-        this.value = null;
-        this.relativePath = EvolutionPathUtil.getRelativeResourceName(resource.getPath());
+        value = null;
+        relativePath = EvolutionPathUtil.getRelativeResourceName(resource.getPath());
     }
 
-    public EvolutionEntryImpl(final Property property, final Version version, final EvolutionConfig config) {
+    public EvolutionEntryImpl(final Property property, final Version version) {
+        this.property = property;
+        type = EvolutionEntryType.PROPERTY;
+        this.version = version;
+        value = EvolutionConfig.printProperty(property);
         try {
-            this.config = config;
-            this.property = property;
-            this.type = EvolutionEntryType.PROPERTY;
-            this.name = property.getName();
-            this.depth = EvolutionPathUtil.getDepthForPath(property.getPath());
-            this.version = version;
-            this.path = property.getParent().getName();
-            this.value = EvolutionConfig.printProperty(property);
-            this.relativePath = EvolutionPathUtil.getRelativePropertyName(property.getPath());
-        } catch (Exception e) {
+            final String propertyPath = property.getPath();
+            name = property.getName();
+			depth = EvolutionPathUtil.getDepthForPath(propertyPath);
+            path = property.getParent().getName();
+            relativePath = EvolutionPathUtil.getRelativePropertyName(propertyPath);
+        } catch (final RepositoryException e) {
             log.error("Could not inititalize VersionEntry", e);
         }
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImplBase.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImplBase.java
@@ -45,11 +45,11 @@ public abstract class EvolutionEntryImplBase implements EvolutionEntry {
     private final int depth;
 
     protected EvolutionEntryImplBase(
-    		final String name,
-    		final String path,
-    		final EvolutionEntryType type,
-    		final Object value,
-    		final int depth) {
+            final String name,
+            final String path,
+            final EvolutionEntryType type,
+            final Object value,
+            final int depth) {
         this.name = name;
         this.path = path;
         this.type = type;
@@ -58,24 +58,24 @@ public abstract class EvolutionEntryImplBase implements EvolutionEntry {
     }
 
     protected EvolutionEntryImplBase(final Resource resource, final int depth) {
-    	this(
-			resource.getName(),
-			resource.getParent().getName(),
-			EvolutionEntryType.RESOURCE,
-			null,
-			depth
-    	);
+        this(
+            resource.getName(),
+            resource.getParent().getName(),
+            EvolutionEntryType.RESOURCE,
+            null,
+            depth
+        );
     }
 
     protected EvolutionEntryImplBase(final Property property, final int depth)
-    		throws AccessDeniedException, ItemNotFoundException, RepositoryException {
-    	this(
-			property.getName(),
-			property.getParent().getName(),
-			EvolutionEntryType.PROPERTY,
-			EvolutionConfig.printProperty(property),
-			depth
-    	);
+            throws AccessDeniedException, ItemNotFoundException, RepositoryException {
+        this(
+            property.getName(),
+            property.getParent().getName(),
+            EvolutionEntryType.PROPERTY,
+            EvolutionConfig.printProperty(property),
+            depth
+        );
     }
 
     @Override
@@ -88,9 +88,9 @@ public abstract class EvolutionEntryImplBase implements EvolutionEntry {
         return name;
     }
 
-	protected String getUniqueNameBase() {
-		return (name + path).replace(":", "_").replace("/", "_").replace("@", "_");
-	}
+    protected String getUniqueNameBase() {
+        return (name + path).replace(":", "_").replace("/", "_").replace("@", "_");
+    }
 
     @Override
     public EvolutionEntryType getType() {
@@ -104,7 +104,7 @@ public abstract class EvolutionEntryImplBase implements EvolutionEntry {
 
     @Override
     public String getValueStringShort() {
-    	final String fullValueString = getValueString();
+        final String fullValueString = getValueString();
         if (fullValueString.length() > MAX_CHARS) {
             return fullValueString.substring(0, MAX_CHARS) + "...";
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImplBase.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImplBase.java
@@ -44,6 +44,9 @@ public abstract class EvolutionEntryImplBase implements EvolutionEntry {
     private final Object value;
     private final int depth;
 
+    private EvolutionEntryImplBase prev;
+    private EvolutionEntryImplBase next;
+
     protected EvolutionEntryImplBase(
     		final String name,
     		final String path,
@@ -133,5 +136,21 @@ public abstract class EvolutionEntryImplBase implements EvolutionEntry {
             return "";
         }
     }
+
+	public EvolutionEntryImplBase getPrev() {
+		return prev;
+	}
+
+	public void setPrev(final EvolutionEntryImplBase prev) {
+		this.prev = prev;
+	}
+
+	public EvolutionEntryImplBase getNext() {
+		return next;
+	}
+
+	public void setNext(final EvolutionEntryImplBase next) {
+		this.next = next;
+	}
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImplBase.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImplBase.java
@@ -44,9 +44,6 @@ public abstract class EvolutionEntryImplBase implements EvolutionEntry {
     private final Object value;
     private final int depth;
 
-    private EvolutionEntryImplBase prev;
-    private EvolutionEntryImplBase next;
-
     protected EvolutionEntryImplBase(
     		final String name,
     		final String path,
@@ -136,21 +133,5 @@ public abstract class EvolutionEntryImplBase implements EvolutionEntry {
             return "";
         }
     }
-
-	public EvolutionEntryImplBase getPrev() {
-		return prev;
-	}
-
-	public void setPrev(final EvolutionEntryImplBase prev) {
-		this.prev = prev;
-	}
-
-	public EvolutionEntryImplBase getNext() {
-		return next;
-	}
-
-	public void setNext(final EvolutionEntryImplBase next) {
-		this.next = next;
-	}
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImplBase.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionEntryImplBase.java
@@ -1,0 +1,137 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.version.impl;
+
+import javax.jcr.AccessDeniedException;
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+
+import org.apache.sling.api.resource.Resource;
+
+import com.adobe.acs.commons.version.EvolutionEntry;
+
+public abstract class EvolutionEntryImplBase implements EvolutionEntry {
+
+    private static String V_ADDED = "added";
+    private static String V_CHANGED = "changed";
+    private static String V_REMOVED = "removed";
+    private static String V_ADDED_REMOVED = "added-removed";
+    private static String V_CHANGED_REMOVED = "changed-removed";
+
+    private static int MAX_CHARS = 200;
+
+    private final String name;
+    private final String path;
+    private final EvolutionEntryType type;
+    private final Object value;
+    private final int depth;
+
+    protected EvolutionEntryImplBase(
+    		final String name,
+    		final String path,
+    		final EvolutionEntryType type,
+    		final Object value,
+    		final int depth) {
+        this.name = name;
+        this.path = path;
+        this.type = type;
+        this.value = value;
+        this.depth = depth;
+    }
+
+    protected EvolutionEntryImplBase(final Resource resource, final int depth) {
+    	this(
+			resource.getName(),
+			resource.getParent().getName(),
+			EvolutionEntryType.RESOURCE,
+			null,
+			depth
+    	);
+    }
+
+    protected EvolutionEntryImplBase(final Property property, final int depth)
+    		throws AccessDeniedException, ItemNotFoundException, RepositoryException {
+    	this(
+			property.getName(),
+			property.getParent().getName(),
+			EvolutionEntryType.PROPERTY,
+			EvolutionConfig.printProperty(property),
+			depth
+    	);
+    }
+
+    @Override
+    public boolean isResource() {
+        return EvolutionEntryType.RESOURCE == type;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+	protected String getUniqueNameBase() {
+		return (name + path).replace(":", "_").replace("/", "_").replace("@", "_");
+	}
+
+    @Override
+    public EvolutionEntryType getType() {
+        return type;
+    }
+
+    @Override
+    public String getValueString() {
+        return EvolutionConfig.printObject(value);
+    }
+
+    @Override
+    public String getValueStringShort() {
+    	final String fullValueString = getValueString();
+        if (fullValueString.length() > MAX_CHARS) {
+            return fullValueString.substring(0, MAX_CHARS) + "...";
+        }
+
+        return fullValueString;
+    }
+
+    @Override
+    public int getDepth() {
+        return depth - 1;
+    }
+
+    @Override
+    public String getStatus() {
+        if (isChanged() && isWillBeRemoved()) {
+            return V_CHANGED_REMOVED;
+        } else if (isAdded() && isWillBeRemoved()) {
+            return V_ADDED_REMOVED;
+        } else if (isAdded()) {
+            return V_ADDED;
+        } else if (isWillBeRemoved()) {
+            return V_REMOVED;
+        } else if (isChanged()) {
+            return V_CHANGED;
+        } else {
+            return "";
+        }
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImpl.java
@@ -41,8 +41,9 @@ public final class EvolutionImpl extends EvolutionImplBase {
     private final Version version;
 
     public EvolutionImpl(final Version version, final Resource resource, final EvolutionConfig config) {
-    	super(resource, config);
+    	super(resource);
         this.version = version;
+        populate(config);
     }
 
     @Override
@@ -71,9 +72,7 @@ public final class EvolutionImpl extends EvolutionImplBase {
     public boolean isCurrent() {
         try {
             final Version[] successors = version.getSuccessors();
-            if (successors == null || successors.length == 0) {
-                return true;
-            }
+            return successors == null || successors.length == 0;
         } catch (final RepositoryException e) {
             // no-op
         }
@@ -81,12 +80,20 @@ public final class EvolutionImpl extends EvolutionImplBase {
         return false;
     }
 
-	protected EvolutionEntry createEntry(final Resource resource) {
-		return new EvolutionEntryImpl(resource, version);
+	protected String getRelativeName(final Property property) throws RepositoryException {
+		return EvolutionPathUtil.getRelativePropertyName(property.getPath());
 	}
 
 	protected EvolutionEntry createEntry(final Property property)
 			throws AccessDeniedException, ItemNotFoundException, RepositoryException {
 		return new EvolutionEntryImpl(property, version);
+	}
+
+	protected String getRelativeName(final Resource resource) {
+		return EvolutionPathUtil.getRelativeResourceName(resource.getPath());
+	}
+
+	protected EvolutionEntry createEntry(final Resource resource) {
+		return new EvolutionEntryImpl(resource, version);
 	}
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImpl.java
@@ -45,17 +45,17 @@ public final class EvolutionImpl implements Evolution {
     private static final Logger log = LoggerFactory.getLogger(EvolutionImpl.class);
 
     private final List<EvolutionEntry> versionEntries = new ArrayList<EvolutionEntry>();
-    private final Resource versionResource;
     private final Version version;
+    private final Resource versionResource;
     private final EvolutionConfig config;
 
-    public EvolutionImpl(Version version, Resource resource, EvolutionConfig config) {
+    public EvolutionImpl(final Version version, final Resource resource, final EvolutionConfig config) {
         this.version = version;
         this.config = config;
         this.versionResource = resource;
         try {
             populate(versionResource, 0);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             log.warn("Could not populate Evolution", e);
         }
     }
@@ -72,6 +72,7 @@ public final class EvolutionImpl implements Evolution {
         } catch (RepositoryException e) {
             log.warn("Could not get created date from version", e);
         }
+
         return null;
     }
 
@@ -82,19 +83,21 @@ public final class EvolutionImpl implements Evolution {
         } catch (RepositoryException e) {
             log.warn("Could not determine version name");
         }
+
         return "null";
     }
 
     @Override
     public boolean isCurrent() {
         try {
-            Version[] successors = version.getSuccessors();
+            final Version[] successors = version.getSuccessors();
             if (successors == null || successors.length == 0) {
                 return true;
             }
-        } catch (RepositoryException e) {
+        } catch (final RepositoryException e) {
             // no-op
         }
+
         return false;
     }
 
@@ -106,27 +109,26 @@ public final class EvolutionImpl implements Evolution {
         return versionResource.getValueMap();
     }
 
-    private void populate(Resource r, int depth) throws PathNotFoundException, RepositoryException {
-        ValueMap map = r.getValueMap();
-        List<String> keys = new ArrayList<String>(map.keySet());
+    private void populate(final Resource r, final int depth) throws PathNotFoundException, RepositoryException {
+        final ValueMap map = r.getValueMap();
+        final List<String> keys = new ArrayList<String>(map.keySet());
         Collections.sort(keys);
-        for (String key : keys) {
-            Property property = r.adaptTo(Node.class).getProperty(key);
-            String relPath = EvolutionPathUtil.getRelativePropertyName(property.getPath());
+        for (final String key : keys) {
+            final Property property = r.adaptTo(Node.class).getProperty(key);
+            final String relPath = EvolutionPathUtil.getRelativePropertyName(property.getPath());
             if (config.handleProperty(relPath)) {
                 versionEntries.add(new EvolutionEntryImpl(property, version, config));
             }
         }
-        Iterator<Resource> iter = r.getChildren().iterator();
+
+        final Iterator<Resource> iter = r.getChildren().iterator();
         while (iter.hasNext()) {
-            depth++;
-            Resource child = iter.next();
-            String relPath = EvolutionPathUtil.getRelativeResourceName(child.getPath());
+            final Resource child = iter.next();
+            final String relPath = EvolutionPathUtil.getRelativeResourceName(child.getPath());
             if (config.handleResource(relPath)) {
                 versionEntries.add(new EvolutionEntryImpl(child, version, config));
-                populate(child, depth);
+                populate(child, depth + 1);
             }
-            depth--;
         }
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImpl.java
@@ -84,13 +84,13 @@ public final class EvolutionImpl extends EvolutionImplBase {
         return EvolutionPathUtil.getRelativePropertyName(property.getPath());
     }
 
+    protected String getRelativeName(final Resource resource) {
+        return EvolutionPathUtil.getRelativeResourceName(resource.getPath());
+    }
+
     protected EvolutionEntry createEntry(final Property property)
             throws AccessDeniedException, ItemNotFoundException, RepositoryException {
         return new EvolutionEntryImpl(property, version);
-    }
-
-    protected String getRelativeName(final Resource resource) {
-        return EvolutionPathUtil.getRelativeResourceName(resource.getPath());
     }
 
     protected EvolutionEntry createEntry(final Resource resource) {

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImpl.java
@@ -55,7 +55,7 @@ public final class EvolutionImpl implements Evolution {
         this.versionResource = resource;
         try {
             populate(versionResource, 0);
-        } catch (final Exception e) {
+        } catch (final RepositoryException e) {
             log.warn("Could not populate Evolution", e);
         }
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImpl.java
@@ -31,8 +31,6 @@ import org.apache.sling.api.resource.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.acs.commons.version.EvolutionEntry;
-
 
 public final class EvolutionImpl extends EvolutionImplBase {
 
@@ -84,7 +82,7 @@ public final class EvolutionImpl extends EvolutionImplBase {
 		return EvolutionPathUtil.getRelativePropertyName(property.getPath());
 	}
 
-	protected EvolutionEntry createEntry(final Property property)
+	protected EvolutionEntryImplBase createEntry(final Property property)
 			throws AccessDeniedException, ItemNotFoundException, RepositoryException {
 		return new EvolutionEntryImpl(property, version);
 	}
@@ -93,7 +91,7 @@ public final class EvolutionImpl extends EvolutionImplBase {
 		return EvolutionPathUtil.getRelativeResourceName(resource.getPath());
 	}
 
-	protected EvolutionEntry createEntry(final Resource resource) {
+	protected EvolutionEntryImplBase createEntry(final Resource resource) {
 		return new EvolutionEntryImpl(resource, version);
 	}
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImpl.java
@@ -41,7 +41,7 @@ public final class EvolutionImpl extends EvolutionImplBase {
     private final Version version;
 
     public EvolutionImpl(final Version version, final Resource resource, final EvolutionConfig config) {
-    	super(resource);
+        super(resource);
         this.version = version;
         populate(config);
     }
@@ -80,20 +80,20 @@ public final class EvolutionImpl extends EvolutionImplBase {
         return false;
     }
 
-	protected String getRelativeName(final Property property) throws RepositoryException {
-		return EvolutionPathUtil.getRelativePropertyName(property.getPath());
-	}
+    protected String getRelativeName(final Property property) throws RepositoryException {
+        return EvolutionPathUtil.getRelativePropertyName(property.getPath());
+    }
 
-	protected EvolutionEntry createEntry(final Property property)
-			throws AccessDeniedException, ItemNotFoundException, RepositoryException {
-		return new EvolutionEntryImpl(property, version);
-	}
+    protected EvolutionEntry createEntry(final Property property)
+            throws AccessDeniedException, ItemNotFoundException, RepositoryException {
+        return new EvolutionEntryImpl(property, version);
+    }
 
-	protected String getRelativeName(final Resource resource) {
-		return EvolutionPathUtil.getRelativeResourceName(resource.getPath());
-	}
+    protected String getRelativeName(final Resource resource) {
+        return EvolutionPathUtil.getRelativeResourceName(resource.getPath());
+    }
 
-	protected EvolutionEntry createEntry(final Resource resource) {
-		return new EvolutionEntryImpl(resource, version);
-	}
+    protected EvolutionEntry createEntry(final Resource resource) {
+        return new EvolutionEntryImpl(resource, version);
+    }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImpl.java
@@ -31,6 +31,8 @@ import org.apache.sling.api.resource.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.adobe.acs.commons.version.EvolutionEntry;
+
 
 public final class EvolutionImpl extends EvolutionImplBase {
 
@@ -82,7 +84,7 @@ public final class EvolutionImpl extends EvolutionImplBase {
 		return EvolutionPathUtil.getRelativePropertyName(property.getPath());
 	}
 
-	protected EvolutionEntryImplBase createEntry(final Property property)
+	protected EvolutionEntry createEntry(final Property property)
 			throws AccessDeniedException, ItemNotFoundException, RepositoryException {
 		return new EvolutionEntryImpl(property, version);
 	}
@@ -91,7 +93,7 @@ public final class EvolutionImpl extends EvolutionImplBase {
 		return EvolutionPathUtil.getRelativeResourceName(resource.getPath());
 	}
 
-	protected EvolutionEntryImplBase createEntry(final Resource resource) {
+	protected EvolutionEntry createEntry(final Resource resource) {
 		return new EvolutionEntryImpl(resource, version);
 	}
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImpl.java
@@ -117,7 +117,7 @@ public final class EvolutionImpl implements Evolution {
             final Property property = r.adaptTo(Node.class).getProperty(key);
             final String relPath = EvolutionPathUtil.getRelativePropertyName(property.getPath());
             if (config.handleProperty(relPath)) {
-                versionEntries.add(new EvolutionEntryImpl(property, version, config));
+                versionEntries.add(new EvolutionEntryImpl(property, version));
             }
         }
 
@@ -126,7 +126,7 @@ public final class EvolutionImpl implements Evolution {
             final Resource child = iter.next();
             final String relPath = EvolutionPathUtil.getRelativeResourceName(child.getPath());
             if (config.handleResource(relPath)) {
-                versionEntries.add(new EvolutionEntryImpl(child, version, config));
+                versionEntries.add(new EvolutionEntryImpl(child, version));
                 populate(child, depth + 1);
             }
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImplBase.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImplBase.java
@@ -1,0 +1,100 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2015 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.version.impl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.jcr.AccessDeniedException;
+import javax.jcr.ItemNotFoundException;
+import javax.jcr.Node;
+import javax.jcr.PathNotFoundException;
+import javax.jcr.Property;
+import javax.jcr.RepositoryException;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.acs.commons.version.Evolution;
+import com.adobe.acs.commons.version.EvolutionEntry;
+
+
+public abstract class EvolutionImplBase implements Evolution {
+
+    private static final Logger log = LoggerFactory.getLogger(EvolutionImplBase.class);
+
+    private final List<EvolutionEntry> versionEntries = new ArrayList<EvolutionEntry>();
+
+    private final Resource resource;
+
+    protected EvolutionImplBase(final Resource resource, final EvolutionConfig config) {
+        this.resource = resource;
+        try {
+            populate(resource, config, 0);
+        } catch (final RepositoryException e) {
+            log.warn("Could not populate Evolution", e);
+        }
+    }
+
+    @Override
+    public List<EvolutionEntry> getVersionEntries() {
+        return versionEntries;
+    }
+
+    public Resource getResource() {
+        return resource;
+    }
+
+    public ValueMap getProperties() {
+        return resource.getValueMap();
+    }
+
+    private void populate(final Resource resource, final EvolutionConfig config, final int depth) throws PathNotFoundException, RepositoryException {
+        final ValueMap map = resource.getValueMap();
+        final List<String> keys = new ArrayList<String>(map.keySet());
+        Collections.sort(keys);
+        for (final String key : keys) {
+            final Property property = resource.adaptTo(Node.class).getProperty(key);
+            final String relPath = EvolutionPathUtil.getRelativePropertyName(property.getPath());
+            if (config.handleProperty(relPath)) {
+                versionEntries.add(createEntry(property));
+            }
+        }
+
+        final Iterator<Resource> iter = resource.getChildren().iterator();
+        while (iter.hasNext()) {
+            final Resource child = iter.next();
+            final String relPath = EvolutionPathUtil.getRelativeResourceName(child.getPath());
+            if (config.handleResource(relPath)) {
+                versionEntries.add(createEntry(child));
+                populate(child, config, depth + 1);
+            }
+        }
+    }
+
+	protected abstract EvolutionEntry createEntry(Resource resource);
+
+	protected abstract EvolutionEntry createEntry(Property property)
+			throws AccessDeniedException, ItemNotFoundException, RepositoryException;
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImplBase.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImplBase.java
@@ -98,10 +98,10 @@ public abstract class EvolutionImplBase implements Evolution {
 
     protected abstract String getRelativeName(Property property) throws RepositoryException;
 
+    protected abstract String getRelativeName(Resource resource);
+
     protected abstract EvolutionEntry createEntry(Property property)
             throws AccessDeniedException, ItemNotFoundException, RepositoryException;
-
-    protected abstract String getRelativeName(Resource resource);
 
     protected abstract EvolutionEntry createEntry(Resource resource);
 

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImplBase.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImplBase.java
@@ -22,10 +22,7 @@ package com.adobe.acs.commons.version.impl;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import javax.jcr.AccessDeniedException;
 import javax.jcr.ItemNotFoundException;
@@ -47,20 +44,17 @@ public abstract class EvolutionImplBase implements Evolution {
 
     private static final Logger log = LoggerFactory.getLogger(EvolutionImplBase.class);
 
-    private final Map<String, EvolutionEntryImplBase> versionEntries = new LinkedHashMap<>();
+    private final List<EvolutionEntry> versionEntries = new ArrayList<EvolutionEntry>();
 
     private final Resource resource;
 
-    private EvolutionImplBase prev;
-    private EvolutionImplBase next;
-
-	protected EvolutionImplBase(final Resource resource) {
+    protected EvolutionImplBase(final Resource resource) {
         this.resource = resource;
     }
 
     @Override
     public List<EvolutionEntry> getVersionEntries() {
-        return versionEntries.values().stream().collect(Collectors.toList());
+        return versionEntries;
     }
 
     public Resource getResource() {
@@ -87,8 +81,7 @@ public abstract class EvolutionImplBase implements Evolution {
             final Property property = resource.adaptTo(Node.class).getProperty(key);
             final String relPath = getRelativeName(property);
             if (config.handleProperty(relPath)) {
-                final EvolutionEntryImplBase entry = createEntry(property);
-				versionEntries.put(entry.getUniqueName(), entry);
+                versionEntries.add(createEntry(property));
             }
         }
 
@@ -97,8 +90,7 @@ public abstract class EvolutionImplBase implements Evolution {
             final Resource child = iter.next();
             final String relPath = getRelativeName(child);
             if (config.handleResource(relPath)) {
-                final EvolutionEntryImplBase entry = createEntry(child);
-				versionEntries.put(entry.getUniqueName(), entry);
+                versionEntries.add(createEntry(child));
                 populate(child, config, depth + 1);
             }
         }
@@ -106,33 +98,11 @@ public abstract class EvolutionImplBase implements Evolution {
 
 	protected abstract String getRelativeName(Property property) throws RepositoryException;
 
-	protected abstract EvolutionEntryImplBase createEntry(Property property)
+	protected abstract EvolutionEntry createEntry(Property property)
 			throws AccessDeniedException, ItemNotFoundException, RepositoryException;
 
 	protected abstract String getRelativeName(Resource resource);
 
-	protected abstract EvolutionEntryImplBase createEntry(Resource resource);
-
-    public EvolutionImplBase getPrev() {
-		return prev;
-	}
-
-	public void setPrev(final EvolutionImplBase prev) {
-		this.prev = prev;
-		for (final Map.Entry<String, EvolutionEntryImplBase> e : versionEntries.entrySet()) {
-			e.getValue().setPrev(prev.versionEntries.get(e.getKey()));
-		}
-	}
-
-	public EvolutionImplBase getNext() {
-		return next;
-	}
-
-	public void setNext(final EvolutionImplBase next) {
-		this.next = next;
-		for (final Map.Entry<String, EvolutionEntryImplBase> e : versionEntries.entrySet()) {
-			e.getValue().setNext(next.versionEntries.get(e.getKey()));
-		}
-	}
+	protected abstract EvolutionEntry createEntry(Resource resource);
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImplBase.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionImplBase.java
@@ -65,13 +65,13 @@ public abstract class EvolutionImplBase implements Evolution {
         return resource.getValueMap();
     }
 
-	protected final void populate(final EvolutionConfig config) {
-		try {
+    protected final void populate(final EvolutionConfig config) {
+        try {
             populate(resource, config, 0);
         } catch (final RepositoryException e) {
             log.warn("Could not populate Evolution", e);
         }
-	}
+    }
 
     private void populate(final Resource resource, final EvolutionConfig config, final int depth) throws PathNotFoundException, RepositoryException {
         final ValueMap map = resource.getValueMap();
@@ -96,13 +96,13 @@ public abstract class EvolutionImplBase implements Evolution {
         }
     }
 
-	protected abstract String getRelativeName(Property property) throws RepositoryException;
+    protected abstract String getRelativeName(Property property) throws RepositoryException;
 
-	protected abstract EvolutionEntry createEntry(Property property)
-			throws AccessDeniedException, ItemNotFoundException, RepositoryException;
+    protected abstract EvolutionEntry createEntry(Property property)
+            throws AccessDeniedException, ItemNotFoundException, RepositoryException;
 
-	protected abstract String getRelativeName(Resource resource);
+    protected abstract String getRelativeName(Resource resource);
 
-	protected abstract EvolutionEntry createEntry(Resource resource);
+    protected abstract EvolutionEntry createEntry(Resource resource);
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionPathUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionPathUtil.java
@@ -27,7 +27,7 @@ public final class EvolutionPathUtil {
 
     private static final String SEP = "/";
 
-	private EvolutionPathUtil() {}
+    private EvolutionPathUtil() {}
 
     public static int getDepthForPath(final String path) {
         return StringUtils.countMatches(StringUtils.substringAfterLast(path, JcrConstants.JCR_FROZENNODE), SEP);

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionPathUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionPathUtil.java
@@ -21,31 +21,35 @@ package com.adobe.acs.commons.version.impl;
 
 import org.apache.commons.lang.StringUtils;
 
+import com.day.cq.commons.jcr.JcrConstants;
+
 public final class EvolutionPathUtil {
 
-    private EvolutionPathUtil() {}
+    private static final String SEP = "/";
+
+	private EvolutionPathUtil() {}
 
     public static int getDepthForPath(final String path) {
-        return StringUtils.countMatches(StringUtils.substringAfterLast(path, "jcr:frozenNode"), "/");
+        return StringUtils.countMatches(StringUtils.substringAfterLast(path, JcrConstants.JCR_FROZENNODE), SEP);
     }
 
     public static String getRelativePropertyName(final String path) {
-        return StringUtils.substringAfterLast(path, "jcr:frozenNode").replaceFirst("/", "");
+        return StringUtils.substringAfterLast(path, JcrConstants.JCR_FROZENNODE).replaceFirst(SEP, "");
     }
 
     public static String getRelativeResourceName(final String path) {
-        return StringUtils.substringAfterLast(path, "jcr:frozenNode/");
+        return StringUtils.substringAfterLast(path, JcrConstants.JCR_FROZENNODE + SEP);
     }
 
     public static int getLastDepthForPath(final String path) {
-        return StringUtils.countMatches(StringUtils.substringAfterLast(path, "jcr:content"), "/");
+        return StringUtils.countMatches(StringUtils.substringAfterLast(path, JcrConstants.JCR_CONTENT), SEP);
     }
 
     public static String getLastRelativePropertyName(final String path) {
-        return StringUtils.substringAfterLast(path, "jcr:content").replaceFirst("/", "");
+        return StringUtils.substringAfterLast(path, JcrConstants.JCR_CONTENT).replaceFirst(SEP, "");
     }
 
     public static String getLastRelativeResourceName(final String path) {
-        return StringUtils.substringAfterLast(path, "jcr:content/");
+        return StringUtils.substringAfterLast(path, JcrConstants.JCR_CONTENT + SEP);
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionPathUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/impl/EvolutionPathUtil.java
@@ -21,31 +21,31 @@ package com.adobe.acs.commons.version.impl;
 
 import org.apache.commons.lang.StringUtils;
 
-public class EvolutionPathUtil {
+public final class EvolutionPathUtil {
 
     private EvolutionPathUtil() {}
 
-    public static int getDepthForPath(String path) {
+    public static int getDepthForPath(final String path) {
         return StringUtils.countMatches(StringUtils.substringAfterLast(path, "jcr:frozenNode"), "/");
     }
 
-    public static String getRelativePropertyName(String path) {
+    public static String getRelativePropertyName(final String path) {
         return StringUtils.substringAfterLast(path, "jcr:frozenNode").replaceFirst("/", "");
     }
 
-    public static String getRelativeResourceName(String path) {
+    public static String getRelativeResourceName(final String path) {
         return StringUtils.substringAfterLast(path, "jcr:frozenNode/");
     }
 
-    public static int getLastDepthForPath(String path) {
+    public static int getLastDepthForPath(final String path) {
         return StringUtils.countMatches(StringUtils.substringAfterLast(path, "jcr:content"), "/");
     }
 
-    public static String getLastRelativePropertyName(String path) {
+    public static String getLastRelativePropertyName(final String path) {
         return StringUtils.substringAfterLast(path, "jcr:content").replaceFirst("/", "");
     }
 
-    public static String getLastRelativeResourceName(String path) {
+    public static String getLastRelativeResourceName(final String path) {
         return StringUtils.substringAfterLast(path, "jcr:content/");
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/model/EvolutionModel.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/model/EvolutionModel.java
@@ -34,9 +34,11 @@ import com.adobe.acs.commons.version.EvolutionAnalyser;
 import com.adobe.acs.commons.version.EvolutionContext;
 
 @Model(adaptables = SlingHttpServletRequest.class)
-public class EvolutionModel {
+public final class EvolutionModel {
 
     private static final Logger log = LoggerFactory.getLogger(EvolutionModel.class);
+
+    private final String path;
 
     @Inject
     private ResourceResolver resolver;
@@ -44,9 +46,7 @@ public class EvolutionModel {
     @Inject
     private EvolutionAnalyser analyser;
 
-    private final String path;
-
-    public EvolutionModel(SlingHttpServletRequest request) {
+    public EvolutionModel(final SlingHttpServletRequest request) {
         this.path = request.getParameter("path");
     }
 
@@ -56,12 +56,14 @@ public class EvolutionModel {
 
     public EvolutionContext getEvolution() {
         if (StringUtils.isNotEmpty(path)) {
-            Resource resource = resolver.resolve(path);
+            final Resource resource = resolver.resolve(path);
             if (resource != null && !ResourceUtil.isNonExistingResource(resource)) {
                 return analyser.getEvolutionContext(resource);
             }
+
             log.warn("Could not resolve resource at path={}", path);
         }
+
         log.warn("No path provided");
         return null;
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/version/model/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/model/package-info.java
@@ -20,7 +20,7 @@
 /**
  * Version model classes.
  */
-@Version("1.0.0")
+@Version("2.0.0")
 package com.adobe.acs.commons.version.model;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundle/src/main/java/com/adobe/acs/commons/version/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/version/package-info.java
@@ -20,7 +20,7 @@
 /**
  * Version services and helpers.
  */
-@Version("1.1.1")
+@Version("2.0.0")
 package com.adobe.acs.commons.version;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundle/src/test/java/com/adobe/acs/commons/version/impl/EvolutionConfigTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/version/impl/EvolutionConfigTest.java
@@ -19,41 +19,18 @@
  */
 package com.adobe.acs.commons.version.impl;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 
-public class EvolutionConfigTest {
+import org.junit.Test;
 
-    public EvolutionConfigTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception {
-    }
-
-    @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
-    }
+public final class EvolutionConfigTest {
 
     @Test
     public void testHandleProperties() {
-        String[] ignoreProps = { "jcr:.*", "cq:.*", "par/cq:.*" };
-        String[] ignoreRes = {};
+    	final String[] ignoreProps = { "jcr:.*", "cq:.*", "par/cq:.*" };
+    	final String[] ignoreRes = {};
 
-        EvolutionConfig config = new EvolutionConfig(ignoreProps, ignoreRes);
+    	final EvolutionConfig config = new EvolutionConfig(ignoreProps, ignoreRes);
         assertEquals(false, config.handleProperty("jcr:title"));
         assertEquals(true, config.handleProperty("test/jcr:title"));
         assertEquals(false, config.handleProperty("cq:name"));
@@ -63,10 +40,10 @@ public class EvolutionConfigTest {
 
     @Test
     public void testHandleResources() {
-        String[] ignoreProps = {};
-        String[] ignoreRes = { "image", "par/image", ".*test.*" };
+    	final String[] ignoreProps = {};
+    	final String[] ignoreRes = { "image", "par/image", ".*test.*" };
 
-        EvolutionConfig config = new EvolutionConfig(ignoreProps, ignoreRes);
+    	final EvolutionConfig config = new EvolutionConfig(ignoreProps, ignoreRes);
         assertEquals(false, config.handleResource("image"));
         assertEquals(false, config.handleResource("par/image"));
         assertEquals(true, config.handleResource("bert/image"));

--- a/bundle/src/test/java/com/adobe/acs/commons/version/impl/EvolutionConfigTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/version/impl/EvolutionConfigTest.java
@@ -27,10 +27,10 @@ public final class EvolutionConfigTest {
 
     @Test
     public void testHandleProperties() {
-    	final String[] ignoreProps = { "jcr:.*", "cq:.*", "par/cq:.*" };
-    	final String[] ignoreRes = {};
+        final String[] ignoreProps = { "jcr:.*", "cq:.*", "par/cq:.*" };
+        final String[] ignoreRes = {};
 
-    	final EvolutionConfig config = new EvolutionConfig(ignoreProps, ignoreRes);
+        final EvolutionConfig config = new EvolutionConfig(ignoreProps, ignoreRes);
         assertEquals(false, config.handleProperty("jcr:title"));
         assertEquals(true, config.handleProperty("test/jcr:title"));
         assertEquals(false, config.handleProperty("cq:name"));
@@ -40,10 +40,10 @@ public final class EvolutionConfigTest {
 
     @Test
     public void testHandleResources() {
-    	final String[] ignoreProps = {};
-    	final String[] ignoreRes = { "image", "par/image", ".*test.*" };
+        final String[] ignoreProps = {};
+        final String[] ignoreRes = { "image", "par/image", ".*test.*" };
 
-    	final EvolutionConfig config = new EvolutionConfig(ignoreProps, ignoreRes);
+        final EvolutionConfig config = new EvolutionConfig(ignoreProps, ignoreRes);
         assertEquals(false, config.handleResource("image"));
         assertEquals(false, config.handleResource("par/image"));
         assertEquals(true, config.handleResource("bert/image"));

--- a/bundle/src/test/java/com/adobe/acs/commons/version/impl/EvolutionContextImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/version/impl/EvolutionContextImplTest.java
@@ -28,12 +28,15 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import javax.jcr.Node;
 import javax.jcr.Property;
 import javax.jcr.PropertyType;
+import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+import javax.jcr.UnsupportedRepositoryOperationException;
 import javax.jcr.Value;
 import javax.jcr.Workspace;
 import javax.jcr.version.Version;
@@ -48,80 +51,79 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class EvolutionContextImplTest {
+public final class EvolutionContextImplTest {
 
     private static final String RESOURCE_PATH = "/path/to/resource";
     private static final String FROZEN_NODE_1_PATH = "/path/to/first/jcr:frozenNode";
     private static final String FROZEN_NODE_2_PATH = "/path/to/second/jcr:frozenNode";
     private static final String VERSION_1 = "version-1";
     private static final String VERSION_2 = "version-2";
-    private static final String LATEST = "version-2";
 
     private static final String TESTED_KEY = "jcr:title";
     private static final String TESTED_VALUE_1 = "old";
     private static final String TESTED_VALUE_2 = "new";
 
     @Mock
-    Resource resource;
+    private Resource resource;
 
     @Mock
-    ResourceResolver resolver;
+    private ResourceResolver resolver;
 
     @Mock
-    Workspace workspace;
+    private Workspace workspace;
 
     @Mock
-    Session session;
+    private Session session;
 
     @Mock
-    VersionManager versionManager;
+    private VersionManager versionManager;
 
     @Mock
-    VersionHistory versionHistory;
+    private VersionHistory versionHistory;
 
     @Mock
-    VersionIterator versionIterator;
+    private VersionIterator versionIterator;
 
     @Mock
-    Version version1;
+    private Version version1;
 
     @Mock
-    Version version2;
+    private Version version2;
 
     @Mock
-    Node frozenNode1;
+    private Node frozenNode1;
 
     @Mock
-    Node frozenNode2;
+    private Node frozenNode2;
 
     @Mock
-    Resource frozenResource1;
+    private Resource frozenResource1;
 
     @Mock
-    Resource frozenResource2;
+    private Resource frozenResource2;
 
-    ValueMap frozenResource1ValueMap = new ValueMapDecorator(Collections.singletonMap(TESTED_KEY, TESTED_VALUE_1));
+    private final ValueMap frozenResource1ValueMap = new ValueMapDecorator(Collections.singletonMap(TESTED_KEY, TESTED_VALUE_1));
 
-    ValueMap frozenResource2ValueMap = new ValueMapDecorator(Collections.singletonMap(TESTED_KEY, TESTED_VALUE_2));
-
-    @Mock
-    Property jcrPropertyTitle1;
+    private final ValueMap frozenResource2ValueMap = new ValueMapDecorator(Collections.singletonMap(TESTED_KEY, TESTED_VALUE_2));
 
     @Mock
-    Property jcrPropertyTitle2;
+    private Property jcrPropertyTitle1;
 
     @Mock
-    Value value1;
+    private Property jcrPropertyTitle2;
 
     @Mock
-    Value value2;
+    private Value value1;
 
-    EvolutionConfig config = new EvolutionConfig(new String[]{"foo"}, new String[]{"bar"});
+    @Mock
+    private Value value2;
 
-    EvolutionContext evolutionContext;
+    private final EvolutionConfig config = new EvolutionConfig(new String[]{"foo"}, new String[]{"bar"});
+
+    private EvolutionContext evolutionContext;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() throws RepositoryException {
         when(resource.getPath()).thenReturn(RESOURCE_PATH);
         when(resource.getResourceResolver()).thenReturn(resolver);
         when(resource.getValueMap()).thenReturn(frozenResource2ValueMap);

--- a/bundle/src/test/java/com/adobe/acs/commons/version/impl/EvolutionContextImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/version/impl/EvolutionContextImplTest.java
@@ -85,8 +85,8 @@ public final class EvolutionContextImplTest {
 
     @Before
     public void setUp() throws RepositoryException {
-    	final FrozenResourceMock frozenResource1 = new FrozenResourceMock(FROZEN_NODE_1_PATH, VERSION_1, TESTED_VALUE_1);
-    	final FrozenResourceMock frozenResource2 = new FrozenResourceMock(FROZEN_NODE_2_PATH, VERSION_2, TESTED_VALUE_2);
+        final FrozenResourceMock frozenResource1 = new FrozenResourceMock(FROZEN_NODE_1_PATH, VERSION_1, TESTED_VALUE_1);
+        final FrozenResourceMock frozenResource2 = new FrozenResourceMock(FROZEN_NODE_2_PATH, VERSION_2, TESTED_VALUE_2);
         when(resource.getPath()).thenReturn(RESOURCE_PATH);
         when(resource.getResourceResolver()).thenReturn(resolver);
         when(resource.getValueMap()).thenReturn(frozenResource2.getValueMap());

--- a/bundle/src/test/java/com/adobe/acs/commons/version/impl/FrozenResourceMock.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/version/impl/FrozenResourceMock.java
@@ -54,7 +54,7 @@ public final class FrozenResourceMock {
     private final ValueMap valueMap;
 
     public FrozenResourceMock(final String resourcePath, final String versionName, final String propertyValue) throws RepositoryException {
-    	valueMap = new ValueMapDecorator(Collections.singletonMap(TESTED_KEY, propertyValue));
+        valueMap = new ValueMapDecorator(Collections.singletonMap(TESTED_KEY, propertyValue));
 
         when(version.getName()).thenReturn(versionName);
         when(version.getFrozenNode()).thenReturn(node);
@@ -76,19 +76,19 @@ public final class FrozenResourceMock {
         when(value.getType()).thenReturn(PropertyType.STRING);
     }
 
-	public Version getVersion() {
-		return version;
-	}
+    public Version getVersion() {
+        return version;
+    }
 
-	public Resource getResource() {
-		return resource;
-	}
+    public Resource getResource() {
+        return resource;
+    }
 
-	public ValueMap getValueMap() {
-		return valueMap;
-	}
+    public ValueMap getValueMap() {
+        return valueMap;
+    }
 
-	public Node getNode() {
-		return node;
-	}
+    public Node getNode() {
+        return node;
+    }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/version/impl/FrozenResourceMock.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/version/impl/FrozenResourceMock.java
@@ -1,0 +1,94 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.version.impl;
+
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.PropertyType;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+import javax.jcr.version.Version;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.mockito.Mockito;
+
+import com.day.cq.commons.jcr.JcrConstants;
+
+public final class FrozenResourceMock {
+
+    public static final String TESTED_KEY = JcrConstants.JCR_TITLE;
+
+    private final Version version = Mockito.mock(Version.class);
+
+    private final Node node = Mockito.mock(Version.class);
+
+    private final Resource resource = Mockito.mock(Resource.class);
+
+    private final Property property = Mockito.mock(Property.class);
+
+    private final Value value = Mockito.mock(Value.class);
+
+    private final ValueMap valueMap;
+
+    public FrozenResourceMock(final String resourcePath, final String versionName, final String propertyValue) throws RepositoryException {
+    	valueMap = new ValueMapDecorator(Collections.singletonMap(TESTED_KEY, propertyValue));
+
+        when(version.getName()).thenReturn(versionName);
+        when(version.getFrozenNode()).thenReturn(node);
+
+        when(node.getPath()).thenReturn(resourcePath);
+        when(node.getProperty(TESTED_KEY)).thenReturn(property);
+        when(node.getName()).thenReturn(resourcePath);
+
+        when(resource.getValueMap()).thenReturn(valueMap);
+        when(resource.adaptTo(Node.class)).thenReturn(node);
+        when(resource.getChildren()).thenReturn(Collections.emptyList());
+
+        when(property.getPath()).thenReturn(resourcePath + "/" + TESTED_KEY);
+        when(property.getParent()).thenReturn(node);
+        when(property.isMultiple()).thenReturn(false);
+        when(property.getValue()).thenReturn(value);
+
+        when(value.getString()).thenReturn(propertyValue);
+        when(value.getType()).thenReturn(PropertyType.STRING);
+    }
+
+	public Version getVersion() {
+		return version;
+	}
+
+	public Resource getResource() {
+		return resource;
+	}
+
+	public ValueMap getValueMap() {
+		return valueMap;
+	}
+
+	public Node getNode() {
+		return node;
+	}
+}

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/clientlibs/js/app.js
@@ -70,7 +70,7 @@ angular.module('versionComparator', ['acsCoral'])
         };
 
         $scope.addNode = function(node) {
-            node['getTargetId'] = function(indexShift) {
+            node.getTargetId = function(indexShift) {
                 return this.name + "-" + (this.version + indexShift);
             };
 
@@ -98,13 +98,14 @@ angular.module('versionComparator', ['acsCoral'])
             }
 
             return true;
-        }
+        };
 
         var findTarget = function(node) {
+            var target;
             var i = 1;
             while (!target && node.version + i < $scope.versionsCount) {
                 var targetId = node.getTargetId(i);
-                var target = $scope.nodesMap[targetId];
+                target = $scope.nodesMap[targetId];
                 if (target && !isVisible(target)) {
                     target = null;
                 }
@@ -113,7 +114,7 @@ angular.module('versionComparator', ['acsCoral'])
             }
 
             return target;
-        }
+        };
 
         var paintConnections = function() {
             for (var i = 0; i < $scope.nodes.length; i++) {

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/clientlibs/js/app.js
@@ -27,15 +27,14 @@ angular.module('versionComparator', ['acsCoral'])
             home : '',
             resource : '',
             paintConnections : false,
-            hideVersions : {},
-            hideUnchanged : false
+            hideUnchanged : false,
+            hideVersions : {}
         };
 
         $scope.notifications = [];
         $scope.nodes = [];
         $scope.nodesMap = {};
-        $scope.versions = [];
-        $scope.versionEntryMap = {};
+        $scope.versionsCount = 0;
         $scope.changeStatus = [];
 
         $scope.$watch('app.paintConnections', function(newValue,
@@ -43,16 +42,20 @@ angular.module('versionComparator', ['acsCoral'])
             $scope.refreshConnections(newValue);
         });
 
-        $scope.$watch('app.hideUnchanged', function(newValue,
-                oldValue) {
-            var elements = $('div.unchanged');
-            if (newValue) {
-                elements.hide();
-            } else {
+        var setElementsVisible = function(selector, visible) {
+            var elements = $(selector);
+            if (visible) {
                 elements.show();
+            } else {
+                elements.hide();
             }
 
             $scope.refreshConnections();
+        };
+
+        $scope.$watch('app.hideUnchanged', function(newValue,
+                oldValue) {
+            setElementsVisible('div.unchanged', !newValue);
         });
 
         $scope.addNotification = function(type, title, message) {
@@ -74,20 +77,10 @@ angular.module('versionComparator', ['acsCoral'])
         };
 
         $scope.addVersion = function(version) {
-            $scope.versions.push(version);
-            var index = version.index;
-            $scope.versionEntryMap[version.index] = {};
-
+            $scope.versionsCount++;
             $scope.$watch('app.hideVersions["' + version.index + '"]', function(newValue,
                     oldValue) {
-                var elements = $('div#' + version.id);
-                if (newValue) {
-                    elements.hide();
-                } else {
-                    elements.show();
-                }
-
-                $scope.refreshConnections();
+                setElementsVisible('div#' + version.id, !newValue);
             });
         };
 
@@ -98,7 +91,6 @@ angular.module('versionComparator', ['acsCoral'])
 
             $scope.nodes.push(node);
             $scope.nodesMap[node.id] = node;
-            $scope.versionEntryMap[node.version][node.name] = node;
         };
 
         $scope.addChangeStatus = function(params) {
@@ -120,7 +112,7 @@ angular.module('versionComparator', ['acsCoral'])
         var findTarget = function(node) {
             var target;
             var i = 1;
-            while (!target && node.version + i < $scope.versions.length) {
+            while (!target && node.version + i < $scope.versionsCount) {
                 var targetId = node.getTargetId(i);
                 target = $scope.nodesMap[targetId];
                 if (target && !isVisible(target)) {

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/clientlibs/js/app.js
@@ -37,7 +37,7 @@ angular.module('versionComparator', ['acsCoral'])
 
         $scope.$watch('app.paintConnections', function(newValue,
                 oldValue) {
-            $scope.paintConnections(newValue);
+            $scope.refreshConnections(newValue);
         });
 
         $scope.addNotification = function(type, title, message) {
@@ -66,33 +66,40 @@ angular.module('versionComparator', ['acsCoral'])
             $scope.changeStatus.push(params);
         };
 
-        $scope.paintConnections = function(doPrint) {
-            var i;
-            if (doPrint) {
-                for (i = 0; i < $scope.connections.length; i++) {
-                    jsPlumb.connect({
-                        source : $scope.connections[i].source,
-                        target : $scope.connections[i].target,
-                        anchors : [ "Right", "Left" ],
-                        paintStyle : {
-                            lineWidth : 1,
-                            strokeStyle : 'grey'
-                        },
-                        hoverPaintStyle : {
-                            strokeStyle : "rgb(0, 0, 135)"
-                        },
-                        endpointStyle : {
-                            width : 1,
-                            height : 1
-                        },
-                        endpoint : "Rectangle",
-                        connector : "Straight"
-                    });
-                }
-            } else {
-                // $timeout(jsPlumb.reset, 100);
-                $('*[class^="_jsPlumb"]').remove();
+        var paintConnections = function() {
+            for (var i = 0; i < $scope.connections.length; i++) {
+                jsPlumb.connect({
+                    source : $scope.connections[i].source,
+                    target : $scope.connections[i].target,
+                    anchors : [ "Right", "Left" ],
+                    paintStyle : {
+                        lineWidth : 1,
+                        strokeStyle : 'grey'
+                    },
+                    hoverPaintStyle : {
+                        strokeStyle : "rgb(0, 0, 135)"
+                    },
+                    endpointStyle : {
+                        width : 1,
+                        height : 1
+                    },
+                    endpoint : "Rectangle",
+                    connector : "Straight"
+                });
             }
+        };
+
+        var removeConnections = function() {
+            $('*[class^="_jsPlumb"]').remove();
+        };
+
+        $scope.refreshConnections = function(doPrint) {
+            if (doPrint) {
+                paintConnections();
+            } else {
+                removeConnections();
+            }
+
             jsPlumb.repaintEverything();
         };
 
@@ -108,6 +115,7 @@ angular.module('versionComparator', ['acsCoral'])
                     }
                 }
             }
+
             return true;
         };
 

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/clientlibs/js/app.js
@@ -77,6 +77,18 @@ angular.module('versionComparator', ['acsCoral'])
             $scope.versions.push(version);
             var index = version.index;
             $scope.versionEntryMap[version.index] = {};
+
+            $scope.$watch('app.hideVersions["' + version.index + '"]', function(newValue,
+                    oldValue) {
+                var elements = $('div#' + version.id);
+                if (newValue) {
+                    elements.hide();
+                } else {
+                    elements.show();
+                }
+
+                $scope.refreshConnections();
+            });
         };
 
         $scope.addNode = function(node) {
@@ -166,15 +178,6 @@ angular.module('versionComparator', ['acsCoral'])
             }
 
             jsPlumb.repaintEverything();
-        };
-
-        $scope.showVersion = function(version) {
-            if ($scope.app.hideVersions[version]) {
-                jsPlumb.repaintEverything();
-                return false;
-            }
-
-            return true;
         };
 
         $scope.analyse = function() {

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/clientlibs/js/app.js
@@ -45,10 +45,16 @@ angular.module('versionComparator', ['acsCoral'])
 
         $scope.$watch('app.hideUnchanged', function(newValue,
                 oldValue) {
-            if ($scope.app.paintConnections) {
-                removeConnections();
-                paintConnections();
+            var elements = $('div.unchanged');
+            if (newValue) {
+                elements.hide();
+            } else {
+                elements.show();
             }
+
+            removeConnections();
+            paintConnections();
+            jsPlumb.repaintEverything();
         });
 
         $scope.addNotification = function(type, title, message) {

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/clientlibs/js/app.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/clientlibs/js/app.js
@@ -52,9 +52,7 @@ angular.module('versionComparator', ['acsCoral'])
                 elements.show();
             }
 
-            removeConnections();
-            paintConnections();
-            jsPlumb.repaintEverything();
+            $scope.refreshConnections();
         });
 
         $scope.addNotification = function(type, title, message) {
@@ -161,10 +159,9 @@ angular.module('versionComparator', ['acsCoral'])
         };
 
         $scope.refreshConnections = function(doPrint) {
-            if (doPrint) {
+            removeConnections();
+            if (doPrint || (typeof doPrint == 'undefined' && $scope.app.paintConnections)) {
                 paintConnections();
-            } else {
-                removeConnections();
             }
 
             jsPlumb.repaintEverything();

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/graph.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/graph.jsp
@@ -2,13 +2,17 @@
     <h1 acs-coral-heading>No versions could be found for this item.</h1>
 </c:if>
 <c:forEach var="evolutionItem" items="${model.evolution.evolutionItems}" varStatus="evoCounter">
-    <div class="version current-${evolutionItem.current}" id="version-${evolutionItem.versionName}"
-        ng-show="showVersion('version-${evolutionItem.versionName}')">
+    <div class="version current-${evolutionItem.current}" id="version-${evoCounter.index}"
+         ng-init="addVersion({
+             'id': 'version-${evoCounter.index}',
+             'index': ${evoCounter.index}
+         })"
+         ng-show="showVersion('${evoCounter.index}')">
         <div class="version-header">
             <div class="name"><c:out value="${evolutionItem.versionName}"/></div>
             <div class="date"><fmt:formatDate type="both" value="${evolutionItem.versionDate}" /></div>
         </div>
-        <c:forEach var="versionEntry" items="${evolutionItem.versionEntries}" varStatus="entryCounter">
+        <c:forEach var="versionEntry" items="${evolutionItem.versionEntries}">
             <a href="#popover-${versionEntry.uniqueName}-${evoCounter.index}"
                  data-toggle="popover" data-point-from="right" data-align-from="left">
                 <div class="version-entry type-${versionEntry.resource} status-${versionEntry.status} ${versionEntry.status == '' ? 'unchanged' : ''}"

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/graph.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/graph.jsp
@@ -6,8 +6,7 @@
          ng-init="addVersion({
              'id': 'version-${evoCounter.index}',
              'index': ${evoCounter.index}
-         })"
-         ng-show="showVersion('${evoCounter.index}')">
+         })">
         <div class="version-header">
             <div class="name"><c:out value="${evolutionItem.versionName}"/></div>
             <div class="date"><fmt:formatDate type="both" value="${evolutionItem.versionDate}" /></div>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/graph.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/graph.jsp
@@ -13,7 +13,13 @@
                 <div class="version-entry type-${versionEntry.resource} status-${versionEntry.status}"
                      id="${versionEntry.uniqueName}-${evoCounter.index}"
                      ${versionEntry.status == "" ? "ng-show='!app.hideUnchanged'" : ""}
-                     ng-init="addConnection({'source':'${versionEntry.uniqueName}-${evoCounter.index}', 'target':'${versionEntry.uniqueName}-${evoCounter.index + 1}', 'isCurrent':${evolutionItem.current}})">
+                     ng-init="addNode({
+                         'id': '${versionEntry.uniqueName}-${evoCounter.index}',
+                         'version': ${evoCounter.index},
+                         'name': '${versionEntry.uniqueName}',
+                         'isCurrent': ${evolutionItem.current},
+                         'changed': ${not empty versionEntry.status}
+                     })">
                     <div class="inner-version-entry depth-${versionEntry.depth}">
                         <span class="key"><c:out value="${versionEntry.name}"/>:</span>
                         <span class="value"><c:out value="${versionEntry.valueStringShort}"/></span>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/graph.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/graph.jsp
@@ -9,10 +9,10 @@
             <div class="date"><fmt:formatDate type="both" value="${evolutionItem.versionDate}" /></div>
         </div>
         <c:forEach var="versionEntry" items="${evolutionItem.versionEntries}" varStatus="entryCounter">
-            <a href="#popover-${versionEntry.uniqueName}-${evoCounter.index}" data-toggle="popover" data-point-from="right" data-align-from="left">
-                <div class="version-entry type-${versionEntry.resource} status-${versionEntry.status}"
+            <a href="#popover-${versionEntry.uniqueName}-${evoCounter.index}"
+                 data-toggle="popover" data-point-from="right" data-align-from="left">
+                <div class="version-entry type-${versionEntry.resource} status-${versionEntry.status} ${versionEntry.status == '' ? 'unchanged' : ''}"
                      id="${versionEntry.uniqueName}-${evoCounter.index}"
-                     ${versionEntry.status == "" ? "ng-show='!app.hideUnchanged'" : ""}
                      ng-init="addNode({
                          'id': '${versionEntry.uniqueName}-${evoCounter.index}',
                          'version': ${evoCounter.index},

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/graph.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/graph.jsp
@@ -1,0 +1,30 @@
+<c:if test="${empty model.evolution.evolutionItems}">
+    <h1 acs-coral-heading>No versions could be found for this item.</h1>
+</c:if>
+<c:forEach var="evolutionItem" items="${model.evolution.evolutionItems}" varStatus="evoCounter">
+    <div class="version current-${evolutionItem.current}" id="version-${evolutionItem.versionName}"
+        ng-show="showVersion('version-${evolutionItem.versionName}')">
+        <div class="version-header">
+            <div class="name"><c:out value="${evolutionItem.versionName}"/></div>
+            <div class="date"><fmt:formatDate type="both" value="${evolutionItem.versionDate}" /></div>
+        </div>
+        <c:forEach var="versionEntry" items="${evolutionItem.versionEntries}" varStatus="entryCounter">
+            <a href="#popover-${versionEntry.uniqueName}-${evoCounter.index}" data-toggle="popover" data-point-from="right" data-align-from="left">
+                <div class="version-entry type-${versionEntry.resource} status-${versionEntry.status}"
+                     id="${versionEntry.uniqueName}-${evoCounter.index}"
+                     ${versionEntry.status == "" ? "ng-show='!app.hideUnchanged'" : ""}
+                     ng-init="addConnection({'source':'${versionEntry.uniqueName}-${evoCounter.index}', 'target':'${versionEntry.uniqueName}-${evoCounter.index + 1}', 'isCurrent':${evolutionItem.current}})">
+                    <div class="inner-version-entry depth-${versionEntry.depth}">
+                        <span class="key"><c:out value="${versionEntry.name}"/>:</span>
+                        <span class="value"><c:out value="${versionEntry.valueStringShort}"/></span>
+                        <div id="popover-${versionEntry.uniqueName}-${evoCounter.index}" class="coral-Popover">
+                            <div class="coral-Popover-content u-coral-padding">
+                                <c:out value="${versionEntry.valueString}"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </a>
+        </c:forEach>
+    </div>
+</c:forEach>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/options.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/options.jsp
@@ -7,7 +7,7 @@
     <h2 acs-coral-heading>Hide Versions</h2>
     <c:forEach var="evolutionItem" items="${model.evolution.evolutionItems}" varStatus="evoCounter">
         <label acs-coral-checkbox>
-            <input type="checkbox" ng-model="app.hideVersions['version-${evolutionItem.versionName}']"/>
+            <input type="checkbox" ng-model="app.hideVersions['${evoCounter.index}']"/>
             <span>${evolutionItem.versionName}</span>
         </label>
     </c:forEach>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/options.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/options.jsp
@@ -1,7 +1,7 @@
 <div class="options">
     <h2 acs-coral-heading>Configuration</h2>
-    <label acs-coral-checkbox><input type="checkbox" ng-model="app.paintConnections"><span>Paint Connections</span></label>
-    <label acs-coral-checkbox><input type="checkbox" ng-model="app.hideUnchanged"><span>Hide Unchanged</span></label>
+    <label acs-coral-checkbox><input type="checkbox" ng-model="app.paintConnections"/><span>Paint Connections</span></label>
+    <label acs-coral-checkbox><input type="checkbox" ng-model="app.hideUnchanged"/><span>Hide Unchanged</span></label>
 </div>
 <div class="options">
     <h2 acs-coral-heading>Hide Versions</h2>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/options.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/options.jsp
@@ -1,0 +1,22 @@
+<div class="options">
+    <h2 acs-coral-heading>Configuration</h2>
+    <label acs-coral-checkbox><input type="checkbox" ng-model="app.paintConnections"><span>Paint Connections</span></label>
+    <label acs-coral-checkbox><input type="checkbox" ng-model="app.hideUnchanged"><span>Hide Unchanged</span></label>
+</div>
+<div class="options">
+    <h2 acs-coral-heading>Hide Versions</h2>
+    <c:forEach var="evolutionItem" items="${model.evolution.evolutionItems}" varStatus="evoCounter">
+        <label acs-coral-checkbox>
+            <input type="checkbox" ng-model="app.hideVersions['version-${evolutionItem.versionName}']"/>
+            <span>${evolutionItem.versionName}</span>
+        </label>
+    </c:forEach>
+</div>
+<div class="legend">
+    <h2 acs-coral-heading>Legend</h2>
+    <div class="status-added">added</div>
+    <div class="status-changed">changed</div>
+    <div class="status-removed">removed in next version</div>
+    <div class="status-added-removed"><div class="inner-version-entry">added and removed in next version</div></div>
+    <div class="status-changed-removed"><div class="inner-version-entry">changed and removed in next version</div></div>
+</div>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/page-header.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/page-header.jsp
@@ -1,0 +1,25 @@
+<coral-shell-header
+        class="coral--dark granite-shell-header coral3-Shell-header"
+        role="region"
+        aria-label="Header Bar"
+        aria-hidden="false">
+    <coral-shell-header-home class="globalnav-toggle"
+                             data-globalnav-toggle-href="/"
+                             role="heading"
+                             aria-level="2">
+        <a is="coral-shell-homeanchor"
+           style="display: inline-block; padding-right: 0;"
+           icon="adobeExperienceManagerColor"
+           href="/"
+           class="coral3-Shell-homeAnchor">
+           <coral-icon class="coral3-Icon coral3-Shell-homeAnchor-icon coral3-Icon--sizeM coral3-Icon--adobeExperienceManagerColor"
+               icon="adobeExperienceManagerColor"
+               size="M"
+               role="img"
+               aria-label="adobe experience manager color">
+           </coral-icon>
+           <coral-shell-homeanchor-label>Adobe Experience Manager</coral-shell-homeanchor-label>
+        </a>
+        <span style="line-height: 2.375rem;">/ ACS AEM Commons / Version Compare</span>
+    </coral-shell-header-home>
+</coral-shell-header>

--- a/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/version-compare.jsp
+++ b/content/src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/version-compare.jsp
@@ -5,7 +5,7 @@
 <%@taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
 <cq:defineObjects />
-<sling:adaptTo adaptable="${slingRequest}" adaptTo="com.adobe.acs.commons.version.model.EvolutionModel" var="model"/>
+<sling:adaptTo var="model" adaptable="${slingRequest}" adaptTo="com.adobe.acs.commons.version.model.EvolutionModel"/>
 
 <!doctype html>
 <html class="coral-App">
@@ -22,25 +22,7 @@
 </head>
 
 <body class="coral--light">
-    <coral-shell-header
-            class="coral--dark granite-shell-header coral3-Shell-header"
-            role="region"
-            aria-label="Header Bar"
-            aria-hidden="false">
-        <coral-shell-header-home class="globalnav-toggle"
-                                 data-globalnav-toggle-href="/"
-                                 role="heading"
-                                 aria-level="2">
-            <a is="coral-shell-homeanchor"
-               style="display: inline-block; padding-right: 0;"
-               icon="adobeExperienceManagerColor"
-               href="/"
-               class="coral3-Shell-homeAnchor"><coral-icon class="coral3-Icon coral3-Shell-homeAnchor-icon coral3-Icon--sizeM coral3-Icon--adobeExperienceManagerColor" icon="adobeExperienceManagerColor" size="M" role="img" aria-label="adobe experience manager color"></coral-icon>
-                <coral-shell-homeanchor-label>Adobe Experience Manager</coral-shell-homeanchor-label>
-            </a>
-            <span style="line-height: 2.375rem;">/ ACS AEM Commons / Version Compare</span>
-        </coral-shell-header-home>
-    </coral-shell-header>
+    <%@include file="page-header.jsp" %>
 
     <div id="acs-commons-version-comparison">
 
@@ -75,60 +57,12 @@
                         
                    <c:if test="${!empty model.resourcePath && !empty model.evolution.evolutionItems}">
                         <section class="coral-Well">
-                            <div class="options">
-                                <h2 acs-coral-heading>Configuration</h2>
-                                <label acs-coral-checkbox><input type="checkbox" ng-model="app.paintConnections"><span>Paint Connections</span></label>
-                                <label acs-coral-checkbox><input type="checkbox" ng-model="app.hideUnchanged"><span>Hide Unchanged</span></label>
-                            </div>
-                            <div class="options">
-                                <h2 acs-coral-heading>Hide Versions</h2>
-                                <c:forEach var="evolutionItem" items="${model.evolution.evolutionItems}" varStatus="evoCounter">
-                                    <label acs-coral-checkbox><input type="checkbox" ng-model="app.hideVersions['version-${evolutionItem.versionName}']"><span>${evolutionItem.versionName}</span></label>
-                                </c:forEach>
-                            </div>
-                            <div class="legend">
-                                <h2 acs-coral-heading>Legend</h2>
-                                <div class="status-added">added</div>
-                                <div class="status-changed">changed</div>
-                                <div class="status-removed">removed in next version</div>
-                                <div class="status-added-removed"><div class="inner-version-entry">added and removed in next version</div></div>
-                                <div class="status-changed-removed"><div class="inner-version-entry">changed and removed in next version</div></div>
-                            </div>
+                            <%@include file="options.jsp" %>
                         </section>
 
                         <section>
                             <div class="content">
-                                <div>
-                                    <c:forEach var="evolutionItem" items="${model.evolution.evolutionItems}" varStatus="evoCounter" >
-                                        <div class="version current-${evolutionItem.current}" id="version-${evolutionItem.versionName}" ng-show="showVersion('version-${evolutionItem.versionName}')">
-                                            <div class="version-header">
-                                                <div class="name"><c:out value="${evolutionItem.versionName}"/></div>
-                                                <div class="date"><fmt:formatDate type="both" value="${evolutionItem.versionDate}" /></div>
-                                            </div>
-                                            <c:forEach var="versionEntry" items="${evolutionItem.versionEntries}" varStatus="entryCounter">
-                                                <a href="#popover-${versionEntry.uniqueName}-${evoCounter.index}" data-toggle="popover" data-point-from="right" data-align-from="left">
-                                                    <div class="version-entry type-${versionEntry.resource} status-${versionEntry.status}"
-                                                         id="${versionEntry.uniqueName}-${evoCounter.index}" 
-                                                         ${versionEntry.status == "" ? "ng-show='!app.hideUnchanged'" : ""} 
-                                                         ng-init="addConnection({'source':'${versionEntry.uniqueName}-${evoCounter.index}', 'target':'${versionEntry.uniqueName}-${evoCounter.index + 1}', 'isCurrent':${evolutionItem.current}})">
-                                                        <div class="inner-version-entry depth-${versionEntry.depth}">
-                                                            <span class="key"><c:out value="${versionEntry.name}"/>:</span>
-                                                            <span class="value"><c:out value="${versionEntry.valueStringShort}"/></span>
-                                                            <div id="popover-${versionEntry.uniqueName}-${evoCounter.index}" class="coral-Popover">
-                                                                <div class="coral-Popover-content u-coral-padding">
-                                                                    <c:out value="${versionEntry.valueString}"/>
-                                                                </div>
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </a> 
-                                            </c:forEach>
-                                        </div>
-                                    </c:forEach>
-                                    <c:if test="${empty model.evolution.evolutionItems}">
-                                        <h1 acs-coral-heading>No versions could be found for this item.</h1>
-                                    </c:if>
-                                </div>
+                                <%@include file="graph.jsp" %>
                             </div>
                         </section>
                     </c:if>


### PR DESCRIPTION
Fix for [1835](https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/1835). Actually the fix is within frontend files. Java cleanup is a side-effect, it turned out that the BE output was enough already. But I'm leaving those in as e.g. code duplication was reduced, etc.