### PR TITLE
Defect/json/jcr json adapter not closing arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ### Fixed
 - #2206 fix sonar warnings; some package versions had to be increased
+- Fixed JcrJsonAdapter IllegalStateException when writing multi-valued JCR properties
 
 ### Changed
 - #2208 - Remove the WCMInbox webconsole plugin (#2205)

--- a/bundle/src/main/java/com/adobe/acs/commons/json/JcrJsonAdapter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/json/JcrJsonAdapter.java
@@ -50,6 +50,7 @@ public class JcrJsonAdapter extends TypeAdapter<Node> {
                         for (Value v : p.getValues()) {
                             writeValue(writer, v);
                         }
+                        writer.endArray();
                     } else {
                         writeValue(writer, p.getValue());
                     }

--- a/bundle/src/test/java/com/adobe/acs/commons/json/JcrJsonAdapterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/json/JcrJsonAdapterTest.java
@@ -19,11 +19,13 @@
  */
 package com.adobe.acs.commons.json;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import java.io.IOException;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
+
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.jackrabbit.commons.JcrUtils;
 import org.apache.sling.testing.mock.jcr.MockJcr;
@@ -69,6 +71,23 @@ public class JcrJsonAdapterTest {
         assertEquals(2L, getInteger(jsonObject.get("l2").getAsJsonObject(), "level").longValue());
         assertTrue(jsonObject.get("l2").getAsJsonObject().has("l3"));
         assertEquals(3L, getInteger(jsonObject.get("l2").getAsJsonObject().get("l3").getAsJsonObject(), "level").longValue());
+    }
+
+    /**
+     * Test of write method, of class JcrJsonAdapter.
+     * @throws javax.jcr.RepositoryException
+     */
+    @Test
+    public void testWriteWithMultiValuedProperty() throws RepositoryException {
+        Node root = JcrUtils.getOrCreateByPath("/test/level1", JcrConstants.NT_UNSTRUCTURED, session);
+        String[] expectedValues = new String[] { "egg", "beater", "9000"};
+        root.setProperty("array", expectedValues);
+        
+        JsonObject jsonObject = toJsonObject(root);
+
+        JsonArray testArray = jsonObject.getAsJsonArray("array");
+        String[] actualValues = new String[] { testArray.get(0).getAsString(), testArray.get(1).getAsString(), testArray.get(2).getAsString()};
+        assertArrayEquals(expectedValues, actualValues);
     }
 
     /**


### PR DESCRIPTION
JcrJsonAdapter throws an IllegalStateException when serializing JCR nodes with multi-valued properties. This is due to the fact that the current JcrJsonAdapter calls 'writer.startArray' but does not call 'writer.endArray' to close the JSON array.