### PR TITLE
Use HTTPS URL for Maven Central

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -2,7 +2,7 @@
     <mirrors>
         <mirror>
             <id>central-mirror</id>
-            <url>http://repo.maven.apache.org/maven2</url>
+            <url>https://repo.maven.apache.org/maven2</url>
             <mirrorOf>external:*,!adobe-public-releases</mirrorOf>
         </mirror>
     </mirrors>


### PR DESCRIPTION
(https://support.sonatype.com/hc/en-us/articles/360041287334-Central-501-HTTPS-Required)

This closes #2171

The build still fails due to https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/2169