### PR TITLE
1951 - Bulk Workflow Manager broken when AEM Workflow changed how Tra…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ after the 3.9.0 release. All changes up until the 3.9.0 release can be found in 
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## [Unreleased]
+#1951 - Fixed issue with Bulk Workflow Manager misidentifying Transient WF because the transient property location changed in AEM.
+
 
 ### Fixed
 - #1975 - Split application content from mutable content

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/TransientWorkflowUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/TransientWorkflowUtil.java
@@ -1,0 +1,19 @@
+package com.adobe.acs.commons.workflow.bulk.execution.impl;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TransientWorkflowUtil {
+    private static final Logger log  = LoggerFactory.getLogger(TransientWorkflowUtil.class);
+
+    public static boolean isTransient(ResourceResolver resourceResolver, String workflowModelId) {
+            Resource resource = resourceResolver.getResource(workflowModelId);
+            boolean transientValue = resource.getValueMap().get("metaData/transient", resource.getValueMap().get("transient", false));;
+
+            log.debug("Getting transient state for [ {} ]  at [ {} ]", resource.getPath() + "/metaData/transient", transientValue);
+
+            return transientValue;
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/TransientWorkflowUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/TransientWorkflowUtil.java
@@ -1,3 +1,23 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2019 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 package com.adobe.acs.commons.workflow.bulk.execution.impl;
 
 import org.apache.sling.api.resource.Resource;
@@ -7,6 +27,8 @@ import org.slf4j.LoggerFactory;
 
 public class TransientWorkflowUtil {
     private static final Logger log  = LoggerFactory.getLogger(TransientWorkflowUtil.class);
+
+    private TransientWorkflowUtil() {}
 
     public static boolean isTransient(ResourceResolver resourceResolver, String workflowModelId) {
             Resource resource = resourceResolver.getResource(workflowModelId);

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/runners/AbstractWorkflowRunner.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/runners/AbstractWorkflowRunner.java
@@ -191,7 +191,7 @@ public abstract class AbstractWorkflowRunner implements BulkWorkflowRunner {
         // Remove active payload
         workspace.removeActivePayload(payload);
 
-        // Increment the complete count
+        // Increment the fail count
         workspace.incrementFailCount();
 
         // Track the failure details

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/runners/AbstractWorkflowRunner.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/runners/AbstractWorkflowRunner.java
@@ -186,6 +186,8 @@ public abstract class AbstractWorkflowRunner implements BulkWorkflowRunner {
     }
 
     public void fail(Workspace workspace, Payload payload) throws Exception {
+        payload.setStatus(Status.FAILED);
+
         // Remove active payload
         workspace.removeActivePayload(payload);
 

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/servlets/InitFormServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/servlets/InitFormServlet.java
@@ -21,6 +21,7 @@
 package com.adobe.acs.commons.workflow.bulk.execution.impl.servlets;
 
 import com.adobe.acs.commons.workflow.bulk.execution.BulkWorkflowEngine;
+import com.adobe.acs.commons.workflow.bulk.execution.impl.TransientWorkflowUtil;
 import com.adobe.acs.commons.workflow.bulk.execution.impl.runners.AEMWorkflowRunnerImpl;
 import com.adobe.acs.commons.workflow.bulk.execution.impl.runners.FastActionManagerRunnerImpl;
 import com.adobe.acs.commons.workflow.bulk.execution.impl.runners.SyntheticWorkflowRunnerImpl;
@@ -100,7 +101,7 @@ public class InitFormServlet extends SlingAllMethodsServlet {
             final WorkflowModel[] workflowModels = workflowSession.getModels();
 
             for (final WorkflowModel workflowModel : workflowModels) {
-                boolean transientWorkflow = isTransient(request.getResourceResolver(), workflowModel.getId());
+                boolean transientWorkflow = TransientWorkflowUtil.isTransient(request.getResourceResolver(), workflowModel.getId());
                 String workflowLabel = workflowModel.getTitle();
                 if (transientWorkflow) {
                     workflowLabel += " ( Transient )";
@@ -120,10 +121,6 @@ public class InitFormServlet extends SlingAllMethodsServlet {
         }
     }
 
-    protected boolean isTransient(ResourceResolver resourceResolver, String workflowModelId) {
-        Resource resource = resourceResolver.getResource(workflowModelId).getParent();
-        return resource.getValueMap().get("transient", false);
-    }
 
     private JsonObject withLabelValue(String label, String value) {
         JsonObject obj = new JsonObject();

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/servlets/StartServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/servlets/StartServlet.java
@@ -20,6 +20,7 @@
 package com.adobe.acs.commons.workflow.bulk.execution.impl.servlets;
 
 import com.adobe.acs.commons.workflow.bulk.execution.BulkWorkflowEngine;
+import com.adobe.acs.commons.workflow.bulk.execution.impl.TransientWorkflowUtil;
 import com.adobe.acs.commons.workflow.bulk.execution.impl.runners.AEMTransientWorkflowRunnerImpl;
 import com.adobe.acs.commons.workflow.bulk.execution.impl.runners.AEMWorkflowRunnerImpl;
 import com.adobe.acs.commons.workflow.bulk.execution.impl.runners.FastActionManagerRunnerImpl;
@@ -93,7 +94,7 @@ public class StartServlet extends SlingAllMethodsServlet {
             properties.put("autoThrottle", getBoolean(params, "autoThrottle", true));
 
             if (AEMWorkflowRunnerImpl.class.getName().equals(properties.get("runnerType", String.class))
-                    && isTransient(request.getResourceResolver(), properties.get("workflowModel", String.class))) {
+                    && TransientWorkflowUtil.isTransient(request.getResourceResolver(), properties.get("workflowModel", String.class))) {
                 properties.put("runnerType", AEMTransientWorkflowRunnerImpl.class.getName());
             }
 
@@ -133,10 +134,5 @@ public class StartServlet extends SlingAllMethodsServlet {
                     "Could not start Bulk Workflow.",
                     e.getMessage());
         }
-    }
-
-    private boolean isTransient(ResourceResolver resourceResolver, String workflowModelId) {
-        Resource resource = resourceResolver.getResource(workflowModelId).getParent();
-        return resource.getValueMap().get("transient", false);
     }
 }


### PR DESCRIPTION
…nsient WF Model state is persisted

At some point, AEM Workflow Models moved the storage of the transient state of a Workflow Model to thee <workflow model path>/metaData@transient property which broken  BWM's detection of Transient WFs, resulting BWM executing transient WF as if they were non-transient causing major issue. 

This fix updates the logic to handle the new location and uses the old location as a fallback.