### PR TITLE
Also build with OpenJDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,25 @@
 language: java
 dist: trusty
-jdk: oraclejdk8
-env:
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=en -Duser.country=US" POST_COVERAGE=true
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=de -Duser.country=DE" POST_COVERAGE=false SKIP_DEPENDENCY_CHECK=true
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=es -Duser.country=ES" POST_COVERAGE=false SKIP_DEPENDENCY_CHECK=true
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=fr -Duser.country=FR" POST_COVERAGE=false SKIP_DEPENDENCY_CHECK=true
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=hi -Duser.country=IN" POST_COVERAGE=false SKIP_DEPENDENCY_CHECK=true
+matrix:
+  include:
+  - jdk: oraclejdk8
+    name: Java 8 en_US (Main Build)
+    env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=en -Duser.country=US" POST_COVERAGE=true
+  - jdk: oraclejdk8
+    name: Java 8 de_DE (Lightweight Build)
+    env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=de -Duser.country=DE" POST_COVERAGE=false SKIP_DEPENDENCY_CHECK=true
+  - jdk: oraclejdk8
+    name: Java 8 es_ES (Lightweight Build)
+    env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=es -Duser.country=ES" POST_COVERAGE=false SKIP_DEPENDENCY_CHECK=true
+  - jdk: oraclejdk8
+    name: Java 8 fr_FR (Lightweight Build)
+    env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=fr -Duser.country=FR" POST_COVERAGE=false SKIP_DEPENDENCY_CHECK=true
+  - jdk: oraclejdk8
+    name: Java 8 hi_IN (Lightweight Build)
+    env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=hi -Duser.country=IN" POST_COVERAGE=false SKIP_DEPENDENCY_CHECK=true
+  - jdk: openjdk11
+    name: Java 11 en_US (Lightweight Build)
+    env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=en -Duser.country=US" POST_COVERAGE=false SKIP_DEPENDENCY_CHECK=true
 script: mvn verify -B
 before_install:
   - cp .travis.settings.xml $HOME/.m2/settings.xml


### PR DESCRIPTION
One new build added to travis leveraging OpenJDK 11
(https://docs.travis-ci.com/user/languages/java/#using-java-10-and-later)
This fixes #1911