### PR TITLE
XSSApi no longer provided via adaptTo(...)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #2215 - Added Parameterized granite include to support generic dialog snippets
 
 ### Fixed
+- #2220 NPE in Audio component due to XSSApi adapter no longer available
 - #2214 fix java.lang.NoClassDefFoundError: javax/xml/bind/DatatypeConverter in Adobe I/O API's on AEM 6.4
 - #2206 fix sonar warnings; some package versions had to be increased
 - #2213 - Show/Hide Dialog Field TouchUI Widget: Fix hidden required field not disabled to save the dialog 

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/content/audio/partials/analytics.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/content/audio/partials/analytics.jsp
@@ -26,7 +26,7 @@
 %><%@taglib prefix="audio" uri="http://www.adobe.com/consulting/acs-aem-commons/audio" %><%
 %><%@taglib prefix="dam" uri="http://www.adobe.com/consulting/acs-aem-commons/dam" %><%
 %><%@taglib prefix="xss" uri="http://www.adobe.com/consulting/acs-aem-commons/xss/2.0" %><%
-    XSSAPI slingXssAPI = slingRequest.adaptTo(XSSAPI.class);
+    XSSAPI slingXssAPI = sling.get(XSSAPI.class);
     pageContext.setAttribute("slingXssAPI", slingXssAPI);
 %>
 <c:set var="resourcePath">${xss:encodeForJSString(slingXssAPI, resource.resourceType)}</c:set>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/content/definition-list/definition-list.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/content/definition-list/definition-list.jsp
@@ -23,7 +23,7 @@
 %><%@ taglib prefix="widgets" uri="http://www.adobe.com/consulting/acs-aem-commons/widgets" %><%
 %><%@ taglib prefix="xss" uri="http://www.adobe.com/consulting/acs-aem-commons/xss/2.0" %><%
 %><%@ taglib prefix="wcm" uri="http://www.adobe.com/consulting/acs-aem-commons/wcm" %><%
-    XSSAPI slingXssAPI = slingRequest.adaptTo(XSSAPI.class);
+    XSSAPI slingXssAPI = sling.get(XSSAPI.class);
     pageContext.setAttribute("slingXssAPI", slingXssAPI);
 %>
 <c:set var="definitions" value="${widgets:getMultiFieldPanelValues(resource, 'definitions')}"/>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/content/named-transform-image/named-transform-image.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/content/named-transform-image/named-transform-image.jsp
@@ -42,7 +42,7 @@
     pageContext.setAttribute("image", image);
     pageContext.setAttribute("linkURL", linkURL);
 
-    XSSAPI slingXssAPI = slingRequest.adaptTo(XSSAPI.class);
+    XSSAPI slingXssAPI = sling.get(XSSAPI.class);
     pageContext.setAttribute("slingXssAPI", slingXssAPI);
 
 %><c:choose>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/content/twitter-feed/twitter-feed.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/content/twitter-feed/twitter-feed.jsp
@@ -33,7 +33,7 @@
 
     pageContext.setAttribute("tweets", tweetList);
 
-    XSSAPI slingXssAPI = slingRequest.adaptTo(XSSAPI.class);
+    XSSAPI slingXssAPI = sling.get(XSSAPI.class);
     pageContext.setAttribute("slingXssAPI", slingXssAPI);
 %>
 <c:choose>


### PR DESCRIPTION
Compare with https://jira.apache.org/jira/browse/SLING-6793
Instead retrieve via SlingScriptHelper.getService()

This fixes #2220