### PR TITLE
AEM6.3-CFP6.3.3.6-Multifield-RTE-Tag-Fix

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/source/touchui-composite-multifield.js
@@ -188,7 +188,7 @@
                         }
 
                         _.each(record, function (rValue, rKey) {
-                            $field = $($fieldSets[i]).find("[name='./" + rKey + "']").last();
+                            $field = $($fieldSets[i]).find("[name='./" + rKey + "']").first();
 				
 			    if ($field.hasClass("coral-RichText-editable")) {
 	                        $field = $($fieldSets[i]).find("input[name='./" + rKey + "']").first();


### PR DESCRIPTION
**Issue:** The RTE and Tag component is not pre-populating the authored text after the installing the [https://www.adobeaemcloud.com/content/marketplace/marketplaceProxy.html?packagePath=/content/companies/public/adobe/packages/cq630/cumulativefixpack/AEM-CFP-6.3.3.6](AEM 6.3 Cumulative Fix Pack)

**Cause:**
The RichText component received enhancements in the 6.3.3.6 CFP. It was breaking multifield RTE and Tagfield prepopulation.

**Impacted AEM sling:resourceType in multifield scenarios:** 
- cq/gui/components/authoring/dialog/richtext
- cq/gui/components/coral/common/form/tagfield

**Impacted ACS AEM versions:**
- 3.11 (Project is running this version)
- 4.3.4 (I have upgraded the ACS AEM to 4.3.4, still the issue is not resolved, hence raising this PR as a fix for the community)