### PR TITLE
Update to the latest sling-maven-plugin

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -176,12 +176,24 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.sling</groupId>
-                <artifactId>maven-sling-plugin</artifactId>
-                <configuration>
-                    <slingUrl>http://${crx.host}:${crx.port}${crx.contextRoot}/crx/repository/crx.default</slingUrl>
-                    <slingUrlSuffix>/apps/acs-commons/install</slingUrlSuffix>
-                    <deploymentMethod>WebDAV</deploymentMethod>
-                </configuration>
+                <artifactId>sling-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>install-bundle</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>install</goal>
+                        </goals>
+                        <configuration>
+                            <slingUrl>${crx.protocol}://${crx.host}:${crx.port}${crx.contextRoot}</slingUrl>
+                            <slingUrlSuffix>/apps/acs-commons/install</slingUrlSuffix>
+                            <deploymentMethod>SlingPostServlet</deploymentMethod>
+                            <user>${crx.user}</user>
+                            <password>${crx.password}</password>
+                            <failOnError>true</failOnError>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -177,23 +177,14 @@
             <plugin>
                 <groupId>org.apache.sling</groupId>
                 <artifactId>sling-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>install-bundle</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>install</goal>
-                        </goals>
-                        <configuration>
-                            <slingUrl>${crx.protocol}://${crx.host}:${crx.port}${crx.contextRoot}</slingUrl>
-                            <slingUrlSuffix>/apps/acs-commons/install</slingUrlSuffix>
-                            <deploymentMethod>SlingPostServlet</deploymentMethod>
-                            <user>${crx.user}</user>
-                            <password>${crx.password}</password>
-                            <failOnError>true</failOnError>
-                        </configuration>
-                    </execution>
-                </executions>
+		<configuration>
+		    <slingUrl>${crx.protocol}://${crx.host}:${crx.port}${crx.contextRoot}</slingUrl>
+		    <slingUrlSuffix>/apps/acs-commons/install</slingUrlSuffix>
+		    <deploymentMethod>SlingPostServlet</deploymentMethod>
+		    <user>${crx.user}</user>
+		    <password>${crx.password}</password>
+		    <failOnError>true</failOnError>
+		</configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,9 @@
     <properties>
         <crx.host>localhost</crx.host>
         <crx.port>4502</crx.port>
+        <crx.user>admin</crx.user>
+        <crx.password>admin</crx.password>
+        <crx.protocol>http</crx.protocol>
         <crx.contextRoot />
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -177,8 +180,8 @@
 
                 <plugin>
                     <groupId>org.apache.sling</groupId>
-                    <artifactId>maven-sling-plugin</artifactId>
-                    <version>2.3.8</version>
+                    <artifactId>sling-maven-plugin</artifactId>
+                    <version>2.4.2</version>
                 </plugin>
                 <plugin>
                     <groupId>com.day.jcr.vault</groupId>


### PR DESCRIPTION
Update to the latest sling-maven-plugin and enable SlingPostServlet install which also installs the intermediate folders and doesnt fail the install when they dont exist