### PR TITLE
remove all direct references to Oak API (#2195)

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/remoteassets/impl/RemoteAssetDecorator.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/remoteassets/impl/RemoteAssetDecorator.java
@@ -24,7 +24,6 @@ import com.day.cq.dam.api.DamConstants;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.api.security.user.User;
 import org.apache.jackrabbit.api.security.user.UserManager;
-import org.apache.jackrabbit.oak.spi.security.user.UserConstants;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceDecorator;
 import org.apache.sling.api.resource.ResourceResolver;
@@ -58,6 +57,8 @@ public class RemoteAssetDecorator implements ResourceDecorator {
 
     private static final Logger LOG = LoggerFactory.getLogger(RemoteAssetDecorator.class);
     private static int SYNC_WAIT_SECONDS = 100;
+
+    private static String ADMIN_ID = "admin";
 
     /**
      * This set stores resource paths for remote assets that are in the process
@@ -168,7 +169,7 @@ public class RemoteAssetDecorator implements ResourceDecorator {
     private boolean isAllowedUser(Resource resource) throws RepositoryException {
         ResourceResolver resourceResolver = resource.getResourceResolver();
         String userId = resourceResolver.getUserID();
-        if (!userId.equals(UserConstants.DEFAULT_ADMIN_ID)) {
+        if (!userId.equals(ADMIN_ID)) {
             if (this.config.getWhitelistedServiceUsers().contains(userId)) {
                 return true;
             }

--- a/bundle/src/main/java/com/adobe/acs/commons/remoteassets/impl/RemoteAssetsNodeSyncImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/remoteassets/impl/RemoteAssetsNodeSyncImpl.java
@@ -38,7 +38,6 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.fluent.Executor;
 import org.apache.http.client.fluent.Request;
-import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants;
 import org.apache.jackrabbit.vault.util.JcrConstants;
 import org.apache.sling.api.resource.ModifiableValueMap;
 import org.apache.sling.api.resource.Resource;
@@ -48,7 +47,6 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
@@ -81,6 +79,8 @@ import java.util.regex.Pattern;
 )
 public class RemoteAssetsNodeSyncImpl implements RemoteAssetsNodeSync {
 
+  private static final String REP_POLICY = "rep:policy";
+
     private static final Logger LOG = LoggerFactory.getLogger(RemoteAssetsNodeSyncImpl.class);
     private static final Pattern DATE_REGEX = Pattern
             .compile("[A-Za-z]{3}\\s[A-Za-z]{3}\\s\\d\\d\\s\\d\\d\\d\\d\\s\\d\\d:\\d\\d:\\d\\d\\sGMT[-+]\\d\\d\\d\\d");
@@ -92,7 +92,7 @@ public class RemoteAssetsNodeSyncImpl implements RemoteAssetsNodeSync {
             JcrConstants.JCR_ISCHECKEDOUT, JcrConstants.JCR_UUID, JcrConstants.JCR_PREDECESSORS
     ));
     private static final Set<String> PROTECTED_NODES = new HashSet<>(Arrays.asList(
-            DamConstants.THUMBNAIL_NODE, AccessControlConstants.REP_POLICY
+            DamConstants.THUMBNAIL_NODE, REP_POLICY
     ));
 
     @Reference

--- a/bundle/src/main/java/com/adobe/acs/commons/users/impl/Ace.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/users/impl/Ace.java
@@ -26,7 +26,6 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlEntry;
 import org.apache.jackrabbit.commons.jackrabbit.authorization.AccessControlUtils;
-import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +33,6 @@ import javax.jcr.RepositoryException;
 import javax.jcr.Value;
 import javax.jcr.security.AccessControlManager;
 import javax.jcr.security.Privilege;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -64,10 +62,10 @@ public final class Ace {
     private static final String PROP_TYPE = "type";
     private static final String PROP_PATH = "path";
     private static final String PROP_PRIVILEGES = "privileges";
-    private static final String PROP_REP_GLOB = AccessControlConstants.REP_GLOB;
-    private static final String PROP_REP_NT_NAMES = AccessControlConstants.REP_NT_NAMES;
-    private static final String PROP_REP_ITEM_NAMES = AccessControlConstants.REP_ITEM_NAMES;
-    private static final String PROP_REP_PREFIXES = AccessControlConstants.REP_PREFIXES;
+    private static final String PROP_REP_GLOB = "rep:glob";
+    private static final String PROP_REP_NT_NAMES = "rep:ntNames";
+    private static final String PROP_REP_ITEM_NAMES = "rep:itemNames";
+    private static final String PROP_REP_PREFIXES = "rep:prefixes";
 
 
     private String type;
@@ -221,22 +219,22 @@ public final class Ace {
         // rep:glob
 
         // We are converting the single value RepGlob into a List for convenience
-        if(!isRestrictionValid(this.hasRepGlob(), actual.getRestrictions(AccessControlConstants.REP_GLOB), Arrays.asList(new String[]{this.getRepGlob()}))) {
+        if(!isRestrictionValid(this.hasRepGlob(), actual.getRestrictions(PROP_REP_GLOB), Arrays.asList(new String[]{this.getRepGlob()}))) {
             return false;
         }
 
         // rep:ntNames
-        if(!isRestrictionValid(this.hasRepNtNames(), actual.getRestrictions(AccessControlConstants.REP_NT_NAMES), this.getRepNtNames())) {
+        if(!isRestrictionValid(this.hasRepNtNames(), actual.getRestrictions(PROP_REP_NT_NAMES), this.getRepNtNames())) {
             return false;
         }
 
         // rep:itemNames
-        if(!isRestrictionValid(this.hasRepItemNames(), actual.getRestrictions(AccessControlConstants.REP_ITEM_NAMES), this.getRepItemNames())) {
+        if(!isRestrictionValid(this.hasRepItemNames(), actual.getRestrictions(PROP_REP_ITEM_NAMES), this.getRepItemNames())) {
             return false;
         }
 
         // rep:prefixes
-        if(!isRestrictionValid(this.hasRepPrefixes(), actual.getRestrictions(AccessControlConstants.REP_PREFIXES), this.getRepPrefixes())) {
+        if(!isRestrictionValid(this.hasRepPrefixes(), actual.getRestrictions(PROP_REP_PREFIXES), this.getRepPrefixes())) {
             return false;
         }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/users/impl/EnsureAce.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/users/impl/EnsureAce.java
@@ -47,7 +47,6 @@ import org.apache.jackrabbit.api.security.JackrabbitAccessControlList;
 import org.apache.jackrabbit.api.security.JackrabbitAccessControlManager;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.commons.jackrabbit.authorization.AccessControlUtils;
-import org.apache.jackrabbit.oak.spi.security.authorization.accesscontrol.AccessControlConstants;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.slf4j.Logger;
@@ -60,6 +59,14 @@ import com.day.cq.search.PredicateGroup;
 public class EnsureAce {
 
     private static final Logger log = LoggerFactory.getLogger(EnsureAce.class);
+
+    private static final String PROP_PRIVILEGES = "privileges";
+    private static final String PROP_REP_GLOB = "rep:glob";
+    private static final String PROP_REP_NT_NAMES = "rep:ntNames";
+    private static final String PROP_REP_ITEM_NAMES = "rep:itemNames";
+    private static final String PROP_REP_PREFIXES = "rep:prefixes";
+    private static final String PROP_NT_REP_ACE = "rep:ACE";
+    private static final String PROP_REP_PRINCIPAL_NAME = "rep:principalName";
 
     @Reference
     private CloseableQueryBuilder queryBuilder;
@@ -147,25 +154,25 @@ public class EnsureAce {
 
             // Add rep:glob restriction
             if (ace.hasRepGlob()) {
-                restrictions.put(AccessControlConstants.REP_GLOB,
+                restrictions.put(PROP_REP_GLOB,
                         valueFactory.createValue(ace.getRepGlob(), PropertyType.STRING));
             }
 
             // Add rep:ntNames restriction
             if (ace.hasRepNtNames()) {
-                multiRestrictions.put(AccessControlConstants.REP_NT_NAMES,
+                multiRestrictions.put(PROP_REP_NT_NAMES,
                         getMultiValues(valueFactory, ace.getRepNtNames(), PropertyType.NAME));
             }
 
             // Add rep:itemNames
             if (ace.hasRepItemNames()) {
-                multiRestrictions.put(AccessControlConstants.REP_ITEM_NAMES,
+                multiRestrictions.put(PROP_REP_ITEM_NAMES,
                         getMultiValues(valueFactory, ace.getRepItemNames(), PropertyType.NAME));
             }
 
             // Add rep:prefixes
             if (ace.hasRepPrefixes()) {
-                multiRestrictions.put(AccessControlConstants.REP_PREFIXES,
+                multiRestrictions.put(PROP_REP_PREFIXES,
                         getMultiValues(valueFactory, ace.getRepPrefixes(), PropertyType.STRING));
             }
 
@@ -241,8 +248,8 @@ public class EnsureAce {
 
         final Map<String, String> params = new HashMap<String, String>();
 
-        params.put("type", AccessControlConstants.NT_REP_ACE);
-        params.put("property", AccessControlConstants.REP_PRINCIPAL_NAME);
+        params.put("type", PROP_NT_REP_ACE);
+        params.put("property", PROP_REP_PRINCIPAL_NAME);
         params.put("property.value", principalName);
         params.put("p.limit", "-1");
 

--- a/bundle/src/main/java/com/adobe/acs/commons/users/impl/EnsureAce.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/users/impl/EnsureAce.java
@@ -60,7 +60,6 @@ public class EnsureAce {
 
     private static final Logger log = LoggerFactory.getLogger(EnsureAce.class);
 
-    private static final String PROP_PRIVILEGES = "privileges";
     private static final String PROP_REP_GLOB = "rep:glob";
     private static final String PROP_REP_NT_NAMES = "rep:ntNames";
     private static final String PROP_REP_ITEM_NAMES = "rep:itemNames";

--- a/bundle/src/main/java/com/adobe/acs/commons/users/impl/EnsureGroup.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/users/impl/EnsureGroup.java
@@ -20,6 +20,7 @@
 
 package com.adobe.acs.commons.users.impl;
 
+import java.security.Principal;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -38,7 +39,6 @@ import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.Service;
 import org.apache.jackrabbit.api.security.user.Authorizable;
 import org.apache.jackrabbit.api.security.user.UserManager;
-import org.apache.jackrabbit.oak.spi.security.principal.PrincipalImpl;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.osgi.PropertiesUtil;
@@ -223,7 +223,7 @@ public final class EnsureGroup implements EnsureAuthorizable {
             log.debug("Requesting creation of group [ {} ] at [ {} ]", group.getPrincipalName(),
                     group.getIntermediatePath());
 
-            jcrGroup = userManager.createGroup(new PrincipalImpl(group.getPrincipalName()), group.getIntermediatePath());
+            jcrGroup = userManager.createGroup(new SimplePrincipal(group.getPrincipalName()), group.getIntermediatePath());
             log.debug("Created group at [ {} ]", jcrGroup.getPath());
         }
 
@@ -357,5 +357,36 @@ public final class EnsureGroup implements EnsureAuthorizable {
             throw new IllegalArgumentException("Unknown Ensure Group operation [ " + operationStr + " ]", e);
         }
     }
+
+
+    // taken from https://www.albinsblog.com/2015/04/how-to-craetemanage-groups-and-users-java-adobecq5.html
+    private static class SimplePrincipal implements Principal {
+      protected final String name;
+
+      public SimplePrincipal(String name) {
+          if (StringUtils.isBlank(name)) {
+              throw new IllegalArgumentException("Principal name cannot be blank.");
+          }
+          this.name = name;
+      }
+
+      public String getName() {
+          return name;
+      }
+
+      @Override
+      public int hashCode() {
+          return name.hashCode();
+      }
+
+      @Override
+      public boolean equals(Object obj) {
+          if (obj instanceof Principal) {
+              return name.equals(((Principal) obj).getName());
+          }
+          return false;
+      }
+  }
+
 
 }


### PR DESCRIPTION
I we should avoid direct dependencies to Oak API, in most cases it should be replaced by higher-level APIs.

In case of
* RemoteAssets: Not sure why they are used at all...
* EnsureGroup/EnsureUser: Instead of dealing with the raw repo representation we should use the Jackrabbit API for it.