### PR TITLE
Fix for static reference rewriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #2386 - Make folder titles overwrite optional for asset ingestor
 - #2432 - AemEnvironmentFilter: use chunked encoding (fixes #2425)
 - #2416 - Fixing workflow package path calculation in WorkflowPackageManager service
-- Add possibility to use attribute names that contain a colon for the StaticReferenceRewriteTransformerFactory
+- ##2429 - Add ability to use attribute names that contain a colon for the StaticReferenceRewriteTransformerFactory
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #2384 - Fix resource service manager NPEs when service content nodes are missing
 - #2386 - Make folder titles overwrite optional for asset ingestor
 - #2416 - Fixing workflow package path calculation in WorkflowPackageManager service
+- Add possibility to use attribute names that contain a colon for the StaticReferenceRewriteTransformerFactory
 
 
 ### Added

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/StaticReferenceRewriteTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/StaticReferenceRewriteTransformerFactory.java
@@ -287,13 +287,13 @@ public final class StaticReferenceRewriteTransformerFactory implements Transform
 
         Map<String, String> map = ParameterUtil.toMap(matchingPatternsProp, ";");
 
-        for (String key : map.keySet()) {
-            String matchingPatternString = map.get(key);
+        for (Map.Entry<String,String> entry : map.entrySet()) {
+            String matchingPatternString = entry.getValue();
             try {
                 Pattern compiled = Pattern.compile(matchingPatternString);
-                result.put(key, compiled);
+                result.put(entry.getKey(), compiled);
             } catch (Exception e) {
-                log.warn("Could not compile pattern {} for {}. Ignoring it", matchingPatternString, key);
+                log.warn("Could not compile pattern {} for {}. Ignoring it", matchingPatternString, entry.getKey());
             }
         }
         return result;

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/StaticReferenceRewriteTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/StaticReferenceRewriteTransformerFactory.java
@@ -88,6 +88,12 @@ public final class StaticReferenceRewriteTransformerFactory implements Transform
 
     private static final int DEFAULT_HOST_COUNT = 1;
 
+    @Property(label = "Tag Attribute Separator", description = "Separator to split the tag name from the attribute name", value = ":")
+    private static final String PROP_TAG_ATTRIBUTE_SEPARATOR = "tag.attribute.separator";
+
+    @Property(label = "List Separator", description = "Separator to split the different tags", value = ",")
+    private static final String PROP_LIST_SEPARATOR = "list.separator";
+
     @Property(label = "Rewrite Attributes", description = "List of element/attribute pairs to rewrite", value = {
             "img:src", "link:href", "script:src" })
     private static final String PROP_ATTRIBUTES = "attributes";
@@ -133,8 +139,8 @@ public final class StaticReferenceRewriteTransformerFactory implements Transform
             String hostNumberString = Integer.toString(fileHash);
             if (hostNumberString.length() >= 2) {
                 // get the 2nd digit as the 1st digit will not contain "0"
-                Character c = hostNumberString.charAt(1);
-                hostNumberString = c.toString();
+                char c = hostNumberString.charAt(1);
+                hostNumberString = Character.toString(c);
                 // If there are more than 10 hosts, convert it back to base10
                 // so we do not have alpha
                 hostNumberString = Integer.toString(Integer.parseInt(hostNumberString, shardCount));
@@ -256,9 +262,12 @@ public final class StaticReferenceRewriteTransformerFactory implements Transform
     protected void activate(final ComponentContext componentContext) {
         final Dictionary<?, ?> properties = componentContext.getProperties();
 
+        final String tagAttributeSeparator = PropertiesUtil.toString(properties.get(PROP_TAG_ATTRIBUTE_SEPARATOR), ":");
+        final String listSeparator = PropertiesUtil.toString(properties.get(PROP_LIST_SEPARATOR), ",");
+
         final String[] attrProp = PropertiesUtil
                 .toStringArray(properties.get(PROP_ATTRIBUTES), DEFAULT_ATTRIBUTES);
-        this.attributes = ParameterUtil.toMap(attrProp, ":", ",");
+        this.attributes = ParameterUtil.toMap(attrProp, tagAttributeSeparator, listSeparator);
 
         final String[] matchingPatternsProp = PropertiesUtil.toStringArray(properties.get(PROP_MATCHING_PATTERNS));
         this.matchingPatterns = initializeMatchingPatterns(matchingPatternsProp);
@@ -268,19 +277,17 @@ public final class StaticReferenceRewriteTransformerFactory implements Transform
         this.staticHostCount = PropertiesUtil.toInteger(properties.get(PROP_HOST_COUNT), DEFAULT_HOST_COUNT);
         this.replaceHost = PropertiesUtil.toBoolean(properties.get(PROP_REPLACE_HOST), false);
 
-        if (!this.replaceHost && !matchingPatterns.values().stream().anyMatch(str -> str.toString().startsWith("^"))) {
+        if (!this.replaceHost && matchingPatterns.values().stream().noneMatch(str -> str.toString().startsWith("^"))) {
             log.warn("BEWARE! Replace host is false and your regex is not anchored to the start of the string, this may result in a double host.");
         }
     }
 
     private static Map<String, Pattern> initializeMatchingPatterns(String[] matchingPatternsProp) {
-        Map<String, Pattern> result = new HashMap<String, Pattern>();
+        Map<String, Pattern> result = new HashMap<>();
 
         Map<String, String> map = ParameterUtil.toMap(matchingPatternsProp, ";");
 
-        Iterator<String> iterator = map.keySet().iterator();
-        while (iterator.hasNext()) {
-            String key = iterator.next();
+        for (String key : map.keySet()) {
             String matchingPatternString = map.get(key);
             try {
                 Pattern compiled = Pattern.compile(matchingPatternString);
@@ -306,7 +313,7 @@ public final class StaticReferenceRewriteTransformerFactory implements Transform
     };
 
     @SuppressWarnings("squid:S1604")
-    private ShardNameProvider lookupShardNameProvider = new ShardNameProvider() {
+    private final ShardNameProvider lookupShardNameProvider = new ShardNameProvider() {
 
         @Override
         public String lookup(int idx) {


### PR DESCRIPTION
Add possibility to use attribute names that contain a colon for the StaticReferenceRewriteTransformerFactory by providing osgi properties to change the tag - attribute separator

This could be useful for the image tags in svg's:

<image xlink:href="/content/dam...">