### PR TITLE
Correctly evaluate If-None-Match header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-4.3.2...HEAD
 
+### Fixed
+- #2082 - ETag filter never sends 304
+
 ## [4.4.0] - 2019-12-17
 
 ### Added

--- a/bundle/src/main/java/com/adobe/acs/commons/etag/impl/EtagMessageDigestServletFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/etag/impl/EtagMessageDigestServletFilter.java
@@ -86,10 +86,10 @@ public class EtagMessageDigestServletFilter implements Filter {
         @AttributeDefinition(name = "Pattern", description = "Restricts the filter to paths that match the supplied regular expression. Requires Sling Engine 2.4.0 or newer.")
         String sling_filter_pattern() default ".*";
 
-        @AttributeDefinition(name = "Consider Response Headers", description = "If checked will also include the existing response headers for the digest calculation, i.e. different headers lead to different ETags. That is usually intended as you cannot send arbitrary response headers with a 304 response (https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5).")
+        @AttributeDefinition(name = "Consider Response Headers", description = "If checked will also include the existing response headers for the digest calculation, i.e. different headers lead to different ETags. That is usually intended as you cannot send arbitrary response headers with a 304 response (https://tools.ietf.org/html/rfc7232#section-4.1).")
         boolean considerResponseHeaders() default true;
 
-        @AttributeDefinition(name = "Ignored Response Headers", description = "The header names (case-insensitive) which should in no case be considered for the digest calculation as they are considered also for a 304 response (compare with https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5).")
+        @AttributeDefinition(name = "Ignored Response Headers", description = "The header names (case-insensitive) which should in no case be considered for the digest calculation as they are considered also for a 304 response (compare with https://tools.ietf.org/html/rfc7232#section-4.1).")
         String[] ignoredResponseHeaders() default { "Date", "Cache-Control", "Expires", "Vary" };
 
         @AttributeDefinition(name = "Salt", description = "The (optional) salt is also taken into account for the message digest calculation. It is necessary to change that value whenever the response content or the response headers are now modified differently in a proxy instance between client and AEM (e.g. Dispatcher sets additional headers).")

--- a/bundle/src/main/java/com/adobe/acs/commons/etag/impl/EtagMessageDigestServletFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/etag/impl/EtagMessageDigestServletFilter.java
@@ -60,10 +60,14 @@ import com.adobe.acs.commons.util.BufferedServletOutput.ResponseWriteMethod;
 import com.adobe.acs.commons.util.BufferedSlingHttpServletResponse;
 import com.google.common.io.BaseEncoding;
 
-/** Generates the ETag response header from a message digest of the response. This header is supposed to be cached also on the dispatcher! */
-@Component(configurationPolicy = ConfigurationPolicy.REQUIRE, property=EngineConstants.SLING_FILTER_SCOPE+"="+EngineConstants.FILTER_SCOPE_REQUEST)
+/** Generates the ETag response header from a message digest of the response. This header is supposed to be cached also on the
+ * dispatcher! */
+@Component(configurationPolicy = ConfigurationPolicy.REQUIRE, property = EngineConstants.SLING_FILTER_SCOPE + "="
+        + EngineConstants.FILTER_SCOPE_REQUEST)
 @Designate(ocd = Config.class)
 public class EtagMessageDigestServletFilter implements Filter {
+
+    private static final String WEAK_TAG_PREFIX = "W/";
 
     @ObjectClassDefinition(name = "ACS AEM Commons - Digest-based ETag Servlet Filter", description = "Sets an ETag response header based on a message digest from the response's content and optionally its' other headers. Enabling it increases the memory consumption as the full response need to be buffered before being sent to the client!")
     public @interface Config {
@@ -86,7 +90,7 @@ public class EtagMessageDigestServletFilter implements Filter {
         boolean considerResponseHeaders() default true;
 
         @AttributeDefinition(name = "Ignored Response Headers", description = "The header names (case-insensitive) which should in no case be considered for the digest calculation as they are considered also for a 304 response (compare with https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.5).")
-        String[] ignoredResponseHeaders() default {"Date", "Cache-Control", "Expires",  "Vary"};
+        String[] ignoredResponseHeaders() default { "Date", "Cache-Control", "Expires", "Vary" };
 
         @AttributeDefinition(name = "Salt", description = "The (optional) salt is also taken into account for the message digest calculation. It is necessary to change that value whenever the response content or the response headers are now modified differently in a proxy instance between client and AEM (e.g. Dispatcher sets additional headers).")
         String salt();
@@ -108,7 +112,8 @@ public class EtagMessageDigestServletFilter implements Filter {
         this.configuration = configuration;
         if (configuration.ignoredResponseHeaders() != null && configuration.ignoredResponseHeaders().length > 0) {
             // turn to lower case
-            ignoredHeaderNames = Arrays.asList(configuration.ignoredResponseHeaders()).stream().map(String::toLowerCase).collect(Collectors.toSet());
+            ignoredHeaderNames = Arrays.asList(configuration.ignoredResponseHeaders()).stream().map(String::toLowerCase)
+                    .collect(Collectors.toSet());
         } else {
             ignoredHeaderNames = Collections.emptySet();
         }
@@ -116,7 +121,7 @@ public class EtagMessageDigestServletFilter implements Filter {
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
-       // no-op
+        // no-op
     }
 
     @Override
@@ -128,66 +133,94 @@ public class EtagMessageDigestServletFilter implements Filter {
             log.debug("ETag filter not enabled");
             chain.doFilter(request, response);
             return;
-        } 
-        try {
-            // we already checked that this is a HTTP servlet response before
-            SlingHttpServletResponse slingHttpServletResponse = (SlingHttpServletResponse)response;
-            SlingHttpServletRequest slingHttpServletRequest = (SlingHttpServletRequest)request;
+        }
+        // we already checked that this is a HTTP servlet response before
+        SlingHttpServletResponse slingHttpServletResponse = (SlingHttpServletResponse) response;
+        SlingHttpServletRequest slingHttpServletRequest = (SlingHttpServletRequest) request;
+
+        // is this a GET?
+        if (slingHttpServletRequest.getMethod().equals(HttpConstants.METHOD_HEAD)
+                || slingHttpServletRequest.getMethod().equals(HttpConstants.METHOD_GET)) {
             ByteArrayOutputStream outputStream = configuration.enabledForOutputStream() ? new ByteArrayOutputStream() : null;
-            try (BufferedSlingHttpServletResponse bufferedResponse = new BufferedSlingHttpServletResponse(slingHttpServletResponse, new StringWriter(), outputStream)) {
+            try (BufferedSlingHttpServletResponse bufferedResponse = new BufferedSlingHttpServletResponse(slingHttpServletResponse,
+                    new StringWriter(), outputStream)) {
                 chain.doFilter(request, bufferedResponse);
                 if (!configuration.overwrite() && slingHttpServletResponse.containsHeader(HttpConstants.HEADER_ETAG)) {
-                    log.debug("Do not overwrite existing ETag header with value '{}'", slingHttpServletResponse.getHeader(HttpConstants.HEADER_ETAG));
+                    log.debug("Do not overwrite existing ETag header with value '{}'",
+                            slingHttpServletResponse.getHeader(HttpConstants.HEADER_ETAG));
                     return;
-                } 
+                }
                 // was the response buffered?
-                if (!configuration.enabledForOutputStream() && bufferedResponse.getBufferedServletOutput().getWriteMethod() == ResponseWriteMethod.OUTPUTSTREAM) {
+                if (!configuration.enabledForOutputStream()
+                        && bufferedResponse.getBufferedServletOutput().getWriteMethod() == ResponseWriteMethod.OUTPUTSTREAM) {
                     log.debug("Can not calculate message digest as response was written via output stream which was not buffered.");
                     return;
-                } 
+                }
                 if (slingHttpServletResponse.isCommitted()) {
                     log.error("Can not send ETag header because response is already committed, try to give this filter a higher ranking!");
                     return;
-                } 
-                String digest = calculateDigestFromResponse(bufferedResponse);
-                slingHttpServletRequest.getRequestProgressTracker().log("ETag from digest calculated with {0}: {1}", configuration.messageDigestAlgorithm(), digest);
-                slingHttpServletResponse.setHeader(HttpConstants.HEADER_ETAG, "\"" + digest +"\"");
-                if (isUnmodified(slingHttpServletRequest.getHeaders(HttpHeaders.IF_NONE_MATCH), digest)) {
-                    log.debug("Digest is equal to one of the given ETags in the If-None-Match request header, returning empty response with a 304");
-                    bufferedResponse.resetBuffer();
-                    slingHttpServletResponse.setStatus(HttpStatus.SC_NOT_MODIFIED);
-                    return;
                 }
-                if (configuration.addAsHtmlComment() && bufferedResponse.getBufferedServletOutput().getWriteMethod() == ResponseWriteMethod.WRITER && slingHttpServletResponse.getContentType() != null && slingHttpServletResponse.getContentType().startsWith("text/html")) {
-                    bufferedResponse.getWriter().println(String.format("%n<!-- ETag: %s -->", digest));
+
+                try {
+                    String digest = calculateDigestFromResponse(bufferedResponse);
+                    slingHttpServletRequest.getRequestProgressTracker().log("ETag from digest calculated with {0}: {1}",
+                            configuration.messageDigestAlgorithm(), digest);
+                    slingHttpServletResponse.setHeader(HttpConstants.HEADER_ETAG, "\"" + digest + "\"");
+                    if (isUnmodified(slingHttpServletRequest.getHeaders(HttpHeaders.IF_NONE_MATCH), digest)) {
+                        log.debug(
+                                "Digest is equal to one of the given ETags in the If-None-Match request header, returning empty response with a 304");
+                        bufferedResponse.resetBuffer();
+                        slingHttpServletResponse.setStatus(HttpStatus.SC_NOT_MODIFIED);
+                        return;
+                    }
+                    if (configuration.addAsHtmlComment()
+                            && bufferedResponse.getBufferedServletOutput().getWriteMethod() == ResponseWriteMethod.WRITER
+                            && slingHttpServletResponse.getContentType() != null
+                            && slingHttpServletResponse.getContentType().startsWith("text/html")) {
+                        bufferedResponse.getWriter().println(String.format("%n<!-- ETag: %s -->", digest));
+                    }
+                } catch (NoSuchAlgorithmException e) {
+                    log.error("The algorithm configured for this servlet filter is invalid: " + configuration.messageDigestAlgorithm(), e);
                 }
             }
-        } catch (NoSuchAlgorithmException e) {
-            log.error("The algorithm configured for this servlet filter is invalid: " + configuration.messageDigestAlgorithm(), e);
         }
     }
-    
-    /**
-     * Handles conditional requests like outlined in RFC7232.
+
+    /** Handles conditional requests like outlined in RFC7232.
+     * 
      * @param slingHttpServletRequest
      * @param slingHttpServletResponse
      * @return {@code true} in case this was a conditional request and the response was not modified, otherwise {@code false}
-     * @see <a href="// https://tools.ietf.org/html/rfc7232#section-3.2">RFC7232</a>
-     */
+     * @see <a href="// https://tools.ietf.org/html/rfc7232#section-3.2">RFC7232</a> */
     static boolean isUnmodified(Enumeration<String> ifNoneMatchETags, String responseETag) {
         if (ifNoneMatchETags == null) {
             throw new IllegalStateException("Can not access request headers");
         }
         while (ifNoneMatchETags.hasMoreElements()) {
             String ifNoneMatchETag = ifNoneMatchETags.nextElement();
-            if (ifNoneMatchETag.equals(responseETag) || ifNoneMatchETag.equals("*")) {
+            if (ifNoneMatchETag.equals("*")) {
+                return true;
+            }
+            // strip weak tag prefix
+            if (ifNoneMatchETag.startsWith(WEAK_TAG_PREFIX)) {
+                ifNoneMatchETag = ifNoneMatchETag.substring(WEAK_TAG_PREFIX.length());
+            }
+            // remove double quotes (first and last value character)
+            if (!ifNoneMatchETag.startsWith("\"") || !ifNoneMatchETag.endsWith("\"")) {
+                // ignoring invalid etag
+                log.debug("Ignoring invalid ETag not starting and ending with quotes: {}" + ifNoneMatchETag);
+                continue;
+            }
+            ifNoneMatchETag = ifNoneMatchETag.substring(1, ifNoneMatchETag.length() - 1);
+            if (ifNoneMatchETag.equals(responseETag)) {
                 return true;
             }
         }
         return false;
     }
 
-    String calculateDigestFromResponse(BufferedSlingHttpServletResponse bufferedResponse) throws NoSuchAlgorithmException, UnsupportedEncodingException {
+    String calculateDigestFromResponse(BufferedSlingHttpServletResponse bufferedResponse)
+            throws NoSuchAlgorithmException, UnsupportedEncodingException {
         MessageDigest messageDigest = MessageDigest.getInstance(configuration.messageDigestAlgorithm());
         if (bufferedResponse.getBufferedServletOutput().getWriteMethod() == ResponseWriteMethod.OUTPUTSTREAM) {
             messageDigest.update(bufferedResponse.getBufferedServletOutput().getBufferedBytes());
@@ -198,7 +231,7 @@ public class EtagMessageDigestServletFilter implements Filter {
             }
             messageDigest.update(bufferedResponse.getBufferedServletOutput().getBufferedString().getBytes(charsetName));
         }
-   
+
         // consider header values as well?
         if (configuration.considerResponseHeaders()) {
             for (String name : bufferedResponse.getHeaderNames()) {

--- a/bundle/src/test/java/com/adobe/acs/commons/etag/impl/EtagMessageDigestServletFilterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/etag/impl/EtagMessageDigestServletFilterTest.java
@@ -20,13 +20,24 @@
 package com.adobe.acs.commons.etag.impl;
 
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Vector;
 
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.apache.http.HttpHeaders;
+import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.request.RequestProgressTracker;
+import org.apache.sling.api.servlets.HttpConstants;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,7 +57,12 @@ public class EtagMessageDigestServletFilterTest {
     @Mock
     SlingHttpServletResponse mockResponse;
     BufferedSlingHttpServletResponse bufferedResponse;
-    
+
+    @Mock
+    SlingHttpServletRequest mockRequest;
+
+    @Mock
+    RequestProgressTracker tracker; 
     EtagMessageDigestServletFilter filter;
 
     private static final String EXAMPLE_TEXT = "The quick brown fox jumps over the lazy dog";
@@ -58,6 +74,7 @@ public class EtagMessageDigestServletFilterTest {
         filter = new EtagMessageDigestServletFilter();
         filter.activate(configuration);
         bufferedResponse = new BufferedSlingHttpServletResponse(mockResponse);
+        Mockito.when(mockRequest.getRequestProgressTracker()).thenReturn(tracker);
     }
 
     @Test
@@ -131,10 +148,60 @@ public class EtagMessageDigestServletFilterTest {
         ifNoneMatchETags = new Vector<>();
         ifNoneMatchETags.add("*");
         Assert.assertTrue(EtagMessageDigestServletFilter.isUnmodified(ifNoneMatchETags.elements(), "sometag"));
+        // invalid quotes
+        ifNoneMatchETags = new Vector<>();
+        ifNoneMatchETags.add("\"ab");
+        Assert.assertFalse(EtagMessageDigestServletFilter.isUnmodified(ifNoneMatchETags.elements(), "ab"));
     }
 
-    @Test(expected=IllegalStateException.class)
+    @Test
     public void testIsUnmodifiedWithNullParameter() {
-        EtagMessageDigestServletFilter.isUnmodified(null, null);
+        Assert.assertFalse(EtagMessageDigestServletFilter.isUnmodified(null, "ab"));
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    public void testDoFilter() throws IOException, ServletException {
+        Mockito.when(configuration.addAsHtmlComment()).thenReturn(true);
+        Mockito.when(configuration.enabled()).thenReturn(true);
+        StringWriter responseWriter = new StringWriter();
+        Mockito.when(mockResponse.getWriter()).thenReturn(new PrintWriter(responseWriter));
+        Mockito.when(mockResponse.getContentType()).thenReturn("text/html");
+        
+        // first test POST
+        Mockito.when(mockRequest.getMethod()).thenReturn(HttpConstants.METHOD_POST);
+        final FilterChain chain = new FilterChain() {
+            @Override
+            public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException {
+                response.getWriter().write(EXAMPLE_TEXT);
+            }
+        };
+        filter.doFilter(mockRequest, mockResponse, chain);
+        Mockito.verify(mockResponse, Mockito.never()).setHeader(Mockito.eq(HttpConstants.HEADER_ETAG), Mockito.anyString());
+        // don't change response code
+        Mockito.verify(mockResponse, Mockito.never()).setStatus(Mockito.anyInt());
+        
+        // then test GET
+        Mockito.when(mockRequest.getMethod()).thenReturn(HttpConstants.METHOD_GET);
+        responseWriter = new StringWriter();
+        Mockito.when(mockResponse.getWriter()).thenReturn(new PrintWriter(responseWriter));
+        // write to response
+        filter.doFilter(mockRequest, mockResponse, chain);
+        Mockito.verify(mockResponse).setHeader(HttpConstants.HEADER_ETAG, "\"9e107d9d372bb6826bd81d3542a419d6\"");
+        // don't change response code
+        Mockito.verify(mockResponse, Mockito.never()).setStatus(Mockito.anyInt());
+        Mockito.verify(mockResponse, Mockito.never()).setStatus(Mockito.anyInt(), Mockito.anyString());
+        
+        Assert.assertEquals(responseWriter.toString(), String.format("%s%n<!-- ETag: 9e107d9d372bb6826bd81d3542a419d6 -->%n", EXAMPLE_TEXT));
+        
+        // now request carries if-none-match header
+        Vector<String> ifNoneMatchETags = new Vector<>();
+        ifNoneMatchETags.add("\"someinvalidone\"");
+        ifNoneMatchETags.add("\"9e107d9d372bb6826bd81d3542a419d6\"");
+        Mockito.when(mockRequest.getHeaders(HttpHeaders.IF_NONE_MATCH)).thenReturn(ifNoneMatchETags.elements());
+        filter.doFilter(mockRequest, mockResponse, chain);
+        
+        Mockito.verify(mockResponse).setStatus(304);
+        
     }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/etag/impl/EtagMessageDigestServletFilterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/etag/impl/EtagMessageDigestServletFilterTest.java
@@ -109,10 +109,25 @@ public class EtagMessageDigestServletFilterTest {
     @Test
     public void testIsUnmodified() {
         Vector<String> ifNoneMatchETags = new Vector<>();
-        ifNoneMatchETags.add("ab");
+        ifNoneMatchETags.add("W/\"ab\"");
+        ifNoneMatchETags.add("\"cd\"");
+        Assert.assertTrue(EtagMessageDigestServletFilter.isUnmodified(ifNoneMatchETags.elements(), "cd"));
+        // with weak tag it should still match
+        ifNoneMatchETags = new Vector<>();
+        ifNoneMatchETags.add("W/\"ab\"");
+        ifNoneMatchETags.add("W/\"cd\"");
+        Assert.assertTrue(EtagMessageDigestServletFilter.isUnmodified(ifNoneMatchETags.elements(), "cd"));
+        // without quotes it should not match
+        ifNoneMatchETags = new Vector<>();
+        ifNoneMatchETags.add("W/\"ab\"");
         ifNoneMatchETags.add("cd");
-        Assert.assertTrue(EtagMessageDigestServletFilter.isUnmodified(ifNoneMatchETags.elements(), "ab"));
+        Assert.assertFalse(EtagMessageDigestServletFilter.isUnmodified(ifNoneMatchETags.elements(), "cd"));
+        // non matching etag
+        ifNoneMatchETags = new Vector<>();
+        ifNoneMatchETags.add("W/\"ab\"");
+        ifNoneMatchETags.add("W/\"cd\"");
         Assert.assertFalse(EtagMessageDigestServletFilter.isUnmodified(ifNoneMatchETags.elements(), "de"));
+        // wildcard match
         ifNoneMatchETags = new Vector<>();
         ifNoneMatchETags.add("*");
         Assert.assertTrue(EtagMessageDigestServletFilter.isUnmodified(ifNoneMatchETags.elements(), "sometag"));


### PR DESCRIPTION
Only send ETag and 304 for GET/HEAD.
This closes #2082