### PR TITLE
Fix compilation warnings

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/exporters/impl/tags/Parameters.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/exporters/impl/tags/Parameters.java
@@ -33,7 +33,7 @@ public class Parameters {
     this.path = Optional.ofNullable(request.getParameter("path"))
         .orElse(StringUtils.EMPTY);
     this.localized = Optional.ofNullable(request.getParameter("localized"))
-        .map(Boolean::new)
+        .map(Boolean::valueOf)
         .orElse(Boolean.FALSE);
     this.defaultLocalization = Optional.ofNullable(request.getParameter("defaultLocalization"))
         .filter(StringUtils::isNotBlank)

--- a/bundle/src/main/java/com/adobe/acs/commons/httpcache/invalidator/event/JCRNodeChangeEventHandler.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/httpcache/invalidator/event/JCRNodeChangeEventHandler.java
@@ -92,7 +92,7 @@ public class JCRNodeChangeEventHandler implements EventHandler, ResourceChangeLi
     private ServiceRegistration<?> registration;
     
     @Activate
-    @SuppressWarnings("squid:S1149")
+    @SuppressWarnings({"squid:S1149","deprecation"})
     protected void activate(BundleContext context, Map<String, Object> config) {
         String pathFilter = PropertiesUtil.toString(config.get(EventConstants.EVENT_FILTER), "");
         if (!pathFilter.isEmpty()) {

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/AbstractContainerComponent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/AbstractContainerComponent.java
@@ -22,6 +22,7 @@ package com.adobe.acs.commons.mcp.form;
 import com.adobe.acs.commons.mcp.util.AccessibleObjectUtil;
 import com.adobe.acs.commons.mcp.util.AnnotatedFieldDeserializer;
 import com.adobe.acs.commons.mcp.util.SyntheticResourceBuilder;
+
 import java.lang.reflect.ParameterizedType;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -96,8 +97,8 @@ public class AbstractContainerComponent extends FieldComponent {
 
     public FieldComponent generateDefaultChildComponent() {
         try {
-            return defaultChildComponent.newInstance();
-        } catch (InstantiationException | IllegalAccessException ex) {
+            return defaultChildComponent.getDeclaredConstructor().newInstance();
+        } catch (RuntimeException | ReflectiveOperationException ex) {
             LOG.error("got exception", ex);
             return null;
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/DialogProviderAnnotationProcessor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/DialogProviderAnnotationProcessor.java
@@ -104,7 +104,7 @@ public class DialogProviderAnnotationProcessor extends AbstractProcessor {
             out.println(String.format("public class %s implements %s {", className, osgiService));
             out.println();
             out.println(String.format("    @Override%n    public Class getTargetClass() {%n        return %s.class;%n    }", targetClass));
-            out.println("    @Activate\n    public void activate(BundleContext context) throws InstantiationException, IllegalAccessException {\n        this.doActivate(context);\n    }\n");
+            out.println("    @Activate\n    public void activate(BundleContext context) throws InstantiationException, IllegalAccessException, ReflectiveOperationException {\n        this.doActivate(context);\n    }\n");
             out.println("    @Deactivate\n    public void deactivate(BundleContext context) {\n        this.doDeactivate();\n    }");
             out.println("}");
             out.flush();

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/DialogResourceProvider.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/DialogResourceProvider.java
@@ -46,7 +46,7 @@ public interface DialogResourceProvider {
     public static Map<Class, ServiceRegistration> registeredProviders = Collections.synchronizedMap(new HashMap<>());
 
     @SuppressWarnings("squid:S1149") // Yes HashTable sucks but it's required here.
-    default void doActivate(BundleContext bundleContext) throws InstantiationException, IllegalAccessException {
+    default void doActivate(BundleContext bundleContext) throws RuntimeException, ReflectiveOperationException {
         DialogResourceProviderImpl provider = new DialogResourceProviderImpl(getTargetClass(), getDialogProvider());
         @SuppressWarnings("UseOfObsoleteCollectionType")
         Dictionary<String, Object> props = new Hashtable<>();

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/DialogResourceProvider.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/DialogResourceProvider.java
@@ -20,6 +20,8 @@
 package com.adobe.acs.commons.mcp.form;
 
 import com.adobe.acs.commons.mcp.impl.DialogResourceProviderImpl;
+
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.Dictionary;
 import java.util.HashMap;
@@ -46,7 +48,7 @@ public interface DialogResourceProvider {
     public static Map<Class, ServiceRegistration> registeredProviders = Collections.synchronizedMap(new HashMap<>());
 
     @SuppressWarnings("squid:S1149") // Yes HashTable sucks but it's required here.
-    default void doActivate(BundleContext bundleContext) throws RuntimeException, ReflectiveOperationException {
+    default void doActivate(BundleContext bundleContext) throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException   {
         DialogResourceProviderImpl provider = new DialogResourceProviderImpl(getTargetClass(), getDialogProvider());
         @SuppressWarnings("UseOfObsoleteCollectionType")
         Dictionary<String, Object> props = new Hashtable<>();

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/DialogResourceProviderFactoryImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/DialogResourceProviderFactoryImpl.java
@@ -19,8 +19,6 @@
  */
 package com.adobe.acs.commons.mcp.impl;
 
-import com.adobe.acs.commons.mcp.DialogResourceProviderConfiguration;
-import com.adobe.acs.commons.mcp.DialogResourceProviderFactory;
 import java.util.Map;
 import org.apache.sling.spi.resource.provider.ResourceProvider;
 import org.osgi.framework.ServiceRegistration;
@@ -32,13 +30,13 @@ import org.osgi.service.metatype.annotations.Designate;
  * @deprecated Will be removed in 5.0 entirely, no longer needed
  */
 @Component(
-        service = DialogResourceProviderFactory.class,
+        service = com.adobe.acs.commons.mcp.DialogResourceProviderFactory.class,
         immediate = true
 )
-@Designate(ocd = DialogResourceProviderConfiguration.class)
+@Designate(ocd = com.adobe.acs.commons.mcp.DialogResourceProviderConfiguration.class)
 @SuppressWarnings("deprecation")
 @Deprecated
-public class DialogResourceProviderFactoryImpl implements DialogResourceProviderFactory {
+public class DialogResourceProviderFactoryImpl implements com.adobe.acs.commons.mcp.DialogResourceProviderFactory {
 
     @Override
     public void registerClass(String className) {

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/DialogResourceProviderImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/DialogResourceProviderImpl.java
@@ -59,11 +59,11 @@ public class DialogResourceProviderImpl extends ResourceProvider {
     private final Class originalClass;
     private final boolean isComponent;
 
-    public DialogResourceProviderImpl(Class c, DialogProvider annotation) throws InstantiationException, IllegalAccessException {
+    public DialogResourceProviderImpl(Class c, DialogProvider annotation) throws RuntimeException, ReflectiveOperationException {
         originalClass = c;
         isComponent = annotation != null && annotation.style() == DialogProvider.DialogStyle.COMPONENT;
         if (GeneratedDialog.class.isAssignableFrom(c)) {
-            dialog = (GeneratedDialog) c.newInstance();
+            dialog = (GeneratedDialog) c.getDeclaredConstructor().newInstance();
         } else {
             dialog = new GeneratedDialogWrapper(c);
         }
@@ -94,16 +94,16 @@ public class DialogResourceProviderImpl extends ResourceProvider {
             try {
                 Method getter = MethodUtils.getMatchingAccessibleMethod(originalClass, "getResourceType", new Class[]{});
                 if (getter != null) {
-                    resourceType = String.valueOf(getter.invoke(originalClass.newInstance()));
+                    resourceType = String.valueOf(getter.invoke(originalClass.getDeclaredConstructor().newInstance()));
                 } else {
                     Field field = FieldUtils.getField(originalClass, "resourceType", true);
                     if (field != null) {
-                        resourceType = String.valueOf(field.get(originalClass.newInstance()));
+                        resourceType = String.valueOf(field.get(originalClass.getDeclaredConstructor().newInstance()));
                     } else {
                         throw new InstantiationException(String.format("No resource type present for %s", originalClass.getCanonicalName()));
                     }
                 }
-            } catch (InvocationTargetException | IllegalAccessException ex) {
+            } catch (RuntimeException | ReflectiveOperationException ex) {
                 LOGGER.debug("Unable to determine sling resource type for model bean: {} ", originalClass);
             }
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/DialogResourceProviderImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/DialogResourceProviderImpl.java
@@ -59,7 +59,7 @@ public class DialogResourceProviderImpl extends ResourceProvider {
     private final Class originalClass;
     private final boolean isComponent;
 
-    public DialogResourceProviderImpl(Class c, DialogProvider annotation) throws RuntimeException, ReflectiveOperationException {
+    public DialogResourceProviderImpl(Class c, DialogProvider annotation) throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException  {
         originalClass = c;
         isComponent = annotation != null && annotation.style() == DialogProvider.DialogStyle.COMPONENT;
         if (GeneratedDialog.class.isAssignableFrom(c)) {

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/BulkWorkflow.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/BulkWorkflow.java
@@ -61,9 +61,11 @@ public class BulkWorkflow extends ProcessDefinition implements Serializable {
         SUCCESS, FAILURE
     }
 
+    
     public enum QueryLanguage {
         QUERY_BUILDER(QueryHelperImpl.QUERY_BUILDER),
         LIST(QueryHelperImpl.LIST),
+        @SuppressWarnings("deprecation")
         XPATH(Query.XPATH),
         JCR_SQL2(Query.JCR_SQL2),
         JCR_SQL("JCR-SQL");

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/util/AnnotatedFieldDeserializer.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/util/AnnotatedFieldDeserializer.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -129,7 +130,7 @@ public class AnnotatedFieldDeserializer {
             }
             FieldUtils.writeField(field, target, array, true);
         } else {
-            Collection c = (Collection) getInstantiatableListType(field.getType()).newInstance();
+            Collection c = (Collection) getInstantiatableListType(field.getType()).getDeclaredConstructor().newInstance();
             c.addAll(convertedValues);
             FieldUtils.writeField(field, target, c, true);
         }
@@ -201,10 +202,10 @@ public class AnnotatedFieldDeserializer {
                     FormField fieldDefinition = f.getAnnotation(FormField.class);
                     FieldComponent component;
                     try {
-                        component = fieldDefinition.component().newInstance();
+                        component = fieldDefinition.component().getDeclaredConstructor().newInstance();
                         component.setup(AccessibleObjectUtil.getFieldName(f), f, fieldDefinition, sling);
                         return component;
-                    } catch (InstantiationException | IllegalAccessException ex) {
+                    } catch (RuntimeException | ReflectiveOperationException ex) {
                         LOG.error("Unable to instantiate field component for " + f.toString(), ex);
                     }
                     return null;

--- a/bundle/src/main/java/com/adobe/acs/commons/models/injectors/annotation/impl/ChildResourceFromRequestAnnotationProcessorFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/models/injectors/annotation/impl/ChildResourceFromRequestAnnotationProcessorFactory.java
@@ -63,6 +63,7 @@ public class ChildResourceFromRequestAnnotationProcessorFactory implements Stati
             return this.annotation.injectionStrategy();
         }
 
+        @SuppressWarnings("deprecation")
         public Boolean isOptional() {
             return this.annotation.optional();
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/util/impl/AemCapabilityHelperImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/impl/AemCapabilityHelperImpl.java
@@ -19,7 +19,6 @@
  */
 package com.adobe.acs.commons.util.impl;
 
-import com.adobe.acs.commons.util.AemCapabilityHelper;
 import org.apache.commons.lang.StringUtils;
 import org.apache.sling.jcr.api.SlingRepository;
 import org.osgi.service.component.annotations.Component;
@@ -36,8 +35,9 @@ import javax.jcr.RepositoryException;
  * @deprecated All supported AEM's run on Oak repositories now, so this will always return true.
  */
 @Deprecated
+@SuppressWarnings("deprecation")
 @Component
-public class AemCapabilityHelperImpl implements AemCapabilityHelper {
+public class AemCapabilityHelperImpl implements com.adobe.acs.commons.util.AemCapabilityHelper {
     @Reference
     private transient SlingRepository slingRepository;
 

--- a/bundle/src/main/java/com/adobe/acs/commons/util/impl/ReflectionUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/impl/ReflectionUtil.java
@@ -191,11 +191,11 @@ public class ReflectionUtil {
 
             switch (type){
                 case "Long":
-                    return new Long(value);
+                    return Long.valueOf(value);
                 case "Integer":
-                    return new Integer(value);
+                    return Integer.valueOf(value);
                 case "Float":
-                    return new Float(value);
+                    return Float.valueOf(value);
                 case "Boolean":
                     if(value.equalsIgnoreCase("true")){
                         return Boolean.TRUE;
@@ -203,7 +203,7 @@ public class ReflectionUtil {
                         return Boolean.FALSE;
                     }
                 case "Double":
-                    return new Double(value);
+                    return Double.valueOf(value);
                 case "String":
                 default:
                     return allowedValue;

--- a/bundle/src/main/java/com/adobe/acs/commons/wrap/jcr/BaseSessionIWrap.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wrap/jcr/BaseSessionIWrap.java
@@ -123,6 +123,7 @@ public interface BaseSessionIWrap<S extends Session> extends Session {
         return wrapSession(unwrapSession().impersonate(credentials));
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     default Node getNodeByUUID(final String uuid) throws ItemNotFoundException, RepositoryException {
         return wrapItem(unwrapSession().getNodeByUUID(uuid));
@@ -298,16 +299,19 @@ public interface BaseSessionIWrap<S extends Session> extends Session {
         return unwrapSession().isLive();
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     default void addLockToken(final String lt) {
         unwrapSession().addLockToken(lt);
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     default String[] getLockTokens() {
         return unwrapSession().getLockTokens();
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     default void removeLockToken(final String lt) {
         unwrapSession().removeLockToken(lt);

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/DialogResourceProviderFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/DialogResourceProviderFactoryTest.java
@@ -61,7 +61,7 @@ public class DialogResourceProviderFactoryTest {
     public Map<String, DialogResourceProvider> providers = new HashMap<>();
 
     @Before
-    public void init() throws IOException, ClassNotFoundException, InstantiationException, IllegalAccessException {
+    public void init() throws IOException, RuntimeException, ReflectiveOperationException {
         slingContext.addModelsForClasses(MODEL_CLASSES);
         for (String className : MODEL_CLASSES) {
             DialogResourceProvider provider = (DialogResourceProvider) Class.forName(DialogResourceProvider.getServiceClassName(className)).newInstance();


### PR DESCRIPTION
* suppress deprecation warnings because we cannot fix them right now or with the currrent implementation
* use the static method valueOf instead of the constructors of the wrapped primitive types (Java9)
* replace type.newInstance() with the recommended version (Java9)