### PR TITLE
#2271 bugfix for contexthub request

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/util/BufferedServletOutput.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/BufferedServletOutput.java
@@ -166,10 +166,10 @@ public final class BufferedServletOutput {
     void close() throws IOException {
         if (ResponseWriteMethod.OUTPUTSTREAM.equals(this.writeMethod) && outputStream != null) {
             wrappedResponse.getOutputStream().write(getBufferedBytes());
-        } else if (ResponseWriteMethod.WRITER.equals(this.writeMethod) && writer != null) {
+        } else if (ResponseWriteMethod.WRITER.equals(this.writeMethod) && writer != null && getBufferedString().length() > 0) {
             wrappedResponse.getWriter().write(getBufferedString());
         }
-        if (flushBuffer) {
+        if (flushBuffer && getBufferedString().length() > 0) {
             wrappedResponse.flushBuffer();
         }
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/AemEnvironmentIndicatorFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/AemEnvironmentIndicatorFilter.java
@@ -193,6 +193,8 @@ public class AemEnvironmentIndicatorFilter implements Filter {
                             ? capturedResponse.getBufferedServletOutput().getBufferedString()
                             : null;
 
+            
+                            
             if (contents != null
                     && StringUtils.contains(response.getContentType(), "html")) {
 
@@ -209,6 +211,12 @@ public class AemEnvironmentIndicatorFilter implements Filter {
                     writeEnvironmentIndicator(css, innerHTML, titlePrefix, printWriter);
 
                     printWriter.write(contents.substring(bodyIndex));
+                } 
+            } else {
+                if (contents != null) {
+                    response.setContentLength(contents.length());
+                    final PrintWriter printWriter = response.getWriter();
+                    printWriter.write(contents);
                 }
             }
         }


### PR DESCRIPTION
It seems that Jetty does some internal validation on the PrintWriter, and you are allowed to invoke flushBuffer() only if there is some body at all. This situation was affecting the AemEnvironmentIndicatorFilter only when then response did not contain a "html" in the content-type and had an empty body (which is indeed a rare situation).