### PR TITLE
resolves #1934 add explicit javax.annotation version to bundle-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1868 - Added support for @Named annotation in MCP Form Field processor
 - #1885 - WorkflowPackageManager API now supports (and prefers) /var/workflow/packages location.
 - #1897 - Fixed an NPE with removing a group w/ Ensure Authorizable when the group was already removed
+- #1934 - add explicit javax.annotation version to maven-bundle-plugin after #1893
 
 ## [4.1.0] - 2019-05-07
 

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -56,6 +56,7 @@
                             twitter4j*;version="[3.0.5,4)";resolution:=optional,
                             org.apache.sling.xss;version="[1.1,3)", <!-- using a wider version range for forward compatibility -->
                             com.github.benmanes.caffeine*;resolution:=optional,
+                            <!-- this explicit import can be removed when we no longer support a version of AEM that supports java versions before 11 -->
                             javax.annotation;version=0.0.0,
                             !com.google.errorprone.annotations,
                             !com.google.errorprone.annotations.concurrent,

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -56,6 +56,7 @@
                             twitter4j*;version="[3.0.5,4)";resolution:=optional,
                             org.apache.sling.xss;version="[1.1,3)", <!-- using a wider version range for forward compatibility -->
                             com.github.benmanes.caffeine*;resolution:=optional,
+                            javax.annotation;version=0.0.0,
                             !com.google.errorprone.annotations,
                             !com.google.errorprone.annotations.concurrent,
                             !org.bouncycastle.jce.*,


### PR DESCRIPTION
This may be a test case to add to #1797 . We may want to test against combinations of exports from AEM versions and Java 8/11 packages.

resolves #1934 