### PR TITLE
Update testing libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-4.3.2...HEAD
 
+### Changed
+- #2133 - Update test library dependencies
+
 ## [4.4.0] - 2019-12-17
 
 ### Added

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -383,6 +383,14 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-library</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 		</dependency>
@@ -704,10 +712,6 @@
 		<dependency>
 			<groupId>org.skyscreamer</groupId>
 			<artifactId>jsonassert</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>me.alexpanov</groupId>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -439,7 +439,7 @@
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
-			<version>1.5.2</version>
+			<version>2.9.1</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -722,7 +722,7 @@
 		<dependency>
 			<groupId>io.findify</groupId>
 			<artifactId>s3mock_2.11</artifactId>
-			<version>0.2.3</version>
+			<version>0.2.5</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -621,7 +621,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-csv</artifactId>
-			<version>1.6</version>
+			<version>1.7</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- needed to override the embedded commons.osgi in org.apache.sling.models.impl -->

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -688,10 +688,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.sling</groupId>
-			<artifactId>org.apache.sling.testing.jcr-mock</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>io.wcm</groupId>
 			<artifactId>io.wcm.testing.aem-mock.junit4</artifactId>
 			<exclusions>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -716,7 +716,7 @@
 		<dependency>
 			<groupId>me.alexpanov</groupId>
 			<artifactId>free-port-finder</artifactId>
-			<version>1.0</version>
+			<version>1.1.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -734,7 +734,7 @@
 		<dependency>
 			<groupId>org.xmlunit</groupId>
 			<artifactId>xmlunit-matchers</artifactId>
-			<version>2.5.1</version>
+			<version>2.6.3</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/bundle/src/test/java/com/adobe/acs/commons/filefetch/impl/FileFetchImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/filefetch/impl/FileFetchImplTest.java
@@ -33,6 +33,7 @@ import java.net.HttpURLConnection;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -76,6 +77,8 @@ public class FileFetchImplTest {
   }
 
   @Test
+  @Ignore
+  // Ignore until https://wcm-io.atlassian.net/browse/WTES-48 is resolved
   public void testFetch() throws IOException, ReplicationException {
     fileFetch.activate(new FileFetchConfiguration() {
 

--- a/bundle/src/test/java/com/adobe/acs/commons/filefetch/impl/FileFetchImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/filefetch/impl/FileFetchImplTest.java
@@ -77,8 +77,6 @@ public class FileFetchImplTest {
   }
 
   @Test
-  @Ignore
-  // Ignore until https://wcm-io.atlassian.net/browse/WTES-48 is resolved
   public void testFetch() throws IOException, ReplicationException {
     fileFetch.activate(new FileFetchConfiguration() {
 

--- a/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/HttpCacheConfigImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/httpcache/config/impl/HttpCacheConfigImplTest.java
@@ -76,7 +76,6 @@ public class HttpCacheConfigImplTest {
 
         when(request.getResourceResolver()).thenReturn(resourceResolver);
         when(resourceResolver.getUserID()).thenReturn("anonymous");
-        when(extension.accepts(request, systemUnderTest)).thenReturn(true);
     }
 
     private void activateWithDefaultValues(Map<String,Object> specifiedProps){

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/AssetFolderCreatorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/AssetFolderCreatorTest.java
@@ -32,7 +32,6 @@ import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.S3ClientOptions;
 import com.day.cq.dam.api.AssetManager;
 import com.google.common.base.Function;
-import io.findify.s3mock.S3Mock;
 import me.alexpanov.net.FreePortFinder;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.resource.ModifiableValueMap;

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/VersionServiceImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/VersionServiceImplTest.java
@@ -94,14 +94,14 @@ public final class VersionServiceImplTest {
     }
 
     @Test
-    @Ignore
+//    @Ignore
     public void lastVersion_noElement_returnNull() throws Exception {
         Version lastVersion = underTest.lastVersion(context.resourceResolver().getResource("/noVersion"));
         assertNull(lastVersion);
     }
 
     @Test
-    @Ignore
+//    @Ignore
     public void lastVersion_listOfVersion_returnLast() throws Exception {
         Version lastVersion = underTest.lastVersion(context.resourceResolver().getResource("/manyVersions"));
         assertEquals(lastVersion.getUUID(), manyVersionVersion.getUUID());

--- a/pom.xml
+++ b/pom.xml
@@ -393,13 +393,13 @@
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
-                <version>2.3.4</version>
+                <version>2.3.18</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.testing.sling-mock</artifactId>
-                <version>2.3.4</version>
+                <version>2.3.18</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -411,13 +411,7 @@
             <dependency>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.testing.sling-mock-oak</artifactId>
-                <version>2.1.2</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.sling</groupId>
-                <artifactId>org.apache.sling.testing.jcr-mock</artifactId>
-                <version>1.4.0</version>
+                <version>2.1.8-1.16.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -375,19 +375,19 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.powermock</groupId>
                 <artifactId>powermock-api-mockito2</artifactId>
-                <version>2.0.2</version>
+                <version>2.0.4</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.powermock</groupId>
                 <artifactId>powermock-module-junit4</artifactId>
-                <version>2.0.2</version>
+                <version>2.0.4</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -137,12 +137,12 @@
                         <dependency>
                             <groupId>org.apache.maven.shared</groupId>
                             <artifactId>maven-invoker</artifactId>
-                            <version>2.2</version>
+                            <version>3.0.1</version>
                         </dependency>
                         <dependency>
                             <groupId>org.apache.maven.release</groupId>
                             <artifactId>maven-release-oddeven-policy</artifactId>
-                            <version>2.5.3</version>
+                            <version>3.0-r1585899</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -434,8 +434,14 @@
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest</artifactId>
+                <version>2.2</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-library</artifactId>
-                <version>1.3</version>
+                <version>2.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -417,7 +417,7 @@
             <dependency>
                 <groupId>io.wcm</groupId>
                 <artifactId>io.wcm.testing.aem-mock.junit4</artifactId>
-                <version>2.7.0</version>
+                <version>2.7.2</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -423,7 +423,7 @@
             <dependency>
                 <groupId>io.wcm</groupId>
                 <artifactId>io.wcm.testing.aem-mock.junit4</artifactId>
-                <version>2.3.2</version>
+                <version>2.7.0</version>
                 <scope>test</scope>
                 <exclusions>
                     <exclusion>


### PR DESCRIPTION
Update the testing libraries to their latest available versions. In preparation for migration to JUnit 5.

* also update joda-time (version 2.9.1 comes with AEM 6.3 and 6.4)