### PR TITLE
resolves #2065 upgrade to oakpal 1.5.1; use expectPaths and expectAces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ### Changed
 - #2033 - Upgraded oakpal to 1.4.2; added .opear artifact for oakpal-checks module for docker-based cli scans
 - #2045 added oakpal configuration to ui.content to verify that rep:policy nodes are effectively applied, and that existing config pages are not deleted
-- #2065 - Upgraded oakpal to 1.4.2; added .opear artifact for oakpal-checks module for docker-based cli scans
+- #2065 - Upgraded oakpal to 1.5.1; use expectPaths and expectAces checks to verify rep:policy nodes instead of inlineScript
 
 ### Fixed
 - #2032 - Fixed filter.xml on /var/acs-commons

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ### Changed
 - #2033 - Upgraded oakpal to 1.4.2; added .opear artifact for oakpal-checks module for docker-based cli scans
 - #2045 added oakpal configuration to ui.content to verify that rep:policy nodes are effectively applied, and that existing config pages are not deleted
+- #2065 - Upgraded oakpal to 1.4.2; added .opear artifact for oakpal-checks module for docker-based cli scans
 
 ### Fixed
 - #2032 - Fixed filter.xml on /var/acs-commons

--- a/oakpal-checks/pom.xml
+++ b/oakpal-checks/pom.xml
@@ -285,12 +285,6 @@
             <artifactId>osgi.core</artifactId>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.jackrabbit</groupId>
-            <artifactId>oak-jcr</artifactId>
-            <version>1.8.9</version>
-            <scope>provided</scope>
-        </dependency>
 
         <!-- Test Dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <license.addJavaLicenseAfterPackage>false</license.addJavaLicenseAfterPackage>
         <sl4fj.version>1.7.21</sl4fj.version>
         <scr.plugin.version>1.26.0</scr.plugin.version>
-        <oakpal.version>1.4.2</oakpal.version>
+        <oakpal.version>1.5.1</oakpal.version>
     </properties>
 
     <build>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -109,15 +109,19 @@
                             </config>
                         </check>
                         <check>
-                            <name>verify-acls</name>
+                            <name>verify-acls-on-apps</name>
+                            <template>basic/expectAces</template>
                             <!-- enforces resolution of issue #2048 -->
-                            <inlineScript>
-                                function afterExtract(packageId, session) {
-                                    if (!session.itemExists("/apps/rep:policy")) {
-                                        oakpal.majorViolation("expected /apps/rep:policy node to be created", packageId);
-                                    }
-                                }
-                            </inlineScript>
+                            <config>
+                                <principals>
+                                    <principal>acs-commons-ensure-oak-index-service</principal>
+                                    <principal>acs-commons-component-error-handler-service</principal>
+                                    <principal>acs-commons-shared-component-props-service</principal>
+                                </principals>
+                                <expectedAces>
+                                    <expectedAce>type=allow;path=/apps;privileges=jcr:read</expectedAce>
+                                </expectedAces>
+                            </config>
                         </check>
                     </checks>
 

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -103,39 +103,66 @@
                         <!-- check that rep:policy nodes are actually created by the package -->
                         <check>
                             <name>check-expected-policy-paths</name>
-                            <inlineScript>
-                                function afterExtract(packageId, session) {
-                                    var policyPaths = [
-                                        "/oak:index",
-                                        "/content",
-                                        "/content/dam",
-                                        "/etc",
-                                        "/etc/acs-commons/bulk-workflow-manager",
-                                        "/etc/acs-commons/notifications",
-                                        "/etc/acs-commons/redirect-maps",
-                                        "/etc/cloudservices/dtm",
-                                        "/etc/cloudservices/sharethis",
-                                        "/etc/cloudservices/typekit",
-                                        "/etc/packages",
-                                        "/etc/notification/email",
-                                        "/etc/workflow/instances",
-                                        "/home/groups",
-                                        "/home/users",
-                                        "/var/workflow/instances",
-                                        "/var/acs-commons",
-                                        "/var/acs-commons/httpcache",
-                                        "/var/acs-commons/mcp",
-                                        "/var/acs-commons/on-deploy-scripts-status"
-                                    ];
-                                    for (var idx in policyPaths) {
-                                        var path = policyPaths[idx] + "/rep:policy";
-                                        if (!session.itemExists(path)) {
-                                            // change this to major when missing paths are resolved.
-                                            oakpal.minorViolation("expected path creation: " + path, packageId);
-                                        }
-                                    }
-                                }
-                            </inlineScript>
+                            <template>basic/expectPaths</template>
+                            <config>
+                                <severity>minor</severity>
+                                <expectedPaths>
+                                    <path>/oak:index/rep:policy</path>
+                                    <path>/content/rep:policy</path>
+                                    <path>/content/dam/rep:policy</path>
+                                    <path>/etc/rep:policy</path>
+                                    <path>/etc/acs-commons/bulk-workflow-manager/rep:policy</path>
+                                    <path>/etc/acs-commons/notifications/rep:policy</path>
+                                    <path>/etc/acs-commons/redirect-maps/rep:policy</path>
+                                    <path>/etc/cloudservices/dtm/rep:policy</path>
+                                    <path>/etc/cloudservices/sharethis/rep:policy</path>
+                                    <path>/etc/cloudservices/typekit/rep:policy</path>
+                                    <path>/etc/packages/rep:policy</path>
+                                    <path>/etc/notification/email/rep:policy</path>
+                                    <path>/etc/workflow/instances/rep:policy</path>
+                                    <path>/home/groups/rep:policy</path>
+                                    <path>/home/users/rep:policy</path>
+                                    <path>/var/workflow/instances/rep:policy</path>
+                                    <path>/var/acs-commons/rep:policy</path>
+                                    <path>/var/acs-commons/httpcache/rep:policy</path>
+                                    <path>/var/acs-commons/mcp/rep:policy</path>
+                                    <path>/var/acs-commons/on-deploy-scripts-status/rep:policy</path>
+                                </expectedPaths>
+                            </config>
+                        </check>
+                        <check>
+                            <name>verify-acls-on-root</name>
+                            <template>basic/expectAces</template>
+                            <!-- since the root rep:policy node will obviously exist regardless, we should be more
+                            specific for these acl entries -->
+                            <config>
+                                <expectedAces>
+                                    <expectedAce>
+                                        principal=acs-commons-ensure-oak-index-service
+                                        ;type=allow;path=/;privileges=jcr:read,rep:write,rep:indexDefinitionManagement
+                                    </expectedAce>
+                                    <expectedAce>
+                                        principal=acs-commons-dispatcher-flush-service
+                                        ;type=allow;path=/;privileges=jcr:read,crx:replicate,jcr:removeNode
+                                    </expectedAce>
+                                    <expectedAce>
+                                        principal=acs-commons-package-replication-status-event-service
+                                        ;type=allow;path=/;privileges=jcr:read,rep:write,jcr:readAccessControl,jcr:modifyAccessControl
+                                    </expectedAce>
+                                    <expectedAce>
+                                        principal=acs-commons-ensure-service-user-service
+                                        ;type=allow;path=/;privileges=jcr:read,rep:write,jcr:readAccessControl,jcr:modifyAccessControl
+                                    </expectedAce>
+                                    <expectedAce>
+                                        principal=acs-commons-automatic-package-replicator-service
+                                        ;type=allow;path=/;privileges=jcr:read
+                                    </expectedAce>
+                                    <expectedAce>
+                                        principal=acs-commons-on-deploy-scripts-service
+                                        ;type=allow;path=/;privileges=jcr:read
+                                    </expectedAce>
+                                </expectedAces>
+                            </config>
                         </check>
                     </checks>
 


### PR DESCRIPTION
Upgraded oakpal to 1.5.1; use expectPaths and expectAces checks to verify rep:policy nodes instead of inlineScript