### PR TITLE
Support create page dialogs now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ after the 3.9.0 release. All changes up until the 3.9.0 release can be found in 
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## Unreleased ([details][unreleased changes details])
-
-### Fixed
-- #2146 - POI exception generating Excel file with too many references
-
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-4.3.2...HEAD
 
@@ -18,8 +14,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ### Fixed
 - #2082 - ETag filter never sends 304
 - #2148 bugfix for displaying sizes (adresses #2132)
+- #2146 - POI exception generating Excel file with too many references
 
 ### Changed
+- #2164 - Adding support for page create dialog to content model framework (aka dialog resource provider)
 
 ## [4.4.0] - 2019-12-17
 

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FieldComponent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FieldComponent.java
@@ -73,6 +73,9 @@ public abstract class FieldComponent {
             componentMetadata.put("required", formField.required());
         }
         componentMetadata.put("emptyText", formField.hint());
+        if (formField.showOnCreate()) {
+            componentMetadata.put("cq:showOnCreate", true);
+        }
 
         Optional<String> defaultValue = getOption("default");
         if (!defaultValue.isPresent()) {

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FieldsetComponent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FieldsetComponent.java
@@ -43,7 +43,7 @@ public final class FieldsetComponent extends ContainerComponent {
 
     @Override
     public Resource buildComponentResource() {
-        getComponentMetadata().put(CLASS, getClass());
+        getComponentMetadata().put(CLASS, getCssClass());
         return super.buildComponentResource();
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FormField.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FormField.java
@@ -48,6 +48,8 @@ public @interface FormField {
 
     String[] options() default {};
 
+    boolean showOnCreate() default true;
+
     public static class Factory {
         private Factory() {
             // Factory cannot be instantiated
@@ -94,6 +96,11 @@ public @interface FormField {
                 @Override
                 public Class<? extends Annotation> annotationType() {
                     return null;
+                }
+
+                @Override
+                public boolean showOnCreate() {
+                    return true;
                 }
             };
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/package-info.java
@@ -20,7 +20,7 @@
 /**
  * Form components for MCP
  */
-@Version("5.0.0")
+@Version("5.1.0")
 package com.adobe.acs.commons.mcp.form;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/form/FieldComponentTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/form/FieldComponentTest.java
@@ -179,6 +179,10 @@ public class FieldComponentTest {
                 public String[] options() {
                     return options;
                 }
+
+                public boolean showOnCreate() {
+                    return true;
+                }
             };
             setup("test", null, field, null);
         }


### PR DESCRIPTION
The dialog resource provider was not setting any fields to show in create page dialogs.  Now that feature is enabled for all fields by default but can optionally be toggled in the annotation for each field.