### PR TITLE
Feature/2359 deep prune administrators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ### Changed
 - #2324 - On-Deploy-Scripts are not supported on AEMaaCS
 - #2350 - Added hook for VanityUrlAdjuster in VanityServiceUrlImpl
+- #2359 - Deprecated AdminOnlyProcessDefinitionFactory in favor of recommending AdministratorsOnlyProcessDefinitionFactory, updated Deep Prune to allow all administrators group.
 
 ## [4.7.0] - 2020-05-12
 

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/AdminOnlyProcessDefinitionFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/AdminOnlyProcessDefinitionFactory.java
@@ -19,14 +19,20 @@
  */
 package com.adobe.acs.commons.mcp;
 
-import org.osgi.annotation.versioning.ConsumerType;
 import org.apache.jackrabbit.api.security.user.User;
-
+import org.osgi.annotation.versioning.ConsumerType;
 
 /**
- * ProcessDefinitionFactory which limits availablity of a process to the literal 'admin' user.
+ * ProcessDefinitionFactory which limits availablity of a process to the literal
+ * 'admin' user.
+ *
  * @param <P> Process definition class
+ * @deprecated Please use AdministratorsOnlyProcessDefinitionFactory as it is
+ * still sufficiently restrictive but more generally usable in environments
+ * where the admin account is impossible to attain. This class will still
+ * continue to work but is generally discouraged.
  */
+@Deprecated
 @ConsumerType
 public abstract class AdminOnlyProcessDefinitionFactory<P extends ProcessDefinition> extends ProcessDefinitionFactory<P> {
 

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/DeepPruneFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/DeepPruneFactory.java
@@ -19,7 +19,7 @@
  */
 package com.adobe.acs.commons.mcp.impl.processes;
 
-import com.adobe.acs.commons.mcp.AdminOnlyProcessDefinitionFactory;
+import com.adobe.acs.commons.mcp.AdministratorsOnlyProcessDefinitionFactory;
 import com.adobe.acs.commons.mcp.ProcessDefinitionFactory;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Reference;
@@ -28,7 +28,7 @@ import org.apache.sling.event.jobs.JobManager;
 
 @Component
 @Service(ProcessDefinitionFactory.class)
-public class DeepPruneFactory extends AdminOnlyProcessDefinitionFactory<DeepPrune> {
+public class DeepPruneFactory extends AdministratorsOnlyProcessDefinitionFactory<DeepPrune> {
 
     @Reference
     private JobManager jobManager;


### PR DESCRIPTION
Seems that admin-only is a bit too limited for a lot of folks because the actual admin account is generally inaccessible.  Therefore it makes more sense to allow all administrators to use tools rather than check for the primary admin user.  Changed deep prune to allow administrators group.