### PR TITLE
Feature/tree activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 
 ### Added
+- #1060 - New tree activation MCP utility
 
 ### Changed
 

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplication.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplication.java
@@ -1,0 +1,316 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.mcp.impl.processes;
+
+import com.adobe.acs.commons.fam.ActionManager;
+import com.adobe.acs.commons.fam.actions.ActionBatch;
+import com.adobe.acs.commons.functions.CheckedFunction;
+import com.adobe.acs.commons.mcp.ProcessDefinition;
+import com.adobe.acs.commons.mcp.ProcessInstance;
+import com.adobe.acs.commons.mcp.form.CheckboxComponent;
+import com.adobe.acs.commons.mcp.form.FormField;
+import com.adobe.acs.commons.mcp.form.PathfieldComponent;
+import com.adobe.acs.commons.mcp.form.RadioComponent;
+import com.adobe.acs.commons.mcp.model.GenericReport;
+import com.adobe.acs.commons.util.visitors.TreeFilteringResourceVisitor;
+import com.day.cq.commons.jcr.JcrConstants;
+import com.day.cq.contentsync.handler.util.RequestResponseFactory;
+import com.day.cq.dam.api.DamConstants;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.jcr.RepositoryException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.engine.SlingRequestProcessor;
+
+/**
+ * Replace folder thumbnails under a user-definable set of circumstances As a business user, I would like an easy way to
+ * scan and repair missing thumbnails, or just regenerate all thumbnails under a given tree of the DAM.
+ */
+public class RefreshFolderTumbnails extends ProcessDefinition {
+
+    protected static enum ThumbnailScanLogic {
+        MISSING(RefreshFolderTumbnails::isThumbnailMissing),
+        PLACEHOLDERS(RefreshFolderTumbnails::isThumbnailMissing,
+                RefreshFolderTumbnails::isPlaceholderThumbnail),
+        OUTDATED(RefreshFolderTumbnails::isThumbnailMissing,
+                RefreshFolderTumbnails::isPlaceholderThumbnail,
+                RefreshFolderTumbnails::isThumbnailContentsOutdated),
+        ALL_AUTOMATIC_OR_MISSING(RefreshFolderTumbnails::isThumbnailMissing,
+                RefreshFolderTumbnails::isThumbnailAutomatic),
+        ALL(r -> true);
+
+        CheckedFunction<Resource, Boolean> test;
+
+        @SuppressWarnings("squid:UnusedPrivateMethod")
+        private ThumbnailScanLogic(CheckedFunction<Resource, Boolean>... tests) {
+            this.test = CheckedFunction.or(tests);
+        }
+
+        @SuppressWarnings("squid:S00112")
+        public boolean shouldReplace(Resource r) throws Exception {
+            return this.test.apply(r);
+        }
+    }
+
+    public static final String FOLDER_THUMBNAIL = "/jcr:content/folderThumbnail";
+
+    private static Map<String, Object> THUMBNAIL_PARAMS = new HashMap<>();
+
+    static {
+        THUMBNAIL_PARAMS.put("width", "200");
+        THUMBNAIL_PARAMS.put("height", "120");
+    }
+
+    private static final int PLACEHOLDER_SIZE = 1024;
+
+    private RequestResponseFactory requestFactory;
+    private SlingRequestProcessor slingProcessor;
+
+    @FormField(name = "Starting Path",
+            component = PathfieldComponent.FolderSelectComponent.class)
+    private String startingPath = "/content/dam";
+
+    @FormField(name = "Mode",
+            component = RadioComponent.EnumerationSelector.class,
+            options = "default=placeholders"
+    )
+    private ThumbnailScanLogic scanMode = ThumbnailScanLogic.PLACEHOLDERS;
+
+    @FormField(name = "Dry Run",
+            component = CheckboxComponent.class,
+            options = "checked"
+    )
+    private boolean dryRun = true;
+
+    private transient List<String> foldersToReplace = Collections.synchronizedList(new ArrayList<>());
+
+    public RefreshFolderTumbnails(RequestResponseFactory reqRspFactory, SlingRequestProcessor slingProcessor) {
+        this.requestFactory = reqRspFactory;
+        this.slingProcessor = slingProcessor;
+    }
+
+    @Override
+    public void init() {
+        // Nothing to do here
+    }
+
+    @Override
+    public void buildProcess(ProcessInstance instance, ResourceResolver rr) throws LoginException, RepositoryException {
+        instance.defineCriticalAction("Scan folders", rr, this::scanFolders);
+        if (!dryRun) {
+            instance.defineAction("Remove old thumbnails", rr, this::removeOldThumbnails);
+            instance.defineAction("Rebuild thumbnails", rr, this::rebuildThumbnails);
+        }
+    }
+
+    public static enum ReportColumns {
+        PATH, ACTION, DESCRIPTION
+    }
+
+    List<EnumMap<ReportColumns, String>> reportData = Collections.synchronizedList(new ArrayList<>());
+
+    private void record(String path, String action, String description) {
+        EnumMap<ReportColumns, String> row = new EnumMap<ReportColumns, String>(ReportColumns.class);
+        row.put(ReportColumns.PATH, path);
+        row.put(ReportColumns.ACTION, action);
+        row.put(ReportColumns.DESCRIPTION, description);
+        reportData.add(row);
+    }
+
+    @Override
+    public void storeReport(ProcessInstance instance, ResourceResolver rr) throws RepositoryException, PersistenceException {
+        GenericReport report = new GenericReport();
+        report.setName("Rebuild thumbnails " + startingPath);
+        report.setRows(reportData, ReportColumns.class);
+        report.persist(rr, instance.getPath() + "/jcr:content/report");
+    }
+
+    static ThreadLocal<String> scanResult = new ThreadLocal<>();
+
+    private void scanFolders(ActionManager manager) {
+        TreeFilteringResourceVisitor visitor = new TreeFilteringResourceVisitor();
+        visitor.setBreadthFirstMode();
+        visitor.setResourceVisitor((folder, level) -> {
+            String path = folder.getPath();
+            manager.deferredWithResolver(rr -> {
+                if (scanMode.shouldReplace(rr.getResource(path))) {
+                    String result = scanResult.get();
+                    scanResult.remove();
+                    record(path, "Flagged", result);
+                    foldersToReplace.add(path);
+                }
+            });
+        });
+        manager.deferredWithResolver(rr -> {
+            record(startingPath, "Start", "Starting folder scan");
+            visitor.accept(rr.getResource(startingPath));
+        });
+    }
+
+    private void removeOldThumbnails(ActionManager manager) {
+        ActionBatch batch = new ActionBatch(manager, 20);
+        foldersToReplace.forEach(path -> {
+            batch.add(rr -> {
+                Resource res = rr.getResource(path + FOLDER_THUMBNAIL);
+                if (res != null) {
+                    rr.delete(res);
+                    record(path, "Deleted", "Existing thumbnail removed");
+                }
+            });
+        });
+        batch.commitBatch();
+    }
+
+    private void rebuildThumbnails(ActionManager manager) {
+        foldersToReplace.forEach(path -> {
+            manager.deferredWithResolver(rr -> rebuildThumbnail(rr, path));
+        });
+    }
+
+    private void rebuildThumbnail(ResourceResolver rr, String folderPath) throws ServletException, IOException {
+        HttpServletRequest req = requestFactory.createRequest("GET", folderPath + ".folderthumbnail.jpg", THUMBNAIL_PARAMS);
+        try (NullOutputStream out = new NullOutputStream()) {
+            HttpServletResponse res = requestFactory.createResponse(out);
+            slingProcessor.processRequest(req, res, rr);
+            res.flushBuffer();
+        }
+        record(folderPath, "Rebuild", "Thumbnail was rebuilt");
+    }
+
+    protected static boolean isThumbnailMissing(Resource damFolder) {
+        if (isThumbnailManual(damFolder) || isThumbnailAutomatic(damFolder)) {
+            return false;
+        } else {
+            scanResult.set("Thumbnail missing");
+            return true;
+        }
+    }
+
+    protected static boolean isPlaceholderThumbnail(Resource damFolder) throws IOException {
+        Resource jcrContent = damFolder.getChild(JcrConstants.JCR_CONTENT);
+        if (jcrContent == null) {
+            return false;
+        }
+        Resource thumbnail = jcrContent.getChild(DamConstants.THUMBNAIL_NODE);
+        if (thumbnail == null) {
+            return false;
+        } else {
+            long size = getBinarySize(thumbnail);
+            if (size <= PLACEHOLDER_SIZE) {
+                scanResult.set("Placeholder detected, " + (size <= 0 ? "no thumbnail data" : "size is " + size + " bytes"));
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+
+    private static long getBinarySize(Resource res) throws IOException {
+        InputStream thumbnailData = res.adaptTo(InputStream.class);
+        if (thumbnailData == null) {
+            return -1;
+        }
+        long size = 0;
+        long count = 0;
+        byte[] buf = new byte[1024];
+        while ((count = thumbnailData.read(buf)) > 0) {
+            size += count;
+        }
+        thumbnailData.close();
+        return size;
+    }
+
+    protected static boolean isThumbnailContentsOutdated(Resource damFolder) {
+        Resource contents = damFolder.getChild("jcr:content/folderThumbnail/jcr:content");
+        if (isThumbnailManual(damFolder)) {
+            return false;
+        }
+        if (contents == null) {
+            scanResult.set("No folder metadata, assuming contents outdated");
+            return true;
+        } else {
+            Date thumbnailModified = (Date) contents.getValueMap().getOrDefault("jcr:lastModified", Date.class);
+            String[] paths = contents.getValueMap().get("dam:folderThumbnailPaths", String[].class);
+            if (thumbnailModified == null || paths == null || paths.length == 0) {
+                scanResult.set("No folder thumbnails being tracked, assuming contents outdated");
+                return true;
+            } else {
+                for (String assetPath : paths) {
+                    Resource assetResource = damFolder.getResourceResolver().getResource(assetPath);
+                    if (isAssetMissingOrNewer(assetResource, thumbnailModified)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    protected static boolean isAssetMissingOrNewer(Resource asset, Date compareDate) {
+        if (asset == null) {
+            scanResult.set("Referenced asset missing");
+            return true;
+        } else {
+            Resource content = asset.getChild("jcr:content");
+            if (content == null) {
+                scanResult.set("Referenced asset has no content node; " + asset.getPath());
+                return true;
+            }
+            Date assetModified = content.getValueMap().get("jcr:lastModified", Date.class);
+            if (assetModified == null) {
+                scanResult.set("Referenced asset has no modified date; " + asset.getPath());
+                return true;
+            } else if (assetModified.after(compareDate)) {
+                scanResult.set("Referenced newer than folder; " + asset.getPath());
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected static boolean isThumbnailManual(Resource damFolder) {
+        return damFolder.getChild("jcr:content/manualThumbnail.jpg") != null
+                || damFolder.getChild("jcr:content/manualThumbnail.png") != null;
+    }
+
+    protected static boolean isThumbnailAutomatic(Resource damFolder) {
+        if (isThumbnailManual(damFolder)) {
+            return false;
+        } else if (damFolder.getChild("jcr:content/folderThumbnail") != null) {
+            scanResult.set("Detected automatic thumbnail and no manual thumbnail");
+            return true;
+        }
+        return false;
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplication.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplication.java
@@ -2,7 +2,7 @@
  * #%L
  * ACS AEM Commons Bundle
  * %%
- * Copyright (C) 2018 Adobe
+ * Copyright (C) 2020 Adobe
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplication.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplication.java
@@ -20,104 +20,89 @@
 package com.adobe.acs.commons.mcp.impl.processes;
 
 import com.adobe.acs.commons.fam.ActionManager;
-import com.adobe.acs.commons.fam.actions.ActionBatch;
 import com.adobe.acs.commons.functions.CheckedFunction;
 import com.adobe.acs.commons.mcp.ProcessDefinition;
 import com.adobe.acs.commons.mcp.ProcessInstance;
 import com.adobe.acs.commons.mcp.form.CheckboxComponent;
 import com.adobe.acs.commons.mcp.form.FormField;
 import com.adobe.acs.commons.mcp.form.PathfieldComponent;
-import com.adobe.acs.commons.mcp.form.RadioComponent;
+import com.adobe.acs.commons.mcp.form.SelectComponent;
 import com.adobe.acs.commons.mcp.model.GenericReport;
 import com.adobe.acs.commons.util.visitors.TreeFilteringResourceVisitor;
-import com.day.cq.commons.jcr.JcrConstants;
-import com.day.cq.contentsync.handler.util.RequestResponseFactory;
-import com.day.cq.dam.api.DamConstants;
-import java.io.IOException;
-import java.io.InputStream;
+import com.day.cq.replication.ReplicationActionType;
+import com.day.cq.replication.ReplicationOptions;
+import com.day.cq.replication.Replicator;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.jcr.RepositoryException;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import org.apache.commons.io.output.NullOutputStream;
+import javax.jcr.Session;
 import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.engine.SlingRequestProcessor;
 
 /**
- * Replace folder thumbnails under a user-definable set of circumstances As a business user, I would like an easy way to
- * scan and repair missing thumbnails, or just regenerate all thumbnails under a given tree of the DAM.
+ * Replace folder thumbnails under a user-definable set of circumstances As a
+ * business user, I would like an easy way to scan and repair missing
+ * thumbnails, or just regenerate all thumbnails under a given tree of the DAM.
  */
-public class RefreshFolderTumbnails extends ProcessDefinition {
+public class TreeReplication extends ProcessDefinition {
 
-    protected static enum ThumbnailScanLogic {
-        MISSING(RefreshFolderTumbnails::isThumbnailMissing),
-        PLACEHOLDERS(RefreshFolderTumbnails::isThumbnailMissing,
-                RefreshFolderTumbnails::isPlaceholderThumbnail),
-        OUTDATED(RefreshFolderTumbnails::isThumbnailMissing,
-                RefreshFolderTumbnails::isPlaceholderThumbnail,
-                RefreshFolderTumbnails::isThumbnailContentsOutdated),
-        ALL_AUTOMATIC_OR_MISSING(RefreshFolderTumbnails::isThumbnailMissing,
-                RefreshFolderTumbnails::isThumbnailAutomatic),
-        ALL(r -> true);
+    protected static enum ReplicationFilter {
+        ALL(r -> true),
+        FOLDERS_ONLY(TreeReplication::isFolder);
 
         CheckedFunction<Resource, Boolean> test;
 
         @SuppressWarnings("squid:UnusedPrivateMethod")
-        private ThumbnailScanLogic(CheckedFunction<Resource, Boolean>... tests) {
+        private ReplicationFilter(CheckedFunction<Resource, Boolean>... tests) {
             this.test = CheckedFunction.or(tests);
         }
 
         @SuppressWarnings("squid:S00112")
-        public boolean shouldReplace(Resource r) throws Exception {
+        public boolean shouldReplicate(Resource r) throws Exception {
             return this.test.apply(r);
         }
     }
 
-    public static final String FOLDER_THUMBNAIL = "/jcr:content/folderThumbnail";
-
-    private static Map<String, Object> THUMBNAIL_PARAMS = new HashMap<>();
-
-    static {
-        THUMBNAIL_PARAMS.put("width", "200");
-        THUMBNAIL_PARAMS.put("height", "120");
+    protected static enum QueueMethod {
+        USE_PUBLISH_QUEUE, USE_MCP_QUEUE, MCP_AFTER_10K
     }
 
-    private static final int PLACEHOLDER_SIZE = 1024;
+    public static int ASYNC_LIMIT = 10000;
 
-    private RequestResponseFactory requestFactory;
-    private SlingRequestProcessor slingProcessor;
+    private Replicator replicatorService;
 
     @FormField(name = "Starting Path",
-            component = PathfieldComponent.FolderSelectComponent.class)
+            component = PathfieldComponent.FolderSelectComponent.class,
+            description = "This folder and all its subfolders will be published")
     private String startingPath = "/content/dam";
 
-    @FormField(name = "Mode",
-            component = RadioComponent.EnumerationSelector.class,
-            options = "default=placeholders"
+    @FormField(name = "What to Publish",
+            component = SelectComponent.EnumerationSelector.class,
+            description = "Publish only folders or all content inside of folders",
+            options = "default=FOLDERS_ONLY"
     )
-    private ThumbnailScanLogic scanMode = ThumbnailScanLogic.PLACEHOLDERS;
+    private ReplicationFilter publishFilter = ReplicationFilter.FOLDERS_ONLY;
+
+    @FormField(name = "Queueing Method",
+            component = SelectComponent.EnumerationSelector.class,
+            description = "For small publishing tasks, standard is sufficient.  For large folder trees, MCP is recommended.",
+            options = "default=USE_MCP_QUEUE")
+    QueueMethod queueMethod = QueueMethod.USE_MCP_QUEUE;
 
     @FormField(name = "Dry Run",
             component = CheckboxComponent.class,
-            options = "checked"
+            options = "checked",
+            description = "If checked, only generate a report but don't perform the work"
     )
     private boolean dryRun = true;
 
-    private transient List<String> foldersToReplace = Collections.synchronizedList(new ArrayList<>());
-
-    public RefreshFolderTumbnails(RequestResponseFactory reqRspFactory, SlingRequestProcessor slingProcessor) {
-        this.requestFactory = reqRspFactory;
-        this.slingProcessor = slingProcessor;
+    public TreeReplication(Replicator replicator) {
+        replicatorService = replicator;
     }
 
     @Override
@@ -127,10 +112,13 @@ public class RefreshFolderTumbnails extends ProcessDefinition {
 
     @Override
     public void buildProcess(ProcessInstance instance, ResourceResolver rr) throws LoginException, RepositoryException {
-        instance.defineCriticalAction("Scan folders", rr, this::scanFolders);
-        if (!dryRun) {
-            instance.defineAction("Remove old thumbnails", rr, this::removeOldThumbnails);
-            instance.defineAction("Rebuild thumbnails", rr, this::rebuildThumbnails);
+        instance.getInfo().setDescription(startingPath + "; "
+                + publishFilter.name() + "; "
+                + queueMethod.name()
+                + (dryRun ? " (dry run)" : ""));
+        instance.defineCriticalAction("Activate tree structure", rr, this::activateTreeStructure);
+        if (publishFilter != ReplicationFilter.FOLDERS_ONLY) {
+            instance.defineAction("Activiate content", rr, this::activateContent);
         }
     }
 
@@ -141,7 +129,7 @@ public class RefreshFolderTumbnails extends ProcessDefinition {
     List<EnumMap<ReportColumns, String>> reportData = Collections.synchronizedList(new ArrayList<>());
 
     private void record(String path, String action, String description) {
-        EnumMap<ReportColumns, String> row = new EnumMap<ReportColumns, String>(ReportColumns.class);
+        EnumMap<ReportColumns, String> row = new EnumMap<>(ReportColumns.class);
         row.put(ReportColumns.PATH, path);
         row.put(ReportColumns.ACTION, action);
         row.put(ReportColumns.DESCRIPTION, description);
@@ -151,166 +139,75 @@ public class RefreshFolderTumbnails extends ProcessDefinition {
     @Override
     public void storeReport(ProcessInstance instance, ResourceResolver rr) throws RepositoryException, PersistenceException {
         GenericReport report = new GenericReport();
-        report.setName("Rebuild thumbnails " + startingPath);
+        report.setName("Tree Replication " + startingPath);
         report.setRows(reportData, ReportColumns.class);
         report.persist(rr, instance.getPath() + "/jcr:content/report");
     }
 
-    static ThreadLocal<String> scanResult = new ThreadLocal<>();
+    // Should match nt:folder, sling:OrderedFolder, sling:UnorderedFolder, etc
+    public static Boolean isFolder(Resource res) {
+        String primaryType = String.valueOf(res.getResourceMetadata().get("jcr:primaryType"));
+        return (primaryType.toLowerCase().contains("folder"));
+    }
 
-    private void scanFolders(ActionManager manager) {
+    private void activateTreeStructure(ActionManager t) {
         TreeFilteringResourceVisitor visitor = new TreeFilteringResourceVisitor();
-        visitor.setBreadthFirstMode();
-        visitor.setResourceVisitor((folder, level) -> {
-            String path = folder.getPath();
-            manager.deferredWithResolver(rr -> {
-                if (scanMode.shouldReplace(rr.getResource(path))) {
-                    String result = scanResult.get();
-                    scanResult.remove();
-                    record(path, "Flagged", result);
-                    foldersToReplace.add(path);
-                }
-            });
-        });
-        manager.deferredWithResolver(rr -> {
-            record(startingPath, "Start", "Starting folder scan");
-            visitor.accept(rr.getResource(startingPath));
-        });
-    }
-
-    private void removeOldThumbnails(ActionManager manager) {
-        ActionBatch batch = new ActionBatch(manager, 20);
-        foldersToReplace.forEach(path -> {
-            batch.add(rr -> {
-                Resource res = rr.getResource(path + FOLDER_THUMBNAIL);
-                if (res != null) {
-                    rr.delete(res);
-                    record(path, "Deleted", "Existing thumbnail removed");
-                }
-            });
-        });
-        batch.commitBatch();
-    }
-
-    private void rebuildThumbnails(ActionManager manager) {
-        foldersToReplace.forEach(path -> {
-            manager.deferredWithResolver(rr -> rebuildThumbnail(rr, path));
-        });
-    }
-
-    private void rebuildThumbnail(ResourceResolver rr, String folderPath) throws ServletException, IOException {
-        HttpServletRequest req = requestFactory.createRequest("GET", folderPath + ".folderthumbnail.jpg", THUMBNAIL_PARAMS);
-        try (NullOutputStream out = new NullOutputStream()) {
-            HttpServletResponse res = requestFactory.createResponse(out);
-            slingProcessor.processRequest(req, res, rr);
-            res.flushBuffer();
-        }
-        record(folderPath, "Rebuild", "Thumbnail was rebuilt");
-    }
-
-    protected static boolean isThumbnailMissing(Resource damFolder) {
-        if (isThumbnailManual(damFolder) || isThumbnailAutomatic(damFolder)) {
-            return false;
-        } else {
-            scanResult.set("Thumbnail missing");
-            return true;
-        }
-    }
-
-    protected static boolean isPlaceholderThumbnail(Resource damFolder) throws IOException {
-        Resource jcrContent = damFolder.getChild(JcrConstants.JCR_CONTENT);
-        if (jcrContent == null) {
-            return false;
-        }
-        Resource thumbnail = jcrContent.getChild(DamConstants.THUMBNAIL_NODE);
-        if (thumbnail == null) {
-            return false;
-        } else {
-            long size = getBinarySize(thumbnail);
-            if (size <= PLACEHOLDER_SIZE) {
-                scanResult.set("Placeholder detected, " + (size <= 0 ? "no thumbnail data" : "size is " + size + " bytes"));
-                return true;
+        visitor.setResourceVisitorChecked((resource, u) -> {
+            String path = resource.getPath();
+            if (publishFilter.shouldReplicate(resource)) {
+                t.deferredWithResolver(rr -> performReplication(t, path));
             } else {
-                return false;
+                record(path, "Skip", "Skipping folder");
             }
-        }
+        });
+        t.deferredWithResolver(rr -> visitor.accept(rr.getResource(startingPath)));
     }
 
-    private static long getBinarySize(Resource res) throws IOException {
-        InputStream thumbnailData = res.adaptTo(InputStream.class);
-        if (thumbnailData == null) {
-            return -1;
-        }
-        long size = 0;
-        long count = 0;
-        byte[] buf = new byte[1024];
-        while ((count = thumbnailData.read(buf)) > 0) {
-            size += count;
-        }
-        thumbnailData.close();
-        return size;
-    }
-
-    protected static boolean isThumbnailContentsOutdated(Resource damFolder) {
-        Resource contents = damFolder.getChild("jcr:content/folderThumbnail/jcr:content");
-        if (isThumbnailManual(damFolder)) {
-            return false;
-        }
-        if (contents == null) {
-            scanResult.set("No folder metadata, assuming contents outdated");
-            return true;
-        } else {
-            Date thumbnailModified = (Date) contents.getValueMap().getOrDefault("jcr:lastModified", Date.class);
-            String[] paths = contents.getValueMap().get("dam:folderThumbnailPaths", String[].class);
-            if (thumbnailModified == null || paths == null || paths.length == 0) {
-                scanResult.set("No folder thumbnails being tracked, assuming contents outdated");
-                return true;
+    private void activateContent(ActionManager t) {
+        TreeFilteringResourceVisitor visitor = new TreeFilteringResourceVisitor();
+        visitor.setLeafVisitorChecked((resource, u) -> {
+            String path = resource.getPath();
+            if (publishFilter.shouldReplicate(resource)) {
+                t.deferredWithResolver(rr -> performReplication(t, path));
             } else {
-                for (String assetPath : paths) {
-                    Resource assetResource = damFolder.getResourceResolver().getResource(assetPath);
-                    if (isAssetMissingOrNewer(assetResource, thumbnailModified)) {
-                        return true;
-                    }
-                }
+                record(path, "Skip", "Skipping content");
             }
-        }
-        return false;
+        });
+        t.deferredWithResolver(rr -> visitor.accept(rr.getResource(startingPath)));
     }
 
-    protected static boolean isAssetMissingOrNewer(Resource asset, Date compareDate) {
-        if (asset == null) {
-            scanResult.set("Referenced asset missing");
-            return true;
+    public AtomicInteger replicationCount = new AtomicInteger();
+
+    private void performReplication(ActionManager t, String path) {
+        int counter = replicationCount.incrementAndGet();
+        if (queueMethod == QueueMethod.USE_MCP_QUEUE
+                || (queueMethod == QueueMethod.MCP_AFTER_10K && counter >= ASYNC_LIMIT)) {
+            performSynchronousReplication(t, path);
         } else {
-            Resource content = asset.getChild("jcr:content");
-            if (content == null) {
-                scanResult.set("Referenced asset has no content node; " + asset.getPath());
-                return true;
-            }
-            Date assetModified = content.getValueMap().get("jcr:lastModified", Date.class);
-            if (assetModified == null) {
-                scanResult.set("Referenced asset has no modified date; " + asset.getPath());
-                return true;
-            } else if (assetModified.after(compareDate)) {
-                scanResult.set("Referenced newer than folder; " + asset.getPath());
-                return true;
-            }
+            performAsynchronousReplication(t, path);
         }
-        return false;
     }
 
-    protected static boolean isThumbnailManual(Resource damFolder) {
-        return damFolder.getChild("jcr:content/manualThumbnail.jpg") != null
-                || damFolder.getChild("jcr:content/manualThumbnail.png") != null;
+    private void performSynchronousReplication(ActionManager t, String path) {
+        ReplicationOptions options = new ReplicationOptions();
+        options.setSynchronous(true);
+        scheduleReplication(t, options, path);
+        record(path, "Replicate", "Synchronous replication");
     }
 
-    protected static boolean isThumbnailAutomatic(Resource damFolder) {
-        if (isThumbnailManual(damFolder)) {
-            return false;
-        } else if (damFolder.getChild("jcr:content/folderThumbnail") != null) {
-            scanResult.set("Detected automatic thumbnail and no manual thumbnail");
-            return true;
+    private void performAsynchronousReplication(ActionManager t, String path) {
+        ReplicationOptions options = new ReplicationOptions();
+        options.setSynchronous(false);
+        scheduleReplication(t, options, path);
+        record(path, "Replicate", "Asynchronous replication");
+    }
+
+    private void scheduleReplication(ActionManager t, ReplicationOptions options, String path) {
+        if (!dryRun) {
+            t.deferredWithResolver(rr -> {
+                Session session = rr.adaptTo(Session.class);
+                replicatorService.replicate(session, ReplicationActionType.ACTIVATE, path, options);
+            });
         }
-        return false;
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplication.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplication.java
@@ -89,7 +89,7 @@ public class TreeReplication extends ProcessDefinition {
     @FormField(name = "Starting Path",
             component = PathfieldComponent.FolderSelectComponent.class,
             description = "This item and its descendants will be published/unpublished")
-    private String startingPath = "/content/dam";
+    private String startingPath = null;
 
     @FormField(name = "What to Publish",
             component = SelectComponent.EnumerationSelector.class,

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplication.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplication.java
@@ -91,18 +91,19 @@ public class TreeReplication extends ProcessDefinition {
     )
     private ReplicationFilter publishFilter = ReplicationFilter.FOLDERS_ONLY;
 
-    @FormField(name = "Agents",
-            component = TextfieldComponent.class,
-            description = "Publish agents to use, if blank then all default agents will be used. Multiple agents can be listed using commas or regex.")
-    private String agents = null;
-    List<String> agentList = new ArrayList<>();
-    AgentFilter replicationAgentFilter;
-
     @FormField(name = "Queueing Method",
             component = SelectComponent.EnumerationSelector.class,
             description = "For small publishing tasks, standard is sufficient.  For large folder trees, MCP is recommended.",
             options = "default=USE_MCP_QUEUE")
     QueueMethod queueMethod = QueueMethod.USE_MCP_QUEUE;
+
+    @FormField(name = "Agents",
+            component = TextfieldComponent.class,
+            hint = "(leave blank for default agents)",
+            description = "Publish agents to use, if blank then all default agents will be used. Multiple agents can be listed using commas or regex.")
+    private String agents = null;
+    List<String> agentList = new ArrayList<>();
+    AgentFilter replicationAgentFilter;
 
     @FormField(name = "Dry Run",
             component = CheckboxComponent.class,
@@ -162,7 +163,7 @@ public class TreeReplication extends ProcessDefinition {
 
     // Should match nt:folder, sling:OrderedFolder, sling:UnorderedFolder, etc
     public static Boolean isFolder(Resource res) {
-        String primaryType = String.valueOf(res.getResourceMetadata().get("jcr:primaryType"));
+        String primaryType = String.valueOf(res.getResourceType());
         return (primaryType.toLowerCase().contains("folder"));
     }
 
@@ -171,7 +172,7 @@ public class TreeReplication extends ProcessDefinition {
         visitor.setResourceVisitorChecked((resource, u) -> {
             String path = resource.getPath();
             if (publishFilter.shouldReplicate(resource)) {
-                t.deferredWithResolver(rr -> performReplication(t, path));
+                t.withResolver(rr -> performReplication(t, path));
             } else {
                 record(path, "Skip", "Skipping folder");
             }

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplicationFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplicationFactory.java
@@ -1,0 +1,54 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2018 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.mcp.impl.processes;
+
+import com.adobe.acs.commons.mcp.ProcessDefinitionFactory;
+import com.adobe.acs.commons.util.RequireAem;
+import com.day.cq.contentsync.handler.util.RequestResponseFactory;
+import org.apache.felix.scr.annotations.Component;
+import org.apache.felix.scr.annotations.Service;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.sling.engine.SlingRequestProcessor;
+
+@Component
+@Service(ProcessDefinitionFactory.class)
+public class RefreshFolderThumbnailsFactory extends ProcessDefinitionFactory<RefreshFolderTumbnails> {
+
+    // Disable this feature on AEM as a Cloud Service
+    @Reference(target="(distribution=classic)")
+    RequireAem requireAem;
+
+    @Reference
+    private SlingRequestProcessor slingProcessor;
+    
+    @Reference
+    RequestResponseFactory reqRspFactory;
+    
+    @Override
+    public String getName() {
+        return "Refresh asset folder thumbnails";
+    }
+
+    @Override
+    protected RefreshFolderTumbnails createProcessDefinitionInstance() {
+        return new RefreshFolderTumbnails(reqRspFactory, slingProcessor);
+    }
+    
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplicationFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplicationFactory.java
@@ -2,7 +2,7 @@
  * #%L
  * ACS AEM Commons Bundle
  * %%
- * Copyright (C) 2018 Adobe
+ * Copyright (C) 2020 Adobe
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplicationFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplicationFactory.java
@@ -21,34 +21,31 @@ package com.adobe.acs.commons.mcp.impl.processes;
 
 import com.adobe.acs.commons.mcp.ProcessDefinitionFactory;
 import com.adobe.acs.commons.util.RequireAem;
-import com.day.cq.contentsync.handler.util.RequestResponseFactory;
+import com.day.cq.replication.Replicator;
 import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Service;
 import org.apache.felix.scr.annotations.Reference;
-import org.apache.sling.engine.SlingRequestProcessor;
+import org.apache.felix.scr.annotations.Service;
 
 @Component
 @Service(ProcessDefinitionFactory.class)
-public class RefreshFolderThumbnailsFactory extends ProcessDefinitionFactory<RefreshFolderTumbnails> {
+public class TreeReplicationFactory extends ProcessDefinitionFactory<TreeReplication> {
 
     // Disable this feature on AEM as a Cloud Service
     @Reference(target="(distribution=classic)")
     RequireAem requireAem;
 
     @Reference
-    private SlingRequestProcessor slingProcessor;
-    
-    @Reference
-    RequestResponseFactory reqRspFactory;
-    
+    Replicator replicator;
+
+
     @Override
     public String getName() {
-        return "Refresh asset folder thumbnails";
+        return "Tree Activation";
     }
 
     @Override
-    protected RefreshFolderTumbnails createProcessDefinitionInstance() {
-        return new RefreshFolderTumbnails(reqRspFactory, slingProcessor);
+    protected TreeReplication createProcessDefinitionInstance() {
+        return new TreeReplication(replicator);
     }
-    
+
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplicationTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplicationTest.java
@@ -1,6 +1,9 @@
 /*
- * Copyright 2020 Adobe.
- *
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2020 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -12,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.mcp.impl.processes;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplicationTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/TreeReplicationTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2020 Adobe.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adobe.acs.commons.mcp.impl.processes;
+
+import com.adobe.acs.commons.fam.ActionManagerFactory;
+import com.adobe.acs.commons.fam.impl.ActionManagerFactoryImpl;
+import com.adobe.acs.commons.functions.CheckedConsumer;
+import com.adobe.acs.commons.mcp.ControlledProcessManager;
+import com.adobe.acs.commons.mcp.form.AbstractResourceImpl;
+import com.adobe.acs.commons.mcp.impl.ProcessInstanceImpl;
+import com.adobe.acs.commons.mcp.impl.processes.renovator.ReplicatorQueue;
+import com.adobe.acs.commons.mcp.util.DeserializeException;
+import com.day.cq.dam.api.DamConstants;
+import com.day.cq.wcm.api.NameConstants;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Function;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.Workspace;
+import javax.jcr.observation.ObservationManager;
+import javax.jcr.security.AccessControlManager;
+import javax.jcr.security.Privilege;
+import org.apache.commons.lang.StringUtils;
+import org.apache.sling.api.resource.LoginException;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.ResourceMetadata;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.jcr.resource.JcrResourceConstants;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+
+import static com.adobe.acs.commons.fam.impl.ActionManagerTest.getActionManager;
+import static com.adobe.acs.commons.fam.impl.ActionManagerTest.getFreshMockResolver;
+import static com.adobe.acs.commons.fam.impl.ActionManagerTest.getMockResolver;
+import static com.day.cq.commons.jcr.JcrConstants.JCR_PRIMARYTYPE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * Validate correct function of the tree activation utility
+ *
+ * @author brobert
+ */
+public class TreeReplicationTest {
+
+    TreeReplicationFactory factory = new TreeReplicationFactory();
+    TreeReplication tool;
+    ProcessInstanceImpl instance;
+    ReplicatorQueue queue;
+    ResourceResolver rr;
+
+    @Before
+    public void setup() throws RepositoryException, PersistenceException, IllegalAccessException, LoginException {
+        queue = spy(new ReplicatorQueue());
+        factory.replicator = queue;
+        tool = prepareProcessDefinition(factory.createProcessDefinition(), null);
+        instance = prepareProcessInstance(
+                new ProcessInstanceImpl(getControlledProcessManager(), tool, "relocator test")
+        );
+        rr = getEnhancedMockResolver();
+        when(rr.hasChanges()).thenReturn(true);
+    }
+
+    @Test
+    public void testFactory() {
+        TreeReplication replicationProcess = factory.createProcessDefinition();
+        assertEquals("Should inject replicator service", replicationProcess.replicatorService, queue);
+    }
+
+    @Test
+    public void testTreeOnlyActivation() throws DeserializeException, RepositoryException {
+        Map<String, Object> values = new HashMap<>();
+        values.put("startingPath", "/content/dam");
+        values.put("publishFilter", "FOLDERS_AND_PAGES_ONLY");
+        values.put("action", "PUBLISH");
+        values.put("dryRun", false);
+        instance.init(rr, values);
+        assertEquals(0.0, instance.updateProgress(), 0.00001);
+        instance.run(rr);
+        assertEquals(1.0, instance.updateProgress(), 0.00001);
+        assertTrue("Should publish /content/dam", queue.getActivateOperations().containsKey("/content/dam"));
+        assertTrue("Should publish /content/dam/folderA", queue.getActivateOperations().containsKey("/content/dam/folderA"));
+        assertTrue("Should publish /content/dam/folderB", queue.getActivateOperations().containsKey("/content/dam/folderB"));
+        assertEquals("Should only publish 3 things", 3, queue.getActivateOperations().size());
+        assertEquals("Should only publish", 0, queue.getDeactivateOperations().size());
+    }
+
+    @Test
+    public void testActivateAll() throws DeserializeException, RepositoryException {
+        Map<String, Object> values = new HashMap<>();
+        values.put("startingPath", "/content/dam");
+        values.put("publishFilter", "ALL");
+        values.put("action", "PUBLISH");
+        values.put("dryRun", false);
+        instance.init(rr, values);
+        assertEquals(0.0, instance.updateProgress(), 0.00001);
+        instance.run(rr);
+        assertEquals(1.0, instance.updateProgress(), 0.00001);
+        assertTrue("Should publish /content/dam", queue.getActivateOperations().containsKey("/content/dam"));
+        assertTrue("Should publish /content/dam/folderA", queue.getActivateOperations().containsKey("/content/dam/folderA"));
+        assertTrue("Should publish /content/dam/folderB", queue.getActivateOperations().containsKey("/content/dam/folderB"));
+        assertTrue("Should publish /content/dam/folderA/asset1", queue.getActivateOperations().containsKey("/content/dam/folderA/asset1"));
+        assertTrue("Should publish /content/dam/folderA/asset2", queue.getActivateOperations().containsKey("/content/dam/folderA/asset2"));
+        assertEquals("Should only publish 5 things", 5, queue.getActivateOperations().size());
+        assertEquals("Should only publish", 0, queue.getDeactivateOperations().size());
+    }
+
+    @Test
+    public void testActivateSite() throws DeserializeException, RepositoryException {
+        Map<String, Object> values = new HashMap<>();
+        values.put("startingPath", "/content/siteA");
+        values.put("publishFilter", "FOLDERS_AND_PAGES_ONLY");
+        values.put("action", "PUBLISH");
+        values.put("dryRun", false);
+        instance.init(rr, values);
+        assertEquals(0.0, instance.updateProgress(), 0.00001);
+        instance.run(rr);
+        assertEquals(1.0, instance.updateProgress(), 0.00001);
+        assertTrue("Should publish /content/siteA", queue.getActivateOperations().containsKey("/content/siteA"));
+        assertTrue("Should publish /content/siteA/page1", queue.getActivateOperations().containsKey("/content/siteA/page1"));
+        assertTrue("Should publish /content/siteA/page1/page1a", queue.getActivateOperations().containsKey("/content/siteA/page1/page1a"));
+        assertTrue("Should publish /content/siteA/page2", queue.getActivateOperations().containsKey("/content/siteA/page2"));
+        assertEquals("Should only publish 4 things", 4, queue.getActivateOperations().size());
+        assertEquals("Should only publish", 0, queue.getDeactivateOperations().size());
+    }
+
+    @Test
+    public void testDeactivate() throws DeserializeException, RepositoryException {
+        Map<String, Object> values = new HashMap<>();
+        values.put("startingPath", "/content");
+        values.put("publishFilter", "FOLDERS_AND_PAGES_ONLY");
+        values.put("action", "UNPUBLISH");
+        values.put("dryRun", false);
+        instance.init(rr, values);
+        assertEquals(0.0, instance.updateProgress(), 0.00001);
+        instance.run(rr);
+        assertEquals(1.0, instance.updateProgress(), 0.00001);
+        assertEquals("Should only unpublish", 0, queue.getActivateOperations().size());
+        assertTrue("Should unpublish /content", queue.getDeactivateOperations().containsKey("/content"));
+        assertEquals("Should only unpublish 1", 1, queue.getDeactivateOperations().size());
+    }
+
+    Map<String, String> testNodes = new TreeMap<String, String>() {
+        {
+            put("/content", JcrResourceConstants.NT_SLING_FOLDER);
+            put("/content/dam", JcrResourceConstants.NT_SLING_FOLDER);
+            put("/content/dam/folderA", JcrResourceConstants.NT_SLING_FOLDER);
+            put("/content/dam/folderB", JcrResourceConstants.NT_SLING_FOLDER);
+            put("/content/dam/folderA/asset1", DamConstants.NT_DAM_ASSET);
+            put("/content/dam/folderA/asset1/jcr:content", "NT:UNSTRUCTURED");
+            put("/content/dam/folderA/asset2", DamConstants.NT_DAM_ASSET);
+            put("/content/dam/folderA/asset2/jcr:content", "NT:UNSTRUCTURED");
+            put("/test", "NT:UNSTRUCTURED");
+            put("/test/child1", "NT:UNSTRUCTURED");
+            put("/content/siteA", NameConstants.NT_PAGE);
+            put("/content/siteA/jcr:content", "NT:UNSTRUCTURED");
+            put("/content/siteA/page1", NameConstants.NT_PAGE);
+            put("/content/siteA/page1/jcr:content", "NT:UNSTRUCTURED");
+            put("/content/siteA/page1/page1a", NameConstants.NT_PAGE);
+            put("/content/siteA/page1/page1a/jcr:content", "NT:UNSTRUCTURED");
+            put("/content/siteA/page2", NameConstants.NT_PAGE);
+        }
+    };
+
+    private ResourceResolver getEnhancedMockResolver() throws RepositoryException, LoginException, PersistenceException {
+        rr = getFreshMockResolver();
+
+        testNodes.entrySet().forEach(entry -> {
+            String path = entry.getKey();
+            String type = entry.getValue();
+            AbstractResourceImpl mockFolder = new AbstractResourceImpl(path, type, "", new ResourceMetadata());
+            mockFolder.getResourceMetadata().put(JCR_PRIMARYTYPE, type);
+
+            when(rr.resolve(path)).thenReturn(mockFolder);
+            when(rr.getResource(path)).thenReturn(mockFolder);
+        });
+        testNodes.entrySet().forEach(entry -> {
+            String parentPath = StringUtils.substringBeforeLast(entry.getKey(), "/");
+            if (rr.getResource(parentPath) != null) {
+                AbstractResourceImpl parent = ((AbstractResourceImpl) rr.getResource(parentPath));
+                AbstractResourceImpl node = (AbstractResourceImpl) rr.getResource(entry.getKey());
+                parent.addChild(node);
+            }
+        });
+
+        Session ses = mock(Session.class);
+        when(ses.nodeExists(any())).thenReturn(true); // Needed to prevent MovingFolder.createFolder from going berserk
+        when(rr.adaptTo(Session.class)).thenReturn(ses);
+        Workspace wk = mock(Workspace.class);
+        ObservationManager om = mock(ObservationManager.class);
+        when(ses.getWorkspace()).thenReturn(wk);
+        when(wk.getObservationManager()).thenReturn(om);
+
+        AccessControlManager acm = mock(AccessControlManager.class);
+        when(ses.getAccessControlManager()).thenReturn(acm);
+        when(acm.privilegeFromName(any())).thenReturn(mock(Privilege.class));
+
+        return rr;
+    }
+
+    private ControlledProcessManager getControlledProcessManager() throws LoginException {
+        ActionManagerFactory amf = mock(ActionManagerFactoryImpl.class);
+        doAnswer((InvocationOnMock invocationOnMock) -> getActionManager())
+                .when(amf).createTaskManager(any(), any(), anyInt());
+
+        ControlledProcessManager cpm = mock(ControlledProcessManager.class);
+        when(cpm.getActionManagerFactory()).thenReturn(amf);
+        return cpm;
+    }
+
+    private ProcessInstanceImpl prepareProcessInstance(ProcessInstanceImpl source) throws PersistenceException {
+        ProcessInstanceImpl instance = spy(source);
+        doNothing().when(instance).persistStatus(any());
+        doAnswer((InvocationOnMock invocationOnMock) -> {
+            CheckedConsumer<ResourceResolver> action = (CheckedConsumer<ResourceResolver>) invocationOnMock.getArguments()[0];
+            action.accept(getMockResolver());
+            return null;
+        }).when(instance).asServiceUser(any());
+
+        return instance;
+    }
+
+    private TreeReplication prepareProcessDefinition(TreeReplication source, Function<String, List<String>> refFunction) throws RepositoryException, PersistenceException, IllegalAccessException {
+        TreeReplication definition = spy(source);
+        doNothing().when(definition).storeReport(any(), any());
+        return definition;
+    }
+}


### PR DESCRIPTION
This adds a tree activation (bulk publish) utility similar to the one discussed in #1060 

User can specify one or more replication agents using a comma-delimited list and/or regex patterns.

User can also specify if they want folders only or all items (useful for pushing out folder structures for assets).  Also the user can choose if they want MCP to manage the publishing which avoids the total mess of an over-stuffed publish queue.