### PR TITLE
Feature/2300 -  Fixed CopyProperties WF Process copy of empty properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-4.3.2...HEAD
 
+### Fixed
+
+- #2300 - Fixed CopyProperties WF Process copy of empty properties
+
 ## [4.7.0] - 2020-05-12
 
 ### Added

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/process/impl/CopyPropertiesProcess.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/process/impl/CopyPropertiesProcess.java
@@ -50,7 +50,6 @@ import java.util.Map;
 public class CopyPropertiesProcess implements WorkflowProcess {
     private static final Logger log = LoggerFactory.getLogger(CopyPropertiesProcess.class);
     private static final String PN_PROPERTY_MAP = "PROPERTY_MAP";
-    private static final String PN_SKIP_EMPTY_SOURCE_PROPERTY = "SKIP_EMPTY_SOURCE_PROPERTY";
     private static final String SEPARATOR = "->";
     private static final String ALTERNATE_SEPARATOR = "=>";
     private static final String EVENT_DATA = "acs-aem-commons.workflow.copy-properties";
@@ -184,10 +183,10 @@ public class CopyPropertiesProcess implements WorkflowProcess {
         }
 
         public String toString() {
-            return String.format("%s/%s (Property %s)", new String[] {
+            return String.format("%s/%s (Property %s)",
                     resource.getPath(),
                     propertyName,
-                    propertyExists() ? "exists" : "does not exist"});
+                    propertyExists() ? "exists" : "does not exist");
         }
     }
 }

--- a/bundle/src/test/resources/com/adobe/acs/commons/workflow/process/impl/CopyPropertiesProcessTest.json
+++ b/bundle/src/test/resources/com/adobe/acs/commons/workflow/process/impl/CopyPropertiesProcessTest.json
@@ -1,34 +1,74 @@
 {
-  "one.png" : {
+  "copy-properties.png" : {
     "jcr:primaryType" : "dam:Asset",
     "jcr:content" : {
       "jcr:primaryType" : "nt:unstructured",
       "onTime": "monday",
-      "offTime": "sunday",
+      "offTime": "thursday",
+      "unknownTime": "",
       "metadata" : {
         "jcr:primaryType": "nt:unstructured",
-        "dam:offTime": "saturday"
+        "dam:onTime": "tuesday",
+        "dam:offTime": "friday"
       }
     }
   },
-  "two.png" : {
+  "source-with-destination-without.png" : {
+    "jcr:primaryType" : "dam:Asset",
+    "jcr:content" : {
+      "jcr:primaryType" : "nt:unstructured",
+      "onTime": "monday",
+      "offTime": "thursday",
+      "metadata" : {
+        "jcr:primaryType": "nt:unstructured"
+      }
+    }
+  },
+  "source-without-destination-with.png" : {
     "jcr:primaryType" : "dam:Asset",
     "jcr:content" : {
       "jcr:primaryType" : "nt:unstructured",
       "metadata" : {
         "jcr:primaryType": "nt:unstructured",
-        "dam:onTime": "tuesday"
+        "dam:onTime": "tuesday",
+        "dam:offTime": "friday"
       }
     }
   },
-  "three.png" : {
+  "source-empty-destination-with.png" : {
     "jcr:primaryType" : "dam:Asset",
     "jcr:content" : {
       "jcr:primaryType" : "nt:unstructured",
-      "onTime": "wednesday",
+      "onTime": "",
+      "offTime": "",
       "metadata" : {
         "jcr:primaryType": "nt:unstructured",
-        "dam:onTime": "thursday"
+        "dam:onTime": "tuesday",
+        "dam:offTime": "friday"
+      }
+    }
+  },
+  "source-empty-destination-without.png" : {
+    "jcr:primaryType" : "dam:Asset",
+    "jcr:content" : {
+      "jcr:primaryType" : "nt:unstructured",
+      "onTime": "",
+      "offTime": "",
+      "metadata" : {
+        "jcr:primaryType": "nt:unstructured"
+      }
+    }
+  },
+  "source-with-destination-with.png" : {
+    "jcr:primaryType" : "dam:Asset",
+    "jcr:content" : {
+      "jcr:primaryType" : "nt:unstructured",
+      "onTime": "monday",
+      "offTime": "thursday",
+      "metadata" : {
+        "jcr:primaryType": "nt:unstructured",
+        "dam:onTime": "tuesday",
+        "dam:offTime": "friday"
       }
     }
   }

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/workflow/copy-properties/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/workflow/copy-properties/_cq_dialog/.content.xml
@@ -75,15 +75,6 @@
                                     jcr:title="Properties to Copy"
                                     sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
                                 <items jcr:primaryType="nt:unstructured">
-                                    <skip-empty-property
-                                            jcr:primaryType="nt:unstructured"
-                                            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                            text="Skip empty source properties"
-                                            fieldDescription="If the source property is empty or missing, leave the destination property alone."
-                                            named="./metadata/SKIP_EMPTY_SOURCE_PROPERTY"
-                                            checked="{Boolean}true"
-                                            value="{Boolean}true"
-                                            uncheckedValue="{Boolean}false"/>
                                     <properties
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="granite/ui/components/coral/foundation/form/multifield"

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/workflow/copy-properties/_cq_editConfig.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/workflow/copy-properties/_cq_editConfig.xml
@@ -24,9 +24,4 @@
           cq:dialogMode="floating"
           cq:inherit="{Boolean}true"
           jcr:primaryType="cq:EditConfig">
-    <cq:formParameters
-            jcr:primaryType="nt:unstructured"
-            jcr:title="Copy Properties"
-            PROCESS="com.adobe.acs.commons.workflow.process.impl.CopyPropertiesProcess"
-            PROCESS_AUTO_ADVANCE="true"/>
 </jcr:root>


### PR DESCRIPTION
Empty or missing properties on the source now delete destination properties (should they exist)
