### PR TITLE
Report Builder: only prepend ampersand if some params already exist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ### Fixed
 - #2265 Review ResourceChangeListener configuration
 - #2187 - Upgraded oakpal.version to 2.0.0. Eliminates transitive compile dependency on oak-core-spi.
+- #2287 - Report Builder pagination buttons not working when report has no Search Parameters configured.
 
 ## [4.5.2] - 2020-04-18
 

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/report-builder/report-page/clientlibs/js/app.js
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/report-builder/report-page/clientlibs/js/app.js
@@ -105,7 +105,10 @@ angular.module('acs-commons-report-page-app', ['acsCoral', 'ACS.Commons.notifica
         $scope.run = function(page) {
         	var params = $('#report--form').serialize();
         	if(page){
-        		params += '&page=' + page;
+        		if (params) {
+        			params += "&";
+        		}
+        		params += 'page=' + page;
         	}
 			loadResults(params);
 		};


### PR DESCRIPTION
fixes issue #2286