### PR TITLE
added functionality to showhidedialogfields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-4.3.2...HEAD
 
 ### Added
+- #2118 - Adding functionality to showhidedialogfields TouchUI widget
 - #2064 - Adding Marketo Form Component
 - #1919 - Report Builder | Path List Executor Implementation
 

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/showhidedialogfields/source/showhidedialogfieldstabs.js
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/showhidedialogfields/source/showhidedialogfieldstabs.js
@@ -1,10 +1,10 @@
 /**
- * Extension to the standard dropdown/select and checkbox component. It enables hidding/unhidding of multiple dialog fields 
- * and dialog tabs based on the selection made in the dropdown/select or on checkbox check or their combination. 
+ * Extension to the standard dropdown/select and checkbox component. It enables hidding/unhidding of multiple dialog fields
+ * and dialog tabs based on the selection made in the dropdown/select or on checkbox check or their combination.
  *
  * How to use:
  * - add the empty property acs-cq-dialog-dropdown-checkbox-showhide to the dropdown/select or checkbox element
- * - add the data attribute acs-cq-dialog-dropdown-checkbox-showhide-target to the dropdown/select or checkbox element, 
+ * - add the data attribute acs-cq-dialog-dropdown-checkbox-showhide-target to the dropdown/select or checkbox element,
  *   value should be the selector, usually a specific class name, to find all possible target elements that can be shown/hidden.
  * - add the target class to each target component that can be shown/hidden
  * - add the class hide to each target component to make them initially hidden
@@ -18,15 +18,32 @@
  * - the acs-dropdownshowhidetargetvalue and/or acs-checkboxshowhidetargetvalue attribute can be added to dialog tab items to show and
  *   hide them.
  * - (optional) add css class acs-commons-field-required-allow-hidden to provided required field validation, which turns off when the field is hidden
+ *
+ * - If the fields lie within a multifield
+ * - add the extra empty property acs-cq-dialog-dropdown-checkbox-showhide-multifield to the dropdown/select or checkbox element
+ *
+ * - If a combination of multiple checkboxes is needed to determine the hiding of fields
+ * - add the empty property acs-cq-dialog-combo-checkbox-showhide to the dropdown/select or checkbox element
+ * - add the data attribute acs-cq-dialog-combo-checkbox-showhide-target to the dropdown/select or checkbox element,
+ *   value should be the selector, usually a specific class name, to find all possible target elements that can be shown/hidden.
+ * - add the target class to each target component that can be shown/hidden
+ * - add the class hide to each target component to make them initially hidden
+ * - add the attribute acs-combocheckboxshowhideclasses to the target component, the value should be a list of the
+ *   classes that determine the hiding of this field, separated by spaces
+ * - add the attribute acs-combocheckboxshowhidevalues to the target component, the value should be a list of the
+ *   target values of the checkboxes that should be combined
+ *   the order of both lists should be the same: the first value should correspond to the first class given
  */
+
+/* global Granite, Coral, $  */
 (function($document, $) {
-  "use strict";
+  'use strict';
 
   // when dialog gets injected
-  $document.on("foundation-contentloaded", function() {
+  $document.on('foundation-contentloaded', function() {
     // if there is already an initial value make sure the according target
     // element becomes visible
-    $("[data-acs-cq-dialog-dropdown-checkbox-showhide]").each(function() {	
+    $('[data-acs-cq-dialog-dropdown-checkbox-showhide]').each(function() {
       // handle Coral3 base drop-down/checkbox
       Coral.commons.ready($(this), function(element) {
         showHide(element);
@@ -35,37 +52,36 @@
 
   });
 
-  $document.on("change", "[data-acs-cq-dialog-dropdown-checkbox-showhide]", function() {
+  $document.on('change', '[data-acs-cq-dialog-dropdown-checkbox-showhide]', function() {
     showHide($(this));
+  });
+
+  $document.on('change', '[data-acs-cq-dialog-combo-checkbox-showhide]', function() {
+    showCorrectComboTargetElements();
   });
 
   function showHide(el) {
     // get the selector to find the target elements. it is stored as
-    // data-attribute
-    // acsCqDialogDropdownCheckboxShowhideTarget
+    // data-attribute 'acsCqDialogDropdownCheckboxShowhideTarget'
     var target = el.data('acsCqDialogDropdownCheckboxShowhideTarget');
     var checkboxValue = '';
     var dropdownValue = '';
 
     // check if the changed element is the drop-down or the check-box
     // and get the values accordingly
-    if ($(el).is("coral-select")) {
+    if ($(el).is('coral-select')) {
       dropdownValue = getDropdownValue(el);
       checkboxValue = getCheckboxValue(el.closest('coral-panel-content').find('coral-checkbox'));
-    } else if ($(el).is("coral-checkbox")) {
+    } else if ($(el).is('coral-checkbox')) {
       dropdownValue = getDropdownValue(el.closest('coral-panel-content').find('coral-select'));
       checkboxValue = getCheckboxValue(el);
     }
 
-    // make sure all target elements are hidden.
-    hideAllTargetElements(target);
-
-    // unhide target elements based on the target values
-    $(target).each(function() {
-      if (shouldBeVisible($(this), dropdownValue, checkboxValue)) {
-        hideElement($(this), false);
-      }
-    });
+    if (typeof (el.data('acsCqDialogDropdownCheckboxShowhideMultifield')) !== 'undefined') {
+      showCorrectTargetElementsBeneath(target, dropdownValue, checkboxValue, el.closest('coral-multifield-item'));
+    } else {
+      showCorrectTargetElementsBeneath(target, dropdownValue, checkboxValue, $(document));
+    }
   }
 
   function getDropdownValue(dropdownElement) {
@@ -80,10 +96,24 @@
     return checked ? checkBoxElement.val() : '';
   }
 
-  // make sure all target elements are hidden.
-  function hideAllTargetElements(target) {
-    $(target).each(function() {
-      hideElement($(this), true);
+  function showCorrectTargetElementsBeneath(target, dropdownValue, checkboxValue, $root) {
+    // unhide target elements based on the target values
+    $root.find(target).each(function() {
+      toggleVisibilityElement($(this), !shouldBeVisible($(this), dropdownValue, checkboxValue));
+    });
+  }
+
+  function showCorrectComboTargetElements() {
+    $('[data-acs-combocheckboxshowhideclasses]').each(function() {
+      var classes = $(this).data('acsCombocheckboxshowhideclasses').split(' ');
+      var values = $(this).data('acsCombocheckboxshowhidevalues').split(' ');
+      var boolean = false;
+      classes.forEach(function(classvalue, index) {
+        var temp = $('[data-acs-cq-dialog-combo-checkbox-showhide-target="' + classvalue + '"]');
+        var checked = temp.prop('checked');
+        boolean = (boolean || (checked === ('true' === values[index])));
+      });
+      toggleVisibilityElement($(this), !boolean);
     });
   }
 
@@ -93,11 +123,13 @@
    */
   function shouldBeVisible($elem, dropdownValue, checkboxValue) {
     if ($elem.is('[data-acs-dropdownshowhidetargetvalue]') && $elem.is('[data-acs-checkboxshowhidetargetvalue]')) {
-      return $elem.attr('data-acs-dropdownshowhidetargetvalue').indexOf(dropdownValue) >= 0 && $elem.attr('data-acs-checkboxshowhidetargetvalue') === checkboxValue;
+      return $elem.attr('data-acs-dropdownshowhidetargetvalue').split(' ').includes(dropdownValue) && $elem.attr('data-acs-checkboxshowhidetargetvalue') === checkboxValue;
     } else if ($elem.is('[data-acs-dropdownshowhidetargetvalue]')) {
-      return $elem.attr('data-acs-dropdownshowhidetargetvalue').indexOf(dropdownValue) >= 0;
+      return $elem.attr('data-acs-dropdownshowhidetargetvalue').split(' ').includes(dropdownValue);
     } else if ($elem.is('[data-acs-checkboxshowhidetargetvalue]')) {
       return $elem.attr('data-acs-checkboxshowhidetargetvalue') === checkboxValue;
+    } else if ($elem.is('[data-acs-dropdownshowhidetargetnotvalue]')) {
+      return $elem.attr('data-acs-dropdownshowhidetargetnotvalue') !== dropdownValue;
     }
     return false;
   }
@@ -105,22 +137,27 @@
   /**
    * Hides/unhides the element
    */
-  function hideElement($elem, hide) {
+  function toggleVisibilityElement($elem, hide) {
     var $fieldWrapper = $elem.closest('.coral-Form-fieldwrapper');
-    var tabPanel = $elem.parent().parent("coral-panel[role='tabpanel']");
+    var tabPanel = $elem.parent().parent('coral-panel[role="tabpanel"]');
     var tabLabelId = $(tabPanel).attr('aria-labelledby');
 
     if (hide) {
       // If target is a container, hides the container
       $elem.addClass('hide');
-      // Hides the target field wrapper. Thus, hiding label, quicktip etc.
-      $fieldWrapper.addClass('hide');
+      if (!$elem.is('coral-checkbox')) {
+        // Hides the target field wrapper. Thus, hiding label, quicktip etc.
+        $fieldWrapper.addClass('hide');
+      }
+
       // hide the tab
       $('#' + tabLabelId).addClass('hide');
     } else {
       // Unhide target container/field wrapper/tab
       $elem.removeClass('hide');
-      $fieldWrapper.removeClass('hide');
+      if (!$elem.is('coral-checkbox')) {
+        $fieldWrapper.removeClass('hide');
+      }
       $('#' + tabLabelId).removeClass('hide');
     }
   }


### PR DESCRIPTION
Added new features to showhidedialogfields:

- possibility to use it within multifields
- possibility to combine different checkboxes determining the showing/hiding of fields
- possibility to have overlapping target values (e.g. 'tag' and 'tagtab') by using split instead of indexOf

Other differences:
- general cleanup of code
- performance improvements by removing extra hiding before show/hiding