### PR TITLE
Versioned ClientLibs are not supported by Page Exports (cw-wcm-conten…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #2300 - Fixed CopyProperties WF Process copy of empty properties
 - #2311 - ResourceTypeHttpCacheConfigExtension does not work with multiple allowed paths
 - #2314 - Fixed java.lang.IllegalStateException: Not a JSON Object for CQIncludePropertyNamespaceServlet
+- #2330 - Deactivated VersionedClientlibsTransformerFactory.VersionableClientlibsTransformer for static page exports
 
 ## [4.7.0] - 2020-05-12
 

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactory.java
@@ -28,6 +28,7 @@ import com.adobe.granite.ui.clientlibs.ClientLibrary;
 import com.adobe.granite.ui.clientlibs.HtmlLibrary;
 import com.adobe.granite.ui.clientlibs.HtmlLibraryManager;
 import com.adobe.granite.ui.clientlibs.LibraryType;
+import com.day.cq.wcm.contentsync.PathRewriterOptions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -337,18 +338,23 @@ public final class VersionedClientlibsTransformerFactory extends AbstractGuavaCa
     private class VersionableClientlibsTransformer extends ContentHandlerBasedTransformer {
 
         private SlingHttpServletRequest request;
+        
+        private boolean enabled;
 
         @Override
         public void init(ProcessingContext context, ProcessingComponentConfiguration config) throws IOException {
             super.init(context, config);
             this.request = context.getRequest();
+            // versioned clientlibs are not supported for Page Exports with cq-wcm-content-sync
+            enabled = request.getAttribute(PathRewriterOptions.ATTRIBUTE_PATH_REWRITING_OPTIONS) == null;
         }
 
         public void startElement(final String namespaceURI, final String localName, final String qName,
                                  final Attributes attrs)
                 throws SAXException {
+            
             final Attributes nextAttributes;
-            if (disableVersioning) {
+            if (disableVersioning || !enabled) {
                 nextAttributes = attrs;
             } else {
                 nextAttributes = versionClientLibs(localName, attrs, request);


### PR DESCRIPTION
The AEM Page Exporter [1] is generating self contained zip files of AEM pages. The service is also getting used for the generation of translation preview packages. Versioned ClientLibs are not supported by cq-wcm-content-sync.  
With this change VersionableClientlibsTransformer will not transform clientlib paths anymore, whenever contentsync.PathRewriterOptions are present.

[1] https://docs.adobe.com/content/help/en/experience-manager-65/administering/contentmanagement/page-exporter.html