### PR TITLE
Adding vanity URL and URL rewrite support to SiteMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1806 - Http Cache: Added RequestPath extension
 - #1825 - Added sql2scorer JSON servlet to provide oak:scoreExplanation details for JCR-SQL2 queries.
 - #1899 - Added page inheritance respected in Named Transform Image Servlet for cq:Page
+- #1973 - Added Vanity URL support and the ability to specify URL rewrites so the output matches dispatcher
 
 ### Changed
 - #1539 - Removed unused references to the QueryBuilder API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - 1927 - HTTP cache: added cookie exclusion
 - 1905 - HTTP cache: added response header exclusion
 
+### Changed
+- #1945 - Added support for jcr:content creation and update to the Data Importer
+
 ## [4.2.0] - 2019-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #1806 - Http Cache: Added RequestPath extension
 - #1825 - Added sql2scorer JSON servlet to provide oak:scoreExplanation details for JCR-SQL2 queries.
 - #1899 - Added page inheritance respected in Named Transform Image Servlet for cq:Page
-- #1973 - Added Vanity URL support and the ability to specify URL rewrites so the output matches dispatcher
+- #1973 - Added Vanity URL support to SiteMap and the ability to specify URL rewrites so the output matches dispatcher
 
 ### Changed
 - #1539 - Removed unused references to the QueryBuilder API.

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/SiteMapServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/SiteMapServlet.java
@@ -239,6 +239,22 @@ public final class SiteMapServlet extends SlingSafeMethodsServlet {
         return allAssetFolders;
     }
 
+    private String applyUrlRewrites(String url) {
+        for (String rewrite : urlRewrites) {
+            if (!rewrite.contains(":") || rewrite.startsWith(":")) {
+                continue;
+            }
+            String[] tokens = rewrite.split(":");
+            String path = tokens[0];
+            String replacement = tokens.length > 1 ? tokens[1] : "";
+            if (url.contains(path)) {
+                url = url.replaceFirst(path, replacement);
+                break;
+            }
+        }
+        return url;
+    }
+
     @SuppressWarnings("squid:S1192")
     private void write(Page page, XMLStreamWriter stream, ResourceResolver resolver) throws XMLStreamException {
         if (isHidden(page)) {
@@ -256,16 +272,7 @@ public final class SiteMapServlet extends SlingSafeMethodsServlet {
             loc = externalizer.externalLink(resolver, externalizerDomain, String.format(urlFormat, page.getPath()));
         }
 
-        for (String rewrite : urlRewrites) {
-            if (!rewrite.contains(":") || rewrite.startsWith(":")) continue;
-            String[] tokens = rewrite.split(":");
-            String path = tokens[0];
-            String replacement = tokens.length > 1 ? tokens[1] : "";
-            if (loc.contains(path)) {
-                loc = loc.replaceFirst(path, replacement);
-                break;
-            }
-        }
+        loc = applyUrlRewrites(loc);
 
         writeElement(stream, "loc", loc);
 

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/SiteMapServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/SiteMapServlet.java
@@ -243,13 +243,17 @@ public final class SiteMapServlet extends SlingSafeMethodsServlet {
     }
 
     private String applyUrlRewrites(String url) {
-        String path = URI.create(url).getPath();
-        for (Map.Entry<String, String> rewrite : urlRewrites.entrySet()) {
-            if (path.startsWith(rewrite.getKey())) {
-                return url.replaceFirst(rewrite.getKey(), rewrite.getValue());
+        try {
+            String path = URI.create(url).getPath();
+            for (Map.Entry<String, String> rewrite : urlRewrites.entrySet()) {
+                if (path.startsWith(rewrite.getKey())) {
+                    return url.replaceFirst(rewrite.getKey(), rewrite.getValue());
+                }
             }
+            return url;
+        } catch (IllegalArgumentException e) {
+            return url;
         }
-        return url;
     }
 
     @SuppressWarnings("squid:S1192")


### PR DESCRIPTION
Summary of changes:
- Vanity URLs specified on a Page resource will be used over the actual path
- New property added that allows users to specify multiple URL rewrites that change `<loc>`'s to match basic apache URL rewrites used on a dispatcher. Format used: `<path>:<replacement>` i.e. `content/mysite/en_US/:mysite/`