### PR TITLE
fix Sonar warnings

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/contentfinder/querybuilder/impl/viewhandler/QueryBuilderViewHandler.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/contentfinder/querybuilder/impl/viewhandler/QueryBuilderViewHandler.java
@@ -60,7 +60,7 @@ public final class QueryBuilderViewHandler extends ViewHandler {
     private static final Logger log = LoggerFactory.getLogger(QueryBuilderViewHandler.class);
 
     @Reference
-    private CloseableQueryBuilder queryBuilder;
+    private transient CloseableQueryBuilder queryBuilder;
 
     @Override
     protected ViewQuery createQuery(SlingHttpServletRequest slingRequest, Session session,

--- a/bundle/src/main/java/com/adobe/acs/commons/dam/impl/AssetsFolderPropertiesSupport.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/dam/impl/AssetsFolderPropertiesSupport.java
@@ -100,7 +100,7 @@ public class AssetsFolderPropertiesSupport extends SlingSafeMethodsServlet imple
      * The is a reference to the OOTB AEM PostOperation that handles updates for Folder Properties; This is used below in process(..) to ensure that all OOTB behaviors are executed.
      */
     @Reference(target="&(sling.post.operation=dam.share.folder)(sling.servlet.methods=POST)")
-    private PostOperation folderShareHandler;
+    private transient PostOperation folderShareHandler;
 
     /**
      * This method is responsible for post processing POSTs to the FolderShareHandler PostOperation (:operation = dam.share.folder).

--- a/bundle/src/main/java/com/adobe/acs/commons/dam/impl/CustomComponentActivatorListServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/dam/impl/CustomComponentActivatorListServlet.java
@@ -31,6 +31,7 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 import org.apache.sling.commons.osgi.PropertiesUtil;
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
@@ -57,7 +58,7 @@ public class CustomComponentActivatorListServlet extends SlingSafeMethodsServlet
         })
     public static final String PROP_COMPONENTS = "components";
 
-    private JsonObject json;
+    private transient JsonObject json;
 
     @Activate
     protected void activate(Map<String, Object> config) {
@@ -70,7 +71,7 @@ public class CustomComponentActivatorListServlet extends SlingSafeMethodsServlet
             array.add(obj);
         }
         this.json = new JsonObject();
-        json.add("components", array);
+        json.add("components", array); // NOSONAR
     }
 
     @Override

--- a/bundle/src/main/java/com/adobe/acs/commons/designer/IncludeDesignLibrariesTag.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/designer/IncludeDesignLibrariesTag.java
@@ -46,7 +46,7 @@ public final class IncludeDesignLibrariesTag extends TagSupport {
 
     private boolean css;
 
-    private Design design;
+    private transient Design design;
 
     /**
      * {@inheritDoc}

--- a/bundle/src/main/java/com/adobe/acs/commons/designer/impl/OptionsServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/designer/impl/OptionsServlet.java
@@ -47,7 +47,7 @@ extensions = "json")
 public class OptionsServlet extends SlingSafeMethodsServlet {
 
     @Reference
-    private HtmlLibraryManager libraryManager;
+    private transient HtmlLibraryManager libraryManager;
 
     @Override
     @SuppressWarnings({"squid:S3776", "squid:S1141"})

--- a/bundle/src/main/java/com/adobe/acs/commons/dispatcher/impl/PermissionSensitiveCacheServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/dispatcher/impl/PermissionSensitiveCacheServlet.java
@@ -80,7 +80,7 @@ public class PermissionSensitiveCacheServlet extends SlingSafeMethodsServlet {
             }
         } catch(Exception e) {
             log.error("Authchecker servlet exception", e);
-            response.setStatus (HttpServletResponse.SC_UNAUTHORIZED );
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED );
         }
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/dispatcher/impl/PermissionSensitiveCacheServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/dispatcher/impl/PermissionSensitiveCacheServlet.java
@@ -19,6 +19,8 @@
  */
 package com.adobe.acs.commons.dispatcher.impl;
 
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Properties;
@@ -66,19 +68,19 @@ public class PermissionSensitiveCacheServlet extends SlingSafeMethodsServlet {
 
                 if( !ResourceUtil.isNonExistingResource( requestedResource ) ){
                     log.debug("Current Session has access to {}", requestUri );
-                    response.setStatus(SlingHttpServletResponse.SC_OK);
+                    response.setStatus(HttpServletResponse.SC_OK);
                 } else {
                     log.info("Current Session does not have access to {}", requestUri );
-                    response.setStatus(SlingHttpServletResponse.SC_UNAUTHORIZED);
+                    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 }
 
             } else {
                 log.debug( "Invalid URI {}", requestUri );
-                response.setStatus( SlingHttpServletResponse.SC_UNAUTHORIZED );
+                response.setStatus( HttpServletResponse.SC_UNAUTHORIZED );
             }
         } catch(Exception e) {
             log.error("Authchecker servlet exception", e);
-            response.setStatus( SlingHttpServletResponse.SC_UNAUTHORIZED );
+            response.setStatus (HttpServletResponse.SC_UNAUTHORIZED );
         }
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/errorpagehandler/ErrorPageHandlerService.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/errorpagehandler/ErrorPageHandlerService.java
@@ -19,6 +19,8 @@
  */
 package com.adobe.acs.commons.errorpagehandler;
 
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
@@ -34,7 +36,7 @@ import org.osgi.annotation.versioning.ProviderType;
 
 @SuppressWarnings("squid:S1214")
 public interface ErrorPageHandlerService {
-    int DEFAULT_STATUS_CODE = SlingHttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+    int DEFAULT_STATUS_CODE = HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 
     /**
      * Determines if this Service is "enabled". If it has been configured to be "Disabled" the Service still exists however it should not be used.

--- a/bundle/src/main/java/com/adobe/acs/commons/errorpagehandler/impl/ErrorPageHandlerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/errorpagehandler/impl/ErrorPageHandlerImpl.java
@@ -60,6 +60,8 @@ import javax.management.DynamicMBean;
 import javax.management.NotCompliantMBeanException;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.AbstractMap.SimpleEntry;
@@ -659,7 +661,7 @@ public final class ErrorPageHandlerImpl implements ErrorPageHandlerService {
             log.debug(iw.toString());
         }
 
-        if (this.getStatusCode(request) == SlingHttpServletResponse.SC_NOT_FOUND
+        if (this.getStatusCode(request) == HttpServletResponse.SC_NOT_FOUND
                 && this.isAnonymousRequest(request)
                 && AuthUtil.isBrowserRequest(request)
                 && this.isRedirectToLogin(path)) {

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/actions/ActionBatch.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/actions/ActionBatch.java
@@ -37,7 +37,7 @@ public class ActionBatch extends LinkedBlockingQueue<CheckedConsumer<ResourceRes
 
     private static final Logger LOG = LoggerFactory.getLogger(ActionBatch.class);
 
-    private final ActionManager manager;
+    private transient final ActionManager manager;
     private int retryCount = 5;
     private long retryDelay = 100;
 

--- a/bundle/src/main/java/com/adobe/acs/commons/fam/actions/ActionBatch.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/fam/actions/ActionBatch.java
@@ -37,7 +37,7 @@ public class ActionBatch extends LinkedBlockingQueue<CheckedConsumer<ResourceRes
 
     private static final Logger LOG = LoggerFactory.getLogger(ActionBatch.class);
 
-    private transient final ActionManager manager;
+    private final transient ActionManager manager;
     private int retryCount = 5;
     private long retryDelay = 100;
 

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/mem/impl/MemCachePersistenceObject.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/store/mem/impl/MemCachePersistenceObject.java
@@ -47,7 +47,7 @@ public class MemCachePersistenceObject implements Serializable {
     /** Response content type */
     private String contentType;
     /** Response headers */
-    Multimap<String, String> headers;
+    transient Multimap<String, String> headers;
     /** Byte array to hold the data from the stream */
     private byte[] bytes;
     private HttpCacheServletResponseWrapper.ResponseWriteMethod writeMethod;

--- a/bundle/src/main/java/com/adobe/acs/commons/images/impl/NamedTransformImageServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/images/impl/NamedTransformImageServlet.java
@@ -23,6 +23,7 @@ import com.adobe.acs.commons.dam.RenditionPatternPicker;
 import com.adobe.acs.commons.images.ImageTransformer;
 import com.adobe.acs.commons.images.NamedImageTransformer;
 import com.adobe.acs.commons.util.PathInfoUtil;
+import com.day.cq.commons.DownloadResource;
 import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.dam.api.Asset;
 import com.day.cq.dam.api.Rendition;
@@ -61,6 +62,7 @@ import javax.imageio.ImageIO;
 import javax.jcr.RepositoryException;
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -153,17 +155,17 @@ public class NamedTransformImageServlet extends SlingSafeMethodsServlet implemen
             value = DEFAULT_ASSET_RENDITION_PICKER_REGEX)
     private static final String PROP_ASSET_RENDITION_PICKER_REGEX = "prop.asset-rendition-picker-regex";
 
-    private final Map<String, NamedImageTransformer> namedImageTransformers =
+    private transient final Map<String, NamedImageTransformer> namedImageTransformers =
             new ConcurrentHashMap<String, NamedImageTransformer>();
 
-    private final Map<String, ImageTransformer> imageTransformers = new ConcurrentHashMap<String, ImageTransformer>();
+    private transient final Map<String, ImageTransformer> imageTransformers = new ConcurrentHashMap<String, ImageTransformer>();
 
     @Reference
-    private MimeTypeService mimeTypeService;
+    private transient MimeTypeService mimeTypeService;
 
     private Pattern lastSuffixPattern = Pattern.compile(DEFAULT_FILENAME_PATTERN);
 
-    private RenditionPatternPicker renditionPatternPicker =
+    private transient RenditionPatternPicker renditionPatternPicker =
             new RenditionPatternPicker(Pattern.compile(DEFAULT_ASSET_RENDITION_PICKER_REGEX));
 
     /**
@@ -215,7 +217,7 @@ public class NamedTransformImageServlet extends SlingSafeMethodsServlet implemen
         Layer layer = getLayer(image);
         
         if (layer == null) {
-            response.setStatus(SlingHttpServletResponse.SC_NOT_FOUND);
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
             return;
         }
         
@@ -340,7 +342,7 @@ public class NamedTransformImageServlet extends SlingSafeMethodsServlet implemen
                 || resource.isResourceType(JcrConstants.NT_RESOURCE)) {
             // For renditions; use the requested rendition
             final Image image = new Image(resource);
-            image.set(Image.PN_REFERENCE, resource.getPath());
+            image.set(DownloadResource.PN_REFERENCE, resource.getPath());
             return image;
         }
 
@@ -378,7 +380,7 @@ public class NamedTransformImageServlet extends SlingSafeMethodsServlet implemen
         final Resource renditionResource = resource.getResourceResolver().getResource(rendition.getPath());
 
         final Image image = new Image(resource);
-        image.set(Image.PN_REFERENCE, renditionResource.getPath());
+        image.set(DownloadResource.PN_REFERENCE, renditionResource.getPath());
         return image;
     }
 
@@ -470,7 +472,7 @@ public class NamedTransformImageServlet extends SlingSafeMethodsServlet implemen
      * @return
      */
     protected final double getQuality(final String mimeType, final ValueMap transforms) {
-        final String key = "quality";
+        final String key = "quality"; // NOSONAR // replace with already existing constant
         final int defaultQuality = 82;
         final int maxQuality = 100;
         final int minQuality = 0;

--- a/bundle/src/main/java/com/adobe/acs/commons/images/impl/NamedTransformImageServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/images/impl/NamedTransformImageServlet.java
@@ -155,10 +155,10 @@ public class NamedTransformImageServlet extends SlingSafeMethodsServlet implemen
             value = DEFAULT_ASSET_RENDITION_PICKER_REGEX)
     private static final String PROP_ASSET_RENDITION_PICKER_REGEX = "prop.asset-rendition-picker-regex";
 
-    private transient final Map<String, NamedImageTransformer> namedImageTransformers =
+    private final transient Map<String, NamedImageTransformer> namedImageTransformers =
             new ConcurrentHashMap<String, NamedImageTransformer>();
 
-    private transient final Map<String, ImageTransformer> imageTransformers = new ConcurrentHashMap<String, ImageTransformer>();
+    private final transient Map<String, ImageTransformer> imageTransformers = new ConcurrentHashMap<String, ImageTransformer>();
 
     @Reference
     private transient MimeTypeService mimeTypeService;

--- a/bundle/src/main/java/com/adobe/acs/commons/logging/impl/SyslogAppender.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/logging/impl/SyslogAppender.java
@@ -99,7 +99,7 @@ public final class SyslogAppender {
 
         final String[] loggers = PropertiesUtil.toStringArray(properties.get(PROP_LOGGERS), new String[] {ROOT});
         Dictionary<String, Object> props = new Hashtable<>();
-        props.put("loggers", loggers);
+        props.put(PROP_LOGGERS, loggers);
         appenderRegistration = ctx.registerService(Appender.class.getName(), appender, props);
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/ControlledProcessManagerServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/ControlledProcessManagerServlet.java
@@ -77,7 +77,7 @@ public class ControlledProcessManagerServlet extends SlingAllMethodsServlet {
     private static final List<String> IGNORED_SERVLET_INPUTS = Arrays.asList("definition", "description", "action");
 
     @Reference
-    ControlledProcessManager manager;
+    transient ControlledProcessManager manager;
 
     @Override
     protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response) throws ServletException, IOException {

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/AssetFolderCreator.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/AssetFolderCreator.java
@@ -131,7 +131,7 @@ public class AssetFolderCreator extends ProcessDefinition implements Serializabl
         instance.defineCriticalAction("Create Asset Folders", rr, this::createAssetFolders);
     }
 
-    volatile transient HashMap<String, AssetFolderDefinition> assetFolderDefinitions = new LinkedHashMap<>();
+    transient volatile HashMap<String, AssetFolderDefinition> assetFolderDefinitions = new LinkedHashMap<>();
 
     /**
      * Parses the input Excel file and creates a list of AssetFolderDefinition objects to process.

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/AssetFolderCreator.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/AssetFolderCreator.java
@@ -319,7 +319,7 @@ public class AssetFolderCreator extends ProcessDefinition implements Serializabl
 
     private final transient GenericReport report = new GenericReport();
 
-    private transient final ArrayList<EnumMap<ReportColumns, Object>> reportRows = new ArrayList<>();
+    private final transient ArrayList<EnumMap<ReportColumns, Object>> reportRows = new ArrayList<>();
 
     private enum ReportColumns {
         STATUS,

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/AssetFolderCreator.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/AssetFolderCreator.java
@@ -131,7 +131,7 @@ public class AssetFolderCreator extends ProcessDefinition implements Serializabl
         instance.defineCriticalAction("Create Asset Folders", rr, this::createAssetFolders);
     }
 
-    volatile HashMap<String, AssetFolderDefinition> assetFolderDefinitions = new LinkedHashMap<>();
+    volatile transient HashMap<String, AssetFolderDefinition> assetFolderDefinitions = new LinkedHashMap<>();
 
     /**
      * Parses the input Excel file and creates a list of AssetFolderDefinition objects to process.
@@ -319,7 +319,7 @@ public class AssetFolderCreator extends ProcessDefinition implements Serializabl
 
     private final transient GenericReport report = new GenericReport();
 
-    private final ArrayList<EnumMap<ReportColumns, Object>> reportRows = new ArrayList<>();
+    private transient final ArrayList<EnumMap<ReportColumns, Object>> reportRows = new ArrayList<>();
 
     private enum ReportColumns {
         STATUS,

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/BulkWorkflow.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/BulkWorkflow.java
@@ -54,8 +54,8 @@ public class BulkWorkflow extends ProcessDefinition implements Serializable {
 
     public static final String PROCESS_NAME = "Bulk Workflow";
 
-    private transient final QueryHelper queryHelper;
-    private transient final SyntheticWorkflowRunner syntheticWorkflowRunner;
+    private final transient QueryHelper queryHelper;
+    private final transient SyntheticWorkflowRunner syntheticWorkflowRunner;
 
     public enum ItemStatus {
         SUCCESS, FAILURE

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/BulkWorkflow.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/BulkWorkflow.java
@@ -54,8 +54,8 @@ public class BulkWorkflow extends ProcessDefinition implements Serializable {
 
     public static final String PROCESS_NAME = "Bulk Workflow";
 
-    private final QueryHelper queryHelper;
-    private final SyntheticWorkflowRunner syntheticWorkflowRunner;
+    private transient final QueryHelper queryHelper;
+    private transient final SyntheticWorkflowRunner syntheticWorkflowRunner;
 
     public enum ItemStatus {
         SUCCESS, FAILURE

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TagCreator.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TagCreator.java
@@ -65,7 +65,7 @@ public class TagCreator extends ProcessDefinition implements Serializable {
 
     public static final String NAME = "Tag Creator";
 
-    private final Map<String, ResourceDefinitionBuilder> resourceDefinitionBuilders;
+    private transient final Map<String, ResourceDefinitionBuilder> resourceDefinitionBuilders;
 
     public enum TagBuilder {
         TITLE_TO_NODE_NAME,
@@ -117,7 +117,7 @@ public class TagCreator extends ProcessDefinition implements Serializable {
         instance.defineCriticalAction("Create tags", rr, this::importTags);
     }
 
-    volatile HashMap<String, TagDefinition> tagDefinitions = new LinkedHashMap<>();
+    volatile transient HashMap<String, TagDefinition> tagDefinitions = new LinkedHashMap<>();
 
     /**
      * Parses the input Excel file and creates a list of TagDefinition objects to process.
@@ -285,7 +285,7 @@ public class TagCreator extends ProcessDefinition implements Serializable {
 
     private final transient GenericReport report = new GenericReport();
 
-    private final ArrayList<EnumMap<ReportColumns, Object>> reportRows = new ArrayList<>();
+    private transient final ArrayList<EnumMap<ReportColumns, Object>> reportRows = new ArrayList<>();
 
     private enum ReportColumns {
         STATUS,

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TagCreator.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TagCreator.java
@@ -65,7 +65,7 @@ public class TagCreator extends ProcessDefinition implements Serializable {
 
     public static final String NAME = "Tag Creator";
 
-    private transient final Map<String, ResourceDefinitionBuilder> resourceDefinitionBuilders;
+    private final transient Map<String, ResourceDefinitionBuilder> resourceDefinitionBuilders;
 
     public enum TagBuilder {
         TITLE_TO_NODE_NAME,
@@ -117,7 +117,7 @@ public class TagCreator extends ProcessDefinition implements Serializable {
         instance.defineCriticalAction("Create tags", rr, this::importTags);
     }
 
-    volatile transient HashMap<String, TagDefinition> tagDefinitions = new LinkedHashMap<>();
+    transient volatile HashMap<String, TagDefinition> tagDefinitions = new LinkedHashMap<>();
 
     /**
      * Parses the input Excel file and creates a list of TagDefinition objects to process.
@@ -285,7 +285,7 @@ public class TagCreator extends ProcessDefinition implements Serializable {
 
     private final transient GenericReport report = new GenericReport();
 
-    private transient final ArrayList<EnumMap<ReportColumns, Object>> reportRows = new ArrayList<>();
+    private final transient ArrayList<EnumMap<ReportColumns, Object>> reportRows = new ArrayList<>();
 
     private enum ReportColumns {
         STATUS,

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/model/ManagedProcess.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/model/ManagedProcess.java
@@ -274,9 +274,9 @@ public class ManagedProcess implements Serializable {
         cal.setTimeInMillis(time);
         DateFormat format;
         if (cal.after(today)) {
-            format = SimpleDateFormat.getTimeInstance();        
+            format = DateFormat.getTimeInstance();        
         } else {
-            format = SimpleDateFormat.getDateTimeInstance();
+            format = DateFormat.getDateTimeInstance();
         }
         return format.format(new Date(time));
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/models/injectors/impl/SharedValueMapValueInjector.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/models/injectors/impl/SharedValueMapValueInjector.java
@@ -96,7 +96,7 @@ public class SharedValueMapValueInjector implements Injector {
     protected ValueMap getSharedProperties(Page pageRoot, Resource resource) {
         String sharedPropsPath = pageRoot.getPath() + "/" + JcrConstants.JCR_CONTENT + "/" + SharedComponentProperties.NN_SHARED_COMPONENT_PROPERTIES + "/" + resource.getResourceType();
         Resource sharedPropsResource = resource.getResourceResolver().getResource(sharedPropsPath);
-        return sharedPropsResource != null ? sharedPropsResource.getValueMap() : ValueMapDecorator.EMPTY;
+        return sharedPropsResource != null ? sharedPropsResource.getValueMap() : ValueMap.EMPTY;
     }
 
     /**
@@ -105,7 +105,7 @@ public class SharedValueMapValueInjector implements Injector {
     protected ValueMap getGlobalProperties(Page pageRoot, Resource resource) {
         String globalPropsPath = pageRoot.getPath() + "/" + JcrConstants.JCR_CONTENT + "/" + SharedComponentProperties.NN_GLOBAL_COMPONENT_PROPERTIES;
         Resource globalPropsResource = resource.getResourceResolver().getResource(globalPropsPath);
-        return globalPropsResource != null ? globalPropsResource.getValueMap() : ValueMapDecorator.EMPTY;
+        return globalPropsResource != null ? globalPropsResource.getValueMap() : ValueMap.EMPTY;
     }
 
     /**

--- a/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexServlet.java
@@ -69,7 +69,7 @@ public class EnsureOakIndexServlet extends SlingAllMethodsServlet {
     private static final String PARAM_PATH = "path";
 
     @Reference
-    private EnsureOakIndexManager ensureOakIndexManager;
+    private transient EnsureOakIndexManager ensureOakIndexManager;
     //@formatter:on
 
     @Override

--- a/bundle/src/main/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutorImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/ondeploy/impl/OnDeployExecutorImpl.java
@@ -110,7 +110,7 @@ public class OnDeployExecutorImpl extends AnnotatedStandardMBean implements OnDe
 
     static {
         try {
-            scriptsItemNames = new String[] { "_provider", "_script", "startDate", "endDate", "status" };
+            scriptsItemNames = new String[] { "_provider", "_script", SCRIPT_DATE_START, SCRIPT_DATE_END, SCRIPT_STATUS };
             scriptsCompositeType =
                     new CompositeType("Script Row", "single script status row", scriptsItemNames, new String[] {
                             "Provider", "Script", "Start Date", "End Date", "Status" },

--- a/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/ACLPackagerServletImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/ACLPackagerServletImpl.java
@@ -89,7 +89,7 @@ public class ACLPackagerServletImpl extends AbstractPackagerServlet {
             "/apps/acs-commons/components/utilities/packager/acl-packager/definition/package-thumbnail.png";
 
     @Reference
-    private PackageHelper packageHelper;
+    private transient PackageHelper packageHelper;
 
     @Override
     public final void doPost(final SlingHttpServletRequest request,

--- a/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/AbstractPackagerServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/AbstractPackagerServlet.java
@@ -45,7 +45,7 @@ import java.util.Map;
 public abstract class AbstractPackagerServlet extends SlingAllMethodsServlet {
 
     @SuppressWarnings("PMD")
-    protected final Logger log = LoggerFactory.getLogger(getClass());
+    protected transient final Logger log = LoggerFactory.getLogger(getClass());
 
     private static final String PACKAGE_NAME = "packageName";
 

--- a/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/AbstractPackagerServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/AbstractPackagerServlet.java
@@ -45,7 +45,7 @@ import java.util.Map;
 public abstract class AbstractPackagerServlet extends SlingAllMethodsServlet {
 
     @SuppressWarnings("PMD")
-    protected transient final Logger log = LoggerFactory.getLogger(getClass());
+    protected final transient Logger log = LoggerFactory.getLogger(getClass());
 
     private static final String PACKAGE_NAME = "packageName";
 

--- a/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/AssetPackagerServletImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/AssetPackagerServletImpl.java
@@ -56,7 +56,7 @@ public class AssetPackagerServletImpl extends AbstractPackagerServlet {
             "/apps/acs-commons/components/utilities/packager/asset-packager/definition/package-thumbnail.png";
 
     @Reference
-    private PackageHelper packageHelper;
+    private transient PackageHelper packageHelper;
 
     @Override
     public final void doPost(final SlingHttpServletRequest request,

--- a/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/AuthorizablePackagerServletImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/AuthorizablePackagerServletImpl.java
@@ -66,10 +66,10 @@ public class AuthorizablePackagerServletImpl extends AbstractPackagerServlet {
             "/apps/acs-commons/components/utilities/packager/authorizable-packager/definition/package-thumbnail.png";
 
     @Reference
-    private Packaging packaging;
+    private transient Packaging packaging;
 
     @Reference
-    private PackageHelper packageHelper;
+    private transient PackageHelper packageHelper;
 
     @Override
     public final void doPost(final SlingHttpServletRequest request,

--- a/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/InstantPackageImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/InstantPackageImpl.java
@@ -77,10 +77,10 @@ public class InstantPackageImpl extends SlingAllMethodsServlet {
     private static final String INSTANT_PACKAGE_THUMBNAIL_RESOURCE_PATH = "/apps/acs-commons/components/utilities/instant-package/thumbnail.png";
 
     @Reference
-    private Packaging packaging;
+    private transient Packaging packaging;
 
     @Reference
-    private PackageHelper packageHelper;
+    private transient PackageHelper packageHelper;
 
     @Override
     public final void doPost(final SlingHttpServletRequest request, final SlingHttpServletResponse response)

--- a/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/QueryPackagerServletImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/packaging/impl/QueryPackagerServletImpl.java
@@ -85,13 +85,13 @@ public class QueryPackagerServletImpl extends SlingAllMethodsServlet {
             "/apps/acs-commons/components/utilities/packager/query-packager/definition/package-thumbnail.png";
 
     @Reference
-    private Packaging packaging;
+    private transient Packaging packaging;
 
     @Reference
-    private PackageHelper packageHelper;
+    private transient PackageHelper packageHelper;
 
     @Reference
-    private QueryHelper queryHelper;
+    private transient QueryHelper queryHelper;
 
     @Override
     public final void doPost(final SlingHttpServletRequest request,
@@ -107,7 +107,7 @@ public class QueryPackagerServletImpl extends SlingAllMethodsServlet {
         try {
             final List<Resource> packageResources = queryHelper.findResources(resourceResolver,
                     properties.get("queryLanguage", Query.JCR_SQL2),
-                    properties.get("query", String.class),
+                    properties.get("query", String.class), // NOSONAR // replace string with existing constant
                     properties.get("relPath", String.class));
 
             final Map<String, String> packageDefinitionProperties = new HashMap<String, String>();

--- a/bundle/src/main/java/com/adobe/acs/commons/quickly/impl/QuicklyServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/quickly/impl/QuicklyServlet.java
@@ -30,6 +30,7 @@ import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 
@@ -42,7 +43,7 @@ import java.io.IOException;
 public class QuicklyServlet extends SlingSafeMethodsServlet {
 
     @Reference
-    private QuicklyEngine quicklyEngine;
+    private transient QuicklyEngine quicklyEngine;
 
     @Override
     protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
@@ -54,7 +55,7 @@ public class QuicklyServlet extends SlingSafeMethodsServlet {
         try {
             response.getWriter().append(quicklyEngine.execute(request, response, cmd).toString());
         } catch (Exception e) {
-            response.sendError(SlingHttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             response.getWriter().print("{\"status:\": \"error\"}");
         }
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlusherServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlusherServlet.java
@@ -44,6 +44,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -60,10 +62,10 @@ public class DispatcherFlusherServlet extends SlingAllMethodsServlet {
     private static final Logger log = LoggerFactory.getLogger(DispatcherFlusherServlet.class);
 
     @Reference
-    private DispatcherFlusher dispatcherFlusher;
+    private transient DispatcherFlusher dispatcherFlusher;
 
     @Reference
-    private ResourceResolverFactory resourceResolverFactory;
+    private transient ResourceResolverFactory resourceResolverFactory;
 
     private static final boolean DEFAULT_FLUSH_WITH_ADMIN_RESOURCE_RESOLVER = true;
 
@@ -157,7 +159,7 @@ public class DispatcherFlusherServlet extends SlingAllMethodsServlet {
 
         private FlushResult(Agent agent, ReplicationResult result) {
             this.agentId = agent.getId();
-            this.success = result.isSuccess() && result.getCode() == SlingHttpServletResponse.SC_OK;
+            this.success = result.isSuccess() && result.getCode() == HttpServletResponse.SC_OK;
         }
 
         private final String agentId;

--- a/bundle/src/main/java/com/adobe/acs/commons/replication/impl/ReplicateVersionImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/replication/impl/ReplicateVersionImpl.java
@@ -67,7 +67,7 @@ public class ReplicateVersionImpl implements
             .getLogger(ReplicateVersionImpl.class);
 
     @Reference
-    private Replicator replicator;
+    private transient Replicator replicator;
 
     @Override
     public final List<ReplicationResult> replicate(
@@ -167,7 +167,7 @@ public class ReplicateVersionImpl implements
                 return 0;
             }
         });
-        Calendar cal = GregorianCalendar.getInstance();
+        Calendar cal = Calendar.getInstance();
         cal.setTime(date);
         for (Version v : versions) {
             try {

--- a/bundle/src/main/java/com/adobe/acs/commons/replication/impl/ReplicateVersionServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/replication/impl/ReplicateVersionServlet.java
@@ -63,7 +63,7 @@ public class ReplicateVersionServlet extends SlingAllMethodsServlet {
     private static final String KEY_VERSION = "version";
 
     @Reference
-    private ReplicateVersion replicateVersion;
+    private transient ReplicateVersion replicateVersion;
 
     @Override
     public final void doPost(SlingHttpServletRequest req,

--- a/bundle/src/main/java/com/adobe/acs/commons/reports/internal/ReportCSVExportServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/reports/internal/ReportCSVExportServlet.java
@@ -63,7 +63,7 @@ public class ReportCSVExportServlet extends SlingSafeMethodsServlet {
   private static final Logger log = LoggerFactory.getLogger(ReportCSVExportServlet.class);
 
   @Reference
-  private DynamicClassLoaderManager dynamicClassLoaderManager;
+  private transient DynamicClassLoaderManager dynamicClassLoaderManager;
 
   @Override
   protected void doGet(@Nonnull SlingHttpServletRequest request, @Nonnull SlingHttpServletResponse response)

--- a/bundle/src/main/java/com/adobe/acs/commons/reports/internal/datasources/DynamicSelectDataSource.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/reports/internal/datasources/DynamicSelectDataSource.java
@@ -39,6 +39,8 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -112,7 +114,7 @@ public class DynamicSelectDataSource extends SlingSafeMethodsServlet {
     } catch (Exception e) {
       log.error(
           "Unable to collect the information to populate the ACS Commons Report Builder dynamic-select drop-down.", e);
-      response.sendError(SlingHttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
   }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/util/impl/AemCapabilityHelperImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/impl/AemCapabilityHelperImpl.java
@@ -25,6 +25,7 @@ import org.apache.sling.jcr.api.SlingRepository;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
+import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
 
 /**
@@ -42,7 +43,7 @@ public class AemCapabilityHelperImpl implements AemCapabilityHelper {
 
     @Override
     public final boolean isOak() throws RepositoryException {
-        final String repositoryName = slingRepository.getDescriptorValue(SlingRepository.REP_NAME_DESC).getString();
+        final String repositoryName = slingRepository.getDescriptorValue(Repository.REP_NAME_DESC).getString();
         return StringUtils.equalsIgnoreCase("Apache Jackrabbit Oak", repositoryName);
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/comparisons/impl/PageCompareDataLineImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/comparisons/impl/PageCompareDataLineImpl.java
@@ -82,7 +82,7 @@ class PageCompareDataLineImpl implements PageCompareDataLine {
 
     @Override
     public String getUniqueName() {
-        return path.replace("/jcr:content", "").replaceAll("/","").replaceAll(":","-");
+        return path.replace("/jcr:content", "").replace("/","").replace(":","-");
     }
 
     @Override

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/AbstractDynamicClientLibraryServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/AbstractDynamicClientLibraryServlet.java
@@ -42,7 +42,7 @@ import java.util.Map;
 abstract class AbstractDynamicClientLibraryServlet extends SlingSafeMethodsServlet {
 
 
-    private HtmlLibraryManager htmlLibraryManager;
+    private transient HtmlLibraryManager htmlLibraryManager;
 
     private String[] categories;
     private boolean excludeAll;

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/CQIncludePropertyNamespaceServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/CQIncludePropertyNamespaceServlet.java
@@ -34,6 +34,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.felix.scr.annotations.Activate;
@@ -146,7 +147,7 @@ public final class CQIncludePropertyNamespaceServlet extends SlingSafeMethodsSer
         response.setCharacterEncoding("UTF-8");
 
         if (!this.accepts(request)) {
-            response.setStatus(SlingHttpServletResponse.SC_NOT_FOUND);
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
             response.getWriter().write("{}");
         }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/QrCodeServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/QrCodeServlet.java
@@ -36,6 +36,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 
 @Component(
@@ -70,7 +72,7 @@ public class QrCodeServlet extends SlingSafeMethodsServlet {
     private static final String JSON_KEY_PUBLISH_URL = "publishURL";
 
     @Reference
-    private Externalizer externalizer;
+    private transient Externalizer externalizer;
 
     @Override
     protected final void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response) throws
@@ -80,7 +82,7 @@ public class QrCodeServlet extends SlingSafeMethodsServlet {
 
         if (externalizer == null) {
             log.warn("Externalizer is not configured. This is required for QR Code servlet to work.");
-            response.setStatus(SlingHttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 
         } else if (request.getResource().getValueMap().get(PN_ENABLED, false)) {
             final JsonObject json = new JsonObject();
@@ -98,11 +100,11 @@ public class QrCodeServlet extends SlingSafeMethodsServlet {
                 response.getWriter().flush();
             } else {
                 log.warn("Externalizer configuration for AEM Publish did not yield a valid URL");
-                response.setStatus(SlingHttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
             }
         } else {
             log.warn("Externalizer configuration for AEM Publish did not yield a valid URL");
-            response.setStatus(SlingHttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/RTEConfigurationServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/RTEConfigurationServlet.java
@@ -74,7 +74,7 @@ public final class RTEConfigurationServlet extends AbstractWidgetConfigurationSe
     private static final String DEFAULT_CONFIG_NAME = "default";
 
     @Reference
-    private XSSAPI xssApi;
+    private transient XSSAPI xssApi;
 
     private static final String DEFAULT_CONFIG
             = "/libs/foundation/components/text/dialog/items/tab1/items/text/rtePlugins";

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/SiteMapServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/SiteMapServlet.java
@@ -127,7 +127,7 @@ public final class SiteMapServlet extends SlingSafeMethodsServlet {
     private static final String NS = "http://www.sitemaps.org/schemas/sitemap/0.9";
 
     @Reference
-    private Externalizer externalizer;
+    private transient Externalizer externalizer;
 
     private String externalizerDomain;
 

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/TagWidgetConfigurationServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/TagWidgetConfigurationServlet.java
@@ -68,7 +68,7 @@ public class TagWidgetConfigurationServlet extends AbstractWidgetConfigurationSe
     private static final String DEFAULT_CONFIG_NAME = "default";
 
     @Reference
-    private XSSAPI xssApi;
+    private transient XSSAPI xssApi;
 
     private static final String DEFAULT_CONFIG = "/libs/foundation/components/page/tab_basic/items/basic/items/tags";
 

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/views/impl/WCMViewsServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/views/impl/WCMViewsServlet.java
@@ -45,6 +45,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -85,7 +87,7 @@ public class WCMViewsServlet extends SlingSafeMethodsServlet {
         response.setContentType("application/json");
 
         if (WCMMode.DISABLED.equals(WCMMode.fromRequest(request))) {
-            response.setStatus(SlingHttpServletResponse.SC_NOT_FOUND);
+            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
             response.getWriter().write("");
             return;
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/servlets/InitFormServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/servlets/InitFormServlet.java
@@ -44,6 +44,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.jcr.Session;
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 
 /**
@@ -65,7 +67,7 @@ public class InitFormServlet extends SlingAllMethodsServlet {
     private static final String KEY_USER_EVENT_DATA = "userEventData";
 
     @Reference
-    private WorkflowService workflowService;
+    private transient WorkflowService workflowService;
 
     @Override
     protected final void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
@@ -115,7 +117,7 @@ public class InitFormServlet extends SlingAllMethodsServlet {
         } catch (WorkflowException e) {
             log.error("Could not create workflow model drop-down.", e);
 
-            JSONErrorUtil.sendJSONError(response, SlingHttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+            JSONErrorUtil.sendJSONError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                     "Could not collect workflows",
                     e.getMessage());
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/servlets/ResumeServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/servlets/ResumeServlet.java
@@ -48,7 +48,7 @@ import static com.adobe.acs.commons.json.JsonObjectUtil.*;
 public class ResumeServlet extends SlingAllMethodsServlet {
 
     @Reference
-    private BulkWorkflowEngine bulkWorkflowEngine;
+    private transient BulkWorkflowEngine bulkWorkflowEngine;
 
     @Override
     protected final void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/servlets/StartServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/servlets/StartServlet.java
@@ -42,6 +42,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.jcr.RepositoryException;
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 
 import static com.adobe.acs.commons.json.JsonObjectUtil.*;
@@ -61,7 +63,7 @@ public class StartServlet extends SlingAllMethodsServlet {
     private static final Logger log = LoggerFactory.getLogger(StartServlet.class);
 
     @Reference
-    private BulkWorkflowEngine bulkWorkflowEngine;
+    private transient BulkWorkflowEngine bulkWorkflowEngine;
     
     @Override
     @SuppressWarnings({"squid:S1192", "squid:S1872"})
@@ -116,21 +118,21 @@ public class StartServlet extends SlingAllMethodsServlet {
         } catch (RepositoryException e) {
             log.error("Could not initialize Bulk Workflow: {}", e);
 
-            JSONErrorUtil.sendJSONError(response, SlingHttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+            JSONErrorUtil.sendJSONError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                     "Could not initialize Bulk Workflow.",
                     e.getMessage());
 
         } catch (IllegalArgumentException e) {
             log.warn("Could not initialize Bulk Workflow due to invalid arguments: {}", e);
 
-            JSONErrorUtil.sendJSONError(response, SlingHttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+            JSONErrorUtil.sendJSONError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                     "Could not initialize Bulk Workflow due to invalid arguments.",
                     e.getMessage());
 
         } catch (Exception e) {
             log.error("Could not initialize Bulk Workflow due to unexpected error: {}", e);
 
-            JSONErrorUtil.sendJSONError(response, SlingHttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+            JSONErrorUtil.sendJSONError(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
                     "Could not start Bulk Workflow.",
                     e.getMessage());
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/servlets/StatusServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/servlets/StatusServlet.java
@@ -66,10 +66,10 @@ public class StatusServlet extends SlingAllMethodsServlet {
     private static final int DECIMAL_TO_PERCENT = 100;
 
     @Reference
-    private ThrottledTaskRunnerStats ttrs;
+    private transient ThrottledTaskRunnerStats ttrs;
 
     @Reference
-    private ActionManagerFactory actionManagerFactory;
+    private transient ActionManagerFactory actionManagerFactory;
 
     @Override
     @SuppressWarnings({"squid:S3776", "squid:S1192", "squid:S1872"})

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/servlets/StopServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/execution/impl/servlets/StopServlet.java
@@ -44,7 +44,7 @@ import java.io.IOException;
 public class StopServlet extends SlingAllMethodsServlet {
 
     @Reference
-    private BulkWorkflowEngine bulkWorkflowEngine;
+    private transient BulkWorkflowEngine bulkWorkflowEngine;
 
     @Override
     protected final void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/granite/SyntheticWorkItem.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/synthetic/impl/granite/SyntheticWorkItem.java
@@ -141,6 +141,7 @@ public class SyntheticWorkItem implements WorkItem {
         return null;
     }
 
+    @SuppressWarnings("java:S1192")
     @Override
     public String getItemType() {
         return "Synthetic Workflow";


### PR DESCRIPTION
I fixed a number of Sonar warnings on level Critical. Nothing really fancy, but just cleanup:

* Variables in servlets should be marked "transient" (because the Servlet is serializable)... It doesn't concern us here (we are not in J2EE anymore), but it makes Sonar happy.
* use constants of the class they were defined in, and not use them from inherited classes.