### PR TITLE
Speedup test execution

### DIFF
--- a/bundle/src/test/java/com/adobe/acs/commons/analysis/jcrchecksum/impl/servlets/ChecksumGeneratorServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/analysis/jcrchecksum/impl/servlets/ChecksumGeneratorServletTest.java
@@ -53,7 +53,7 @@ public class ChecksumGeneratorServletTest {
     private static final String SERVLET_EXTENSION = "txt";
 
     @Rule
-    public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
+    public final SlingContext context = new SlingContext();
 
     @Spy
     private ChecksumGenerator checksumGenerator = new ChecksumGeneratorImpl();

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/TagReportTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/TagReportTest.java
@@ -49,7 +49,7 @@ import junit.framework.Assert;
 public class TagReportTest {
 
   @Rule
-  public AemContext ctx = new AemContext(ResourceResolverType.JCR_MOCK);
+  public AemContext ctx = new AemContext();
 
   @Mock
   private ActionManager actionManager;


### PR DESCRIPTION
Switching TagReportTest to the Mock-Repository speeds up the tests in this class from ~ 24 seconds to 5 seconds.

Use
```grep -h "<testcase" `find . -iname "TEST-*.xml"` | perl -a -p -e 's/<testcase name="(.*)" classname="(.*)" time="(.*)".*/$3\t$2 $1/'  | sort -rn | head```

to detect the slowest tests. Unfortunately speeding up the other test cases requires more than trivial changes.