### PR TITLE
Feature/bug2084 cmf checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ### Added
 - #2118 - Adding functionality to showhidedialogfields TouchUI widget
 - #2110 - Adding File Fetcher for downloading and caching remote files in AEM Assets
+- #2084 - MCP Forms now extract default value/checkbox state from field value as well as from annotation options (both ways work now)
 - #2064 - Adding Marketo Form Component
 - #1919 - Report Builder | Path List Executor Implementation
 
@@ -24,7 +25,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #2124 - cleanup build logs for unittests
 
 ### Changed
-=======
 - #2101 - Cleanup public API of the remote Assets feature (#2094)
 
 

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/CheckboxComponent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/CheckboxComponent.java
@@ -19,6 +19,7 @@
  */
 package com.adobe.acs.commons.mcp.form;
 
+import com.adobe.acs.commons.mcp.util.IntrospectionUtil;
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
@@ -33,7 +34,8 @@ public final class CheckboxComponent extends FieldComponent {
         getComponentMetadata().put("value", "true");
         getComponentMetadata().put("uncheckedValue", "false");
         getComponentMetadata().put("required", false);
-        if (hasOption("checked")) {
+        boolean trueByDefault = IntrospectionUtil.getDeclaredValue(getAccessibleObject()).map(Boolean.TRUE::equals).orElse(false);
+        if (hasOption("checked") || trueByDefault) {
             getComponentMetadata().put("checked", "true");
         }
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FieldComponent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FieldComponent.java
@@ -20,6 +20,7 @@
 package com.adobe.acs.commons.mcp.form;
 
 import com.adobe.acs.commons.data.Variant;
+import com.adobe.acs.commons.mcp.util.IntrospectionUtil;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -72,7 +73,12 @@ public abstract class FieldComponent {
             componentMetadata.put("required", formField.required());
         }
         componentMetadata.put("emptyText", formField.hint());
-        getOption("default").ifPresent(val -> componentMetadata.put("value", val));
+
+        Optional<String> defaultValue = getOption("default");
+        if (!defaultValue.isPresent()) {
+            defaultValue = IntrospectionUtil.getDeclaredValue(fieldOrMethod).map(String::valueOf);
+        }
+        defaultValue.ifPresent(val -> componentMetadata.put("value", val));
         init();
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/util/IntrospectionUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/util/IntrospectionUtil.java
@@ -94,6 +94,12 @@ public class IntrospectionUtil {
         return basicType != null && (isPrimitive(field) || basicType.isEnum() || basicType == String.class);
     }
 
+    /**
+     * Try any available public constructors to create an object.  Return the
+     * first successful attempt.
+     * @param c Class to use
+     * @return Optional object if successful, otherwise empty optional.
+     */
     public static Optional<Object> createObject(Class c) {
         for (Constructor constructor : c.getConstructors()) {
             try {
@@ -118,13 +124,13 @@ public class IntrospectionUtil {
      */
     public static Optional<Object> getDeclaredValue(AccessibleObject field) {
         if (field instanceof Field) {
-            Field f = (Field) field; // Don't throw any errors, just don't report any results
+            Field f = (Field) field;
             Optional<Object> o = createObject(f.getDeclaringClass());
             if (o.isPresent()) {
                 try {
                     return Optional.ofNullable(FieldUtils.readField(f, o.get(), true));
                 } catch (Exception e) {
-                    // Do nothing
+                    // Don't throw any errors, just don't report any results
                 }
             }
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/util/IntrospectionUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/util/IntrospectionUtil.java
@@ -19,26 +19,35 @@
  */
 package com.adobe.acs.commons.mcp.util;
 
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
+import java.util.Optional;
+import org.apache.commons.lang3.reflect.FieldUtils;
 
 /**
  * General introspection utilities
  */
 public class IntrospectionUtil {
+
     /**
      * Figure out if field represents multiple values
+     *
      * @param clazz Field to evaluate
      * @return true if field is an array or collection
      */
     public static boolean hasMultipleValues(Class clazz) {
         return clazz.isArray() || Collection.class.isAssignableFrom(clazz);
     }
-    
+
     /**
-     * Determine if the field is a list or array and return its component type if so.
+     * Determine if the field is a list or array and return its component type
+     * if so.
+     *
      * @param field Field to evaluate
      * @return List/Array component type or field type if not a list or array
      */
@@ -63,7 +72,9 @@ public class IntrospectionUtil {
     }
 
     /**
-     * A primitive field is one which is a single or array/list of primitive values.
+     * A primitive field is one which is a single or array/list of primitive
+     * values.
+     *
      * @param field Field to evaluate
      * @return true if primitive or list/array of primitive values
      */
@@ -71,9 +82,10 @@ public class IntrospectionUtil {
         Class basicType = getCollectionComponentType(field);
         return basicType != null && (basicType.isPrimitive() || Number.class.isAssignableFrom(basicType) || basicType == String.class);
     }
-    
+
     /**
      * A simple field is either primitive, an enumeration, or a string.
+     *
      * @param field Field to evaluate
      * @return true if primitive, an enumeration, or a string
      */
@@ -81,7 +93,44 @@ public class IntrospectionUtil {
         Class basicType = getCollectionComponentType(field);
         return basicType != null && (isPrimitive(field) || basicType.isEnum() || basicType == String.class);
     }
-    
+
+    public static Optional<Object> createObject(Class c) {
+        for (Constructor constructor : c.getConstructors()) {
+            try {
+                Object obj = constructor.newInstance(new Object[constructor.getParameterCount()]);
+                return Optional.of(obj);
+            } catch (NullPointerException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
+                // Do nothing, just move on to the next constructor if any.
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Determine the declared (default) value of a field; if a method is
+     * provided then an Empty optional is returned Note: This assumes that there
+     * is a public no-parameter constructor for the declaring object, otherwise
+     * this will return an empty optional.
+     *
+     * @param field Field to evaluate
+     * @return Optional with value if any found, otherwise empty optional is
+     * returned
+     */
+    public static Optional<Object> getDeclaredValue(AccessibleObject field) {
+        if (field instanceof Field) {
+            Field f = (Field) field; // Don't throw any errors, just don't report any results
+            Optional<Object> o = createObject(f.getDeclaringClass());
+            if (o.isPresent()) {
+                try {
+                    return Optional.ofNullable(FieldUtils.readField(f, o.get(), true));
+                } catch (Exception e) {
+                    // Do nothing
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
     private IntrospectionUtil() {
         // Utility class, not to be instantiated directly
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/util/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/util/package-info.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  * #L%
  */
-@Version("4.2.0")
+@Version("4.3.0")
 package com.adobe.acs.commons.mcp.util;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/form/FieldComponentTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/form/FieldComponentTest.java
@@ -20,8 +20,10 @@
 package com.adobe.acs.commons.mcp.form;
 
 import com.adobe.acs.commons.mcp.form.FieldComponent.ClientLibraryType;
+import com.adobe.acs.commons.mcp.util.AnnotatedFieldDeserializer;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
@@ -99,7 +101,28 @@ public class FieldComponentTest {
         assertEquals("/apps/some/path", resourceCaptor.getValue().getPath());
     }
 
-    public class TestFieldComponent extends FieldComponent {
+    public static final String TEST_VALUE_1 = "Madness?  This is sparta!";
+
+    @Test
+    public void testDefaultFormValuesMatchCodeDefaults() {
+        Map<String, FieldComponent> form = AnnotatedFieldDeserializer.getFormFields(AnnotationTestClass.class, null);
+        assertEquals("Should have default string value", TEST_VALUE_1, form.get("test1").getComponentMetadata().get("value"));
+        assertEquals("1st Checkbox should be checked", "true", form.get("isChecked").getComponentMetadata().get("checked"));
+        assertEquals("2nd Checkbox not should be checked", null, form.get("isNotChecked").getComponentMetadata().get("checked"));
+    }
+
+    public static class AnnotationTestClass {
+        @FormField(name="field 1")
+        String test1=TEST_VALUE_1;
+
+        @FormField(name="Checkbox", component = CheckboxComponent.class)
+        boolean isChecked = true;
+
+        @FormField(name="Checkbox", component = CheckboxComponent.class)
+        boolean isNotChecked;
+    }
+
+    public static class TestFieldComponent extends FieldComponent {
         public TestFieldComponent(String[] options) {
             FormField field = new FormField() {
                 @Override

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/util/IntrospectionTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/util/IntrospectionTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 Adobe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adobe.acs.commons.mcp.util;
+
+import java.util.Optional;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Verify the introspection utility classes not tested elsewhere
+ */
+public class IntrospectionTest {
+
+    @Test
+    public void testDefaults() {
+        assertEquals("Should read default string value", Optional.of("defaultValue"), IntrospectionUtil.getDeclaredValue(FieldUtils.getDeclaredField(SimpleTest.class, "testString", true)));
+        assertEquals("Should read default boolean value", Optional.of(Boolean.TRUE), IntrospectionUtil.getDeclaredValue(FieldUtils.getDeclaredField(SimpleTest.class, "testBoolean", true)));
+    }
+
+    @Test
+    public void testNoDefaults() {
+        assertEquals("Should return empty for no default value", Optional.empty(), IntrospectionUtil.getDeclaredValue(FieldUtils.getDeclaredField(SimpleTest.class, "testNull", true)));
+    }
+
+    @Test
+    public void testParameterizedConstructor() {
+        assertEquals("Should read default string value", Optional.of("Test"), IntrospectionUtil.getDeclaredValue(FieldUtils.getDeclaredField(ComplexConstructorTest.class, "val1", true)));
+        assertEquals("Should read default boolean value", Optional.of(Boolean.TRUE), IntrospectionUtil.getDeclaredValue(FieldUtils.getDeclaredField(ComplexConstructorTest.class, "val2", true)));
+    }
+
+    @Test
+    public void testFailingConstructor() {
+        assertEquals("Should read no default string value", Optional.empty(), IntrospectionUtil.getDeclaredValue(FieldUtils.getDeclaredField(ErrorConstructorTest.class, "val1", true)));
+        assertEquals("Should read no default boolean value", Optional.empty(), IntrospectionUtil.getDeclaredValue(FieldUtils.getDeclaredField(ErrorConstructorTest.class, "val2", true)));
+    }
+
+    public static class SimpleTest {
+        private String testString = "defaultValue";
+        private boolean testBoolean = true;
+        private String testNull;
+    }
+
+    public static class ComplexConstructorTest {
+        private String val1;
+        private Boolean val2;
+
+        public ComplexConstructorTest(Object param1, Object param2) {
+            val1 = "Test";
+            val2 = true;
+        }
+    }
+
+    public static class ErrorConstructorTest {
+        private String val1 = "Test";
+        private Boolean val2 = true;
+
+        public ErrorConstructorTest(Object param1, Object param2) {
+            throw new NullPointerException("I didn't guard against null inputs");
+        }
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/util/IntrospectionTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/util/IntrospectionTest.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2019 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2019 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.mcp.util;
 


### PR DESCRIPTION
This PR adds some neat introspection hacking features to MCP Forms.
1) The introspection util class has methods to decipher default values defined on fields in beans, e.g. ```String test = "defaultValue"``` can be detected with this utility.
2) Checkbox components are checked by default if the boolean field value is set to true by default
3) Text components (and similar) take the defined value as the "value" parameter, generally interpreted as the default field value.