### PR TITLE
trying to fix intermittent test failures (fix #1941)

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/fam/impl/ThrottledTaskRunnerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/impl/ThrottledTaskRunnerImpl.java
@@ -73,7 +73,7 @@ public class ThrottledTaskRunnerImpl extends AnnotatedStandardMBean implements T
     private int maxThreads;
     private double maxCpu;
     private double maxHeap;
-    private boolean isPaused;
+    private volatile boolean isPaused;
     private final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
     private ObjectName osBeanName;
     private ObjectName memBeanName;

--- a/bundle/src/test/java/com/adobe/acs/commons/fam/impl/ThrottledTaskRunnerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/fam/impl/ThrottledTaskRunnerTest.java
@@ -66,6 +66,8 @@ public class ThrottledTaskRunnerTest {
 
         ttr.resumeExecution();
 
+        // Allow the threadpool to start in the background
+        Thread.sleep(100);
         while (ttr.getActiveCount() > 0) {
             Thread.sleep(1000);
         }
@@ -109,6 +111,8 @@ public class ThrottledTaskRunnerTest {
 
         ttr.resumeExecution();
 
+        // Allow the threadpool to start in the background
+        Thread.sleep(100);
         while (ttr.getActiveCount() > 0) {
             Thread.sleep(1000);
         }
@@ -143,8 +147,11 @@ public class ThrottledTaskRunnerTest {
             }, Integer.MIN_VALUE);
         }
 
+
         ttr.resumeExecution();
 
+        // Allow the threadpool to start in the background
+        Thread.sleep(100);
         while (ttr.getActiveCount() > 0) {
             Thread.sleep(1000);
         }


### PR DESCRIPTION
* seems to be a timing issue under load (test case continunes to run while the threadpool threads have not yet started). Adding a sleep might help.
* made a variable volatile, its new value should be always reflected in all threads