### PR TITLE
Issue/shared global icons editconfig unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ### Fixed
 - #1976 - Fixed failing Remote Assets and tests dependent on mock server on JDK 11
-- Fixed the Shared and Global icons that are not appearing in edit bar when the dialog is edited and saved and page refreshes due to Edit Config Listener ( Shared Component Properties )
 
 ## [4.2.0] - 2019-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ### Fixed
 - #1976 - Fixed failing Remote Assets and tests dependent on mock server on JDK 11
-- Fixed the Shared and Global icons that are not appearing in edit bar when the dialog is edited and saved and page refreshes due to Edit Config Listener ( Shared Component Properties )
+- #1982 - Fixed the Shared and Global icons that are not appearing in edit bar when the dialog is edited and saved and page refreshes due to Edit Config Listener ( Shared Component Properties )
 
 ## [4.2.0] - 2019-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ### Fixed
 - #1976 - Fixed failing Remote Assets and tests dependent on mock server on JDK 11
+- Fixed the Shared and Global icons that are not appearing in edit bar when the dialog is edited and saved and page refreshes due to Edit Config Listener ( Shared Component Properties )
 
 ## [4.2.0] - 2019-06-18
 

--- a/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/touchui/js/shared-component-properties.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/touchui/js/shared-component-properties.js
@@ -121,10 +121,8 @@
     // Global properties are loaded as page refreshes due to Edit Config Listeners
     channel.on('cq-editables-updated', function (ev) {
         // reset the flag so that the shared and global icons are loaded again after page refresh
-        if (ns.acsSharedComponentPropertiesIsRegistered
-            && ns.EditorFrame
-            && ns.EditorFrame.editableToolbar
-            && ns.EditorFrame.editableToolbar._customActions) {
+        if (ns.acsSharedComponentPropertiesIsRegistered &&
+            ns.EditorFrame && ns.EditorFrame.editableToolbar && ns.EditorFrame.editableToolbar._customActions) {
             ns.acsSharedComponentPropertiesIsRegistered = false;
         }
     });

--- a/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/touchui/js/shared-component-properties.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/touchui/js/shared-component-properties.js
@@ -121,7 +121,10 @@
     // Global properties are loaded as page refreshes due to Edit Config Listeners
     channel.on('cq-editables-updated', function (ev) {
         // reset the flag so that the shared and global icons are loaded again after page refresh
-        if (ev.editables){
+        if (ns.acsSharedComponentPropertiesIsRegistered
+            && ns.EditorFrame
+            && ns.EditorFrame.editableToolbar
+            && ns.EditorFrame.editableToolbar._customActions) {
             ns.acsSharedComponentPropertiesIsRegistered = false;
         }
     });

--- a/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/touchui/js/shared-component-properties.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/touchui/js/shared-component-properties.js
@@ -117,13 +117,4 @@
         }
     });
 
-    // we listen to the editables to reset the Shared Component Properties Registered flag so that the Shared and
-    // Global properties are loaded as page refreshes due to Edit Config Listeners
-    channel.on('cq-editables-updated', function (ev) {
-        // reset the flag so that the shared and global icons are loaded again after page refresh
-        if (ev.editables){
-            ns.acsSharedComponentPropertiesIsRegistered = false;
-        }
-    });
-
 }(jQuery, Granite.author, jQuery(document), this));

--- a/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/touchui/js/shared-component-properties.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/touchui/js/shared-component-properties.js
@@ -117,4 +117,13 @@
         }
     });
 
+    // we listen to the editables to reset the Shared Component Properties Registered flag so that the Shared and
+    // Global properties are loaded as page refreshes due to Edit Config Listeners
+    channel.on('cq-editables-updated', function (ev) {
+        // reset the flag so that the shared and global icons are loaded again after page refresh
+        if (ev.editables){
+            ns.acsSharedComponentPropertiesIsRegistered = false;
+        }
+    });
+
 }(jQuery, Granite.author, jQuery(document), this));

--- a/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/touchui/js/shared-component-properties.js
+++ b/content/src/main/content/jcr_root/apps/acs-commons/authoring/shared-component-properties/touchui/js/shared-component-properties.js
@@ -116,7 +116,7 @@
             ns.EditorFrame.editableToolbar.registerAction('GLOBAL-COMPONENT-PROPS', initDialog("global"));
         }
     });
-
+    // AEM 6.3 Bug Fix for #1982
     // we listen to the editables to reset the Shared Component Properties Registered flag so that the Shared and
     // Global properties are loaded as page refreshes due to Edit Config Listeners
     channel.on('cq-editables-updated', function (ev) {


### PR DESCRIPTION
Issue : 
When editConfig.xml with afteredit="REFRESH_PAGE" listener is added to a component, and when the component dialog is opened and closed or saved it refreshes the page and does not load the Global or Shared Icons in it. It requires another Page reload in order to load those icons back in the edit bar. 
![image](https://user-images.githubusercontent.com/52685735/60892984-0c4bcb80-a22e-11e9-8722-4c8aae2a1c5e.png)

Fix:
Updated shared-component-properties.js file to listen to editables events and reset the ns.acsSharedComponentPropertiesIsRegistered flag so that it can invoke the initDialog for Shared and Global properties icons.  

![image](https://user-images.githubusercontent.com/52685735/60892969-0524bd80-a22e-11e9-8b72-5d62d96eee2b.png)
