### PR TITLE
#2327 provide build profile for cloudservice [do not merge yet]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,24 @@ jdk:
 - oraclejdk8
 - oraclejdk11
 env:
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=en -Duser.country=US" POST_COVERAGE=true DEPENDENCY_CHECK=true
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=de -Duser.country=DE"
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=es -Duser.country=ES"
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=fr -Duser.country=FR"
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=hi -Duser.country=IN"
+- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=en -Duser.country=US -Pclassic" POST_COVERAGE=true DEPENDENCY_CHECK=true
+- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=de -Duser.country=DE -Pclassic"
+- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=es -Duser.country=ES -Pclassic"
+- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=fr -Duser.country=FR -Pclassic"
+- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=hi -Duser.country=IN -Pclassic"
+- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=hi -Duser.country=US -Pcloudservice"
 jobs:
    exclude:
      - jdk: oraclejdk11
-       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=en -Duser.country=US" POST_COVERAGE=true DEPENDENCY_CHECK=true
+       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=en -Duser.country=US -Pclassic" POST_COVERAGE=true DEPENDENCY_CHECK=true
      - jdk: oraclejdk11
-       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=es -Duser.country=ES"
+       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=es -Duser.country=ES -Pclassic"
      - jdk: oraclejdk11
-       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=fr -Duser.country=FR"
+       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=fr -Duser.country=FR -Pclassic"
      - jdk: oraclejdk11
-       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=hi -Duser.country=IN"
+       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=hi -Duser.country=IN -Pclassic"
+     - jdk: oraclejdk8
+       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=hi -Duser.country=US -Pcloudservice"
 script: mvn verify -B
 before_install:
   - cp .travis.settings.xml $HOME/.m2/settings.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,25 +4,25 @@ jdk:
 - oraclejdk8
 - oraclejdk11
 env:
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=en -Duser.country=US -Pclassic" POST_COVERAGE=true DEPENDENCY_CHECK=true
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=de -Duser.country=DE -Pclassic"
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=es -Duser.country=ES -Pclassic"
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=fr -Duser.country=FR -Pclassic"
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=hi -Duser.country=IN -Pclassic"
-- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=hi -Duser.country=US -Pcloudservice"
+- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=en -Duser.country=US" POST_COVERAGE=true DEPENDENCY_CHECK=true
+- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=de -Duser.country=DE" MAVEN_PROFILE=classic
+- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=es -Duser.country=ES" MAVEN_PROFILE=classic
+- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=fr -Duser.country=FR" MAVEN_PROFILE=classic
+- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=hi -Duser.country=IN" MAVEN_PROFILE=classic
+- MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=hi -Duser.country=US" MAVEN_PROFILE=cloudservice
 jobs:
    exclude:
      - jdk: oraclejdk11
-       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=en -Duser.country=US -Pclassic" POST_COVERAGE=true DEPENDENCY_CHECK=true
+       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=en -Duser.country=US" POST_COVERAGE=true DEPENDENCY_CHECK=true
      - jdk: oraclejdk11
-       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=es -Duser.country=ES -Pclassic"
+       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=es -Duser.country=ES" MAVEN_PROFILE=classic
      - jdk: oraclejdk11
-       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=fr -Duser.country=FR -Pclassic"
+       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=fr -Duser.country=FR" MAVEN_PROFILE=classic
      - jdk: oraclejdk11
-       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=hi -Duser.country=IN -Pclassic"
+       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=hi -Duser.country=IN" MAVEN_PROFILE=classic
      - jdk: oraclejdk8
-       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=hi -Duser.country=US -Pcloudservice"
-script: mvn verify -B
+       env: MAVEN_SKIP_RC=true MAVEN_OPTS="-Xmx512m -XX:MaxMetaspaceSize=512m -Duser.language=hi -Duser.country=US" MAVEN_PROFILE=cloudservice
+script: mvn verify -B -P $MAVEN_PROFILE
 before_install:
   - cp .travis.settings.xml $HOME/.m2/settings.xml
 after_success:

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -342,7 +342,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
                 <configuration>
                     <reuseForks>false</reuseForks>
                     <forkCount>1C</forkCount>
@@ -769,12 +768,7 @@
             <version>4.0.6</version>
             <scope>provided</scope>
         </dependency>
-        <!-- put UberJar last so that more specific artifacts take precedence -->
-        <dependency>
-            <groupId>com.adobe.aem</groupId>
-            <artifactId>uber-jar</artifactId>
-            <classifier>apis</classifier>
-        </dependency>
+
 
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
@@ -812,4 +806,32 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+    
+    <profiles>
+    	<profile>
+    		<id>classic</id>
+    		<activation>
+    			<activeByDefault>true</activeByDefault>
+    		</activation>
+    		<dependencies>
+    			<!-- put UberJar last so that more specific artifacts take precedence -->
+		        <dependency>
+		            <groupId>com.adobe.aem</groupId>
+		            <artifactId>uber-jar</artifactId>
+		            <classifier>apis</classifier>
+		        </dependency>
+    		</dependencies>
+    	</profile>
+    	<profile>
+    		<id>cloudservice</id>
+    		<dependencies>
+    			<!-- put UberJar last so that more specific artifacts take precedence -->
+		        <dependency>
+		            <groupId>com.adobe.aem</groupId>
+		            <artifactId>aem-sdk-api</artifactId>
+		        </dependency>
+    		</dependencies>
+    	</profile>
+    </profiles>
+    
 </project>

--- a/bundle/src/main/java/com/adobe/acs/commons/cloudconfig/impl/CreateCloudConfigServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/cloudconfig/impl/CreateCloudConfigServlet.java
@@ -33,12 +33,12 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.servlets.HttpConstants;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
+import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.apache.sling.servlets.post.HtmlResponse;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.aemds.guide.utils.JcrResourceConstants;
 import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;

--- a/bundle/src/main/java/com/adobe/acs/commons/indesign/dynamicdeckdynamo/workflow/processes/impl/DynamicDeckBackTrackProcess.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/indesign/dynamicdeckdynamo/workflow/processes/impl/DynamicDeckBackTrackProcess.java
@@ -22,7 +22,6 @@ package com.adobe.acs.commons.indesign.dynamicdeckdynamo.workflow.processes.impl
 import com.adobe.acs.commons.indesign.dynamicdeckdynamo.constants.DynamicDeckDynamoConstants;
 import com.adobe.acs.commons.indesign.dynamicdeckdynamo.exception.DynamicDeckDynamoException;
 import com.adobe.acs.commons.indesign.dynamicdeckdynamo.utils.DynamicDeckUtils;
-import com.adobe.aemds.guide.themes.GuideThemeConstants;
 import com.adobe.granite.workflow.WorkflowException;
 import com.adobe.granite.workflow.WorkflowSession;
 import com.adobe.granite.workflow.exec.WorkItem;
@@ -64,6 +63,8 @@ import java.util.Arrays;
 @Component(service = WorkflowProcess.class, property = {"process.label=Dynamic Deck Dynamo Write Back Process"})
 public class DynamicDeckBackTrackProcess implements WorkflowProcess {
     private static final Logger LOGGER = LoggerFactory.getLogger(DynamicDeckBackTrackProcess.class);
+    
+    private static final String CONTENT_DAM_ROOT = "/content/dam";
 
     @Override
     public void execute(WorkItem workItem, WorkflowSession workflowSession, MetaDataMap metaDataMap) throws WorkflowException {
@@ -246,10 +247,10 @@ public class DynamicDeckBackTrackProcess implements WorkflowProcess {
                         return;
                     }
                     String completeHrefValue = null;
-                    if (hrefValue.contains(GuideThemeConstants.CONTENT_DAM_ROOT)) {
+                    if (hrefValue.contains(CONTENT_DAM_ROOT)) {
                         String hrefEncodedValue = StringUtils.substringAfter(
-                                URLDecoder.decode(hrefValue, StandardCharsets.UTF_8.toString()), GuideThemeConstants.CONTENT_DAM_ROOT);
-                        completeHrefValue = GuideThemeConstants.CONTENT_DAM_ROOT + hrefEncodedValue;
+                                URLDecoder.decode(hrefValue, StandardCharsets.UTF_8.toString()), CONTENT_DAM_ROOT);
+                        completeHrefValue = CONTENT_DAM_ROOT + hrefEncodedValue;
                     }
                     if (null == completeHrefValue) {
                         LOGGER.error("Back track root path is not correct {}", hrefValue);

--- a/bundle/src/test/java/com/adobe/acs/commons/dam/impl/AssetsFolderPropertiesSupportTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/dam/impl/AssetsFolderPropertiesSupportTest.java
@@ -20,11 +20,11 @@
 
 package com.adobe.acs.commons.dam.impl;
 
-import com.adobe.cq.commerce.common.ValueMapDecorator;
 import com.google.common.collect.ImmutableMap;
 import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.jcr.resource.JcrResourceConstants;
 import org.apache.sling.servlets.post.PostOperation;
 import org.apache.sling.servlets.post.PostResponse;

--- a/bundle/src/test/java/com/adobe/acs/commons/designer/impl/DesignHtmlLibraryManagerImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/designer/impl/DesignHtmlLibraryManagerImplTest.java
@@ -34,6 +34,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.jcr.RepositoryException;
+
 import junitx.util.PrivateAccessor;
 
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -223,6 +225,20 @@ public class DesignHtmlLibraryManagerImplTest {
             // TODO Auto-generated method stub
             return null;
         }
+
+        // required for cloudservice
+		//@Override
+		public void ensureCached() throws IOException, RepositoryException {
+			// TODO Auto-generated method stub
+			
+		}
+
+        // required for cloudservice
+		//@Override
+		public void invalidateOutputCache() throws RepositoryException {
+			// TODO Auto-generated method stub
+			
+		}
     }
 
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/cfi/MockContentFragment.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/cfi/MockContentFragment.java
@@ -154,5 +154,13 @@ public class MockContentFragment implements ContentFragment {
     public <AdapterType> AdapterType adaptTo(@Nonnull Class<AdapterType> aClass) {
         return null;
     }
+
+    
+    // Required for cloudservice
+	//@Override
+	public void removeVariation(String arg0) throws ContentFragmentException {
+		// TODO Auto-generated method stub
+		
+	}
     
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/twitter/impl/TwitterAdapterFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/twitter/impl/TwitterAdapterFactoryTest.java
@@ -20,7 +20,6 @@
 package com.adobe.acs.commons.twitter.impl;
 
 import com.adobe.acs.commons.twitter.TwitterClient;
-import com.adobe.cq.commerce.common.ValueMapDecorator;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.webservicesupport.ConfigurationConstants;
 import com.day.cq.wcm.webservicesupport.ConfigurationManager;
@@ -29,6 +28,7 @@ import org.apache.sling.api.adapter.AdapterFactory;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.commons.testing.osgi.MockBundleContext;
 import org.junit.Before;
 import org.junit.Rule;

--- a/bundle/src/test/java/com/adobe/acs/commons/workflow/impl/WorkflowPackageManagerImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/workflow/impl/WorkflowPackageManagerImplTest.java
@@ -213,5 +213,12 @@ public final class WorkflowPackageManagerImplTest {
         public String getPath() {
             return WORKFLOW_PACKAGE_PATH;
         }
+
+        // required for cloudservice
+		//@Override
+		public boolean hasNode(String arg0) {
+			// TODO Auto-generated method stub
+			return false;
+		}
     };
 }

--- a/pom.xml
+++ b/pom.xml
@@ -311,6 +311,20 @@
                     <autoReleaseAfterClose>false</autoReleaseAfterClose>
                 </configuration>
             </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-help-plugin</artifactId>
+				<version>3.2.0</version>
+				<executions>
+					<execution>
+						<id>show-profiles</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>active-profiles</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
         </plugins>
     </build>
 
@@ -368,13 +382,6 @@
                 <groupId>javax.jcr</groupId>
                 <artifactId>jcr</artifactId>
                 <version>2.0</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.adobe.aem</groupId>
-                <artifactId>uber-jar</artifactId>
-                <version>6.3.0</version>
-                <classifier>apis</classifier>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -748,6 +755,39 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+        	<id>cloudservice</id>
+        	<dependencyManagement>
+        		<dependencies>
+        			<dependency>
+		                <groupId>com.adobe.aem</groupId>
+		                <artifactId>aem-sdk-api</artifactId>
+		                <version>2020.7.3981.20200731T205128Z-200604</version>
+		                <scope>provided</scope>
+		            </dependency>
+        		</dependencies>
+        	</dependencyManagement>
+        </profile>
+        <profile>
+        	<id>classic</id>
+        	<activation>
+        		<activeByDefault>true</activeByDefault>
+        	</activation>
+        	<properties>
+        		<buildmode>classic</buildmode>
+        	</properties>
+        	<dependencyManagement>
+        		<dependencies>
+        			<dependency>
+		                <groupId>com.adobe.aem</groupId>
+		                <artifactId>uber-jar</artifactId>
+		                <version>6.3.0</version>
+		                <classifier>apis</classifier>
+		                <scope>provided</scope>
+		            </dependency>
+        		</dependencies>
+        	</dependencyManagement>
         </profile>
     </profiles>
 

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -324,11 +324,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.adobe.aem</groupId>
-            <artifactId>uber-jar</artifactId>
-            <classifier>apis</classifier>
-        </dependency>
-        <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
@@ -375,5 +370,30 @@
                 </plugins>
             </build>
         </profile>
+    	<profile>
+    		<id>classic</id>
+    		<activation>
+    			<activeByDefault>true</activeByDefault>
+    		</activation>
+    		<dependencies>
+    			<!-- put UberJar last so that more specific artifacts take precedence -->
+		        <dependency>
+		            <groupId>com.adobe.aem</groupId>
+		            <artifactId>uber-jar</artifactId>
+		            <classifier>apis</classifier>
+		        </dependency>
+    		</dependencies>
+    	</profile>
+    	<profile>
+    		<id>cloudservice</id>
+    		<dependencies>
+    			<!-- put UberJar last so that more specific artifacts take precedence -->
+		        <dependency>
+		            <groupId>com.adobe.aem</groupId>
+		            <artifactId>aem-sdk-api</artifactId>
+		        </dependency>
+    		</dependencies>
+    	</profile>
     </profiles>
+    
 </project>

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -341,11 +341,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.adobe.aem</groupId>
-            <artifactId>uber-jar</artifactId>
-            <classifier>apis</classifier>
-        </dependency>
     </dependencies>
     <profiles>
         <profile>
@@ -368,5 +363,28 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+        	<id>classic</id>
+        	<activation>
+    			<activeByDefault>true</activeByDefault>
+    		</activation>
+        	<dependencies>
+        		<dependency>
+		            <groupId>com.adobe.aem</groupId>
+		            <artifactId>uber-jar</artifactId>
+		            <classifier>apis</classifier>
+		        </dependency>
+        	</dependencies>
+        </profile>
+        <profile>
+    		<id>cloudservice</id>
+    		<dependencies>
+    			<!-- put UberJar last so that more specific artifacts take precedence -->
+		        <dependency>
+		            <groupId>com.adobe.aem</groupId>
+		            <artifactId>aem-sdk-api</artifactId>
+		        </dependency>
+    		</dependencies>
+    	</profile>
     </profiles>
 </project>


### PR DESCRIPTION
adressing #2327 

added 2 build profiles
* ```classic``` (active by default, compiles against the current 6.3 uber.jar)
* ```cloudservice``` (compiles against the current SDK API)