### PR TITLE
Fix #2245 - Marketo Endpoint Protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-4.3.2...HEAD
 
+### Fixed
+ - #2245 Marketo Endpoint Protocol Documentation Issue
+
 ## [4.5.0] - 2020-03-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-4.3.2...HEAD
 
 ### Fixed
-- #2245 Marketo Endpoint Protocol Documentation Issue
+- #2245 - Marketo Endpoint Protocol Documentation Issue
 - #2254 - Fixed unwanted versioned client library cache reload for static CSS/JS resources of a proxied clientlib
 - #2248 - Fixed issue with null values in Generic Lists
 

--- a/bundle/src/main/java/com/adobe/acs/commons/marketo/impl/MarketoClientConfigurationImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/marketo/impl/MarketoClientConfigurationImpl.java
@@ -81,7 +81,7 @@ public class MarketoClientConfigurationImpl implements MarketoClientConfiguratio
   @Override
   public String getEndpointHost() {
     if(endpointHost.startsWith("https://")){
-      return endpointHost.substring(8);
+      return endpointHost.substring("https://".length());
     }
     return endpointHost;
   }

--- a/bundle/src/main/java/com/adobe/acs/commons/marketo/impl/MarketoClientConfigurationImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/marketo/impl/MarketoClientConfigurationImpl.java
@@ -80,6 +80,9 @@ public class MarketoClientConfigurationImpl implements MarketoClientConfiguratio
 
   @Override
   public String getEndpointHost() {
+    if(endpointHost.startsWith("https://")){
+      return endpointHost.substring(8);
+    }
     return endpointHost;
   }
 

--- a/bundle/src/test/java/com/adobe/acs/commons/marketo/impl/TestFormValueImpl.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/marketo/impl/TestFormValueImpl.java
@@ -21,16 +21,15 @@ package com.adobe.acs.commons.marketo.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
 import java.util.Optional;
 
+import com.adobe.acs.commons.marketo.FormValue;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import com.adobe.acs.commons.marketo.FormValue;
 
 import io.wcm.testing.mock.aem.junit.AemContext;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/marketo/impl/TestMarketoClientConfiguration.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/marketo/impl/TestMarketoClientConfiguration.java
@@ -50,7 +50,7 @@ public class TestMarketoClientConfiguration {
 
     configrr = Mockito.mock(ConfigurationResourceResolver.class);
     Mockito.when(configrr.getResourceCollection(Mockito.any(), Mockito.any(), Mockito.any()))
-        .thenReturn(Collections.singletonList(context.resourceResolver().getResource("/conf/test")));
+        .thenReturn(Collections.singletonList(context.resourceResolver().getResource("/conf/test/default")));
     context.registerService(ConfigurationResourceResolver.class, configrr);
 
   }
@@ -68,7 +68,7 @@ public class TestMarketoClientConfiguration {
   @Test
   public void testConfig() {
     MarketoClientConfiguration mcc = Optional
-        .ofNullable(context.resourceResolver().getResource("/conf/test/jcr:content"))
+        .ofNullable(context.resourceResolver().getResource("/conf/test/default/jcr:content"))
         .map(r -> r.adaptTo(MarketoClientConfiguration.class)).orElse(null);
     assertNotNull(mcc);
     assertEquals("123", mcc.getClientId());
@@ -79,9 +79,19 @@ public class TestMarketoClientConfiguration {
     assertEquals(48721, mcc.hashCode());
 
     MarketoClientConfiguration mcc2 = Optional
-        .ofNullable(context.resourceResolver().getResource("/conf/test/jcr:content"))
+        .ofNullable(context.resourceResolver().getResource("/conf/test/default/jcr:content"))
         .map(r -> r.adaptTo(MarketoClientConfiguration.class)).orElse(null);
     assertEquals(mcc, mcc2);
     assertNotEquals(mcc, null);
+  }
+
+
+  @Test
+  public void testHttps() {
+    MarketoClientConfiguration mcc = Optional
+        .ofNullable(context.resourceResolver().getResource("/conf/test/https/jcr:content"))
+        .map(r -> r.adaptTo(MarketoClientConfiguration.class)).orElse(null);
+    assertNotNull(mcc);
+    assertEquals("test.mktorest.com", mcc.getEndpointHost());
   }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/marketo/impl/TestMarketoClientConfiguration.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/marketo/impl/TestMarketoClientConfiguration.java
@@ -26,14 +26,13 @@ import static org.junit.Assert.assertNotNull;
 import java.util.Collections;
 import java.util.Optional;
 
+import com.adobe.acs.commons.marketo.MarketoClientConfiguration;
+
 import org.apache.sling.caconfig.resource.ConfigurationResourceResolver;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
-
-import com.adobe.acs.commons.marketo.MarketoClientConfiguration;
-import com.adobe.acs.commons.marketo.MarketoClientConfigurationManager;
 
 import io.wcm.testing.mock.aem.junit.AemContext;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/marketo/impl/TestMarketoInterfaces.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/marketo/impl/TestMarketoInterfaces.java
@@ -1,0 +1,55 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2020 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.marketo.impl;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import com.adobe.acs.commons.marketo.FormValue;
+import com.adobe.acs.commons.marketo.MarketoClientConfiguration;
+import com.adobe.acs.commons.marketo.MarketoClientConfigurationManager;
+import com.adobe.acs.commons.marketo.MarketoForm;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestMarketoInterfaces {
+
+    @Test
+    public void testInterfaces() throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+        Object[] interfaces = new Object[] { new FormValue() {
+        }, new MarketoClientConfiguration() {
+        }, new MarketoClientConfigurationManager() {
+        }, new MarketoForm() {
+        } };
+        for (Object intf : interfaces) {
+            for (Method m : intf.getClass().getDeclaredMethods()) {
+                try {
+                    m.invoke(intf, new Object[0]);
+                    Assert.fail();
+                } catch (UnsupportedOperationException uoe) {
+                    // expected
+                }
+            }
+        }
+
+    }
+
+}

--- a/bundle/src/test/resources/com/adobe/acs/commons/marketo/cloudconfig.json
+++ b/bundle/src/test/resources/com/adobe/acs/commons/marketo/cloudconfig.json
@@ -1,14 +1,31 @@
 {
-  "jcr:primaryType": "cq:Page",
-  "jcr:content": {
-    "jcr:primaryType": "cq:PageContent",
-    "jcr:title": "Test Cloud Config",
-    "cq:template": "/apps/acs-commons/templates/utilities/marketocloudconfig",
-    "sling:resourceType": "page",
-    "endpointHost": "test.mktorest.com",
-    "serverInstance": "//test.marketo.com",
-    "munchkinId": "123-456-789",
-    "clientId": "123",
-    "clientSecret": "456"
+  "jcr:primaryType": "sling:Folder",
+  "default": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent",
+      "jcr:title": "Test Cloud Config",
+      "cq:template": "/apps/acs-commons/templates/utilities/marketocloudconfig",
+      "sling:resourceType": "page",
+      "endpointHost": "test.mktorest.com",
+      "serverInstance": "//test.marketo.com",
+      "munchkinId": "123-456-789",
+      "clientId": "123",
+      "clientSecret": "456"
+    }
+  },
+  "https": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent",
+      "jcr:title": "Test Cloud Config",
+      "cq:template": "/apps/acs-commons/templates/utilities/marketocloudconfig",
+      "sling:resourceType": "page",
+      "endpointHost": "https://test.mktorest.com",
+      "serverInstance": "//test.marketo.com",
+      "munchkinId": "123-456-789",
+      "clientId": "123",
+      "clientSecret": "456"
+    }
   }
 }

--- a/bundle/src/test/resources/com/adobe/acs/commons/marketo/pages.json
+++ b/bundle/src/test/resources/com/adobe/acs/commons/marketo/pages.json
@@ -3,7 +3,7 @@
     "jcr:content": {
         "jcr:primaryType": "cq:PageContent",
         "jcr:title": "English",
-        "cq:conf": "/conf/test",
+        "cq:conf": "/conf/test/default",
         "sling:resourceType": "weretail/components/structure/page",
         "root": {
             "jcr:primaryType": "nt:unstructured",


### PR DESCRIPTION
As #2245 describes the tooltip for the Marketo configuration indicates that the endpoint should start with https:// but the client prepends https://. This PR adjusts the logic to strip https:// if it is provided so the code should work whether or not the protocol is provided in the endpoint URL.