### PR TITLE
#1979 - DialogResourceProviderFactoryImpl slows down bundle deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ after the 3.9.0 release. All changes up until the 3.9.0 release can be found in 
 
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 
+## [Unreleased]
+
+### Fixed
+- #1979 - DialogResourceProviderFactoryImpl slows down bundle deployment
+
 ## [4.2.2] - 2019-07-15
 
 ### Added

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/DialogResourceProviderFactoryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/DialogResourceProviderFactoryImpl.java
@@ -74,7 +74,7 @@ public class DialogResourceProviderFactoryImpl implements DialogResourceProvider
     @Reference(
             service = AdapterFactory.class,
             cardinality = ReferenceCardinality.MULTIPLE,
-            policy = ReferencePolicy.STATIC,
+            policy = ReferencePolicy.DYNAMIC,
             policyOption = ReferencePolicyOption.GREEDY,
             bind = "bind",
             unbind = "unbind"


### PR DESCRIPTION
Marks bind reference on AdapterFactory as GREEDY to prevent DialogResourceProviderFactoryImpl from restarting everytime a new AdapterFactory activates/deactivates