### PR TITLE
fixes #2214 java.lang.NoClassDefFoundError: javax/xml/bind/DatatypeCo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ### Added
 
 ### Fixed
+- #2214 fix java.lang.NoClassDefFoundError: javax/xml/bind/DatatypeConverter in Adobe I/O API's on AEM 6.4
 - #2206 fix sonar warnings; some package versions had to be increased
 - Fixed JcrJsonAdapter IllegalStateException when writing multi-valued JCR properties
 

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -69,7 +69,9 @@
 							com.github.benmanes.caffeine*;resolution:=optional,
 							com.fasterxml.jackson.core;version="[2.8,3)";resolution:=optional,
 							com.fasterxml.jackson.databind;version="[2.8,3)";resolution:=optional,
-							javax.xml.bind;version="[2.2,3)";resolution:=optional,
+							<!-- wider version range: use 2.1 as AEM 6.4 still uses it, 2.2 is for AEM 6.5 -->
+							<!-- required for jwt library used by Adobe I/O APIs -->
+							javax.xml.bind;version="[2.1,3)",
 							<!-- this explicit import can be removed when we no longer support 
 								a version of AEM that supports java versions before 11 -->
 							javax.annotation;version=0.0.0,
@@ -592,6 +594,14 @@
 			<version>1.4</version>
 			<scope>test</scope>
 		</dependency>
+		<!-- Downgrade from 2.4 to 2.1 for AEM 6.4 support -->
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.1</version>
+			<scope>test</scope>
+		</dependency>
+		<!-- mockserver-netty pulls in jaxb-api 2.4, which isn't compatible with AEM 6.4 -->
 		<dependency>
 			<groupId>org.mock-server</groupId>
 			<artifactId>mockserver-netty</artifactId>


### PR DESCRIPTION
…nverter on AEM 6.4

Don't know if the explicit addition of the javax.xml.bind:jaxb-api:2.1 Maven test dependency was absolutely necessary, but this could show breaking unit tests due to incompatibilities in interface classes. 

In any case, it didn't break any tests.

I installed this SNAPSHOT version on AEM 6.4.4.0 and it showed a proper import of javax.xml.bind on the ACS Commons OSGi bundle.

The scheduled run of IntegrationServiceImpl did not log any java.lang.NoClassDefFoundError issues.