### PR TITLE
Fix #2441 - Memory Exhaustion with Large Report Download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-4.7.2...HEAD
 
+### Fixed
+- #2441 - Memory Exhaustion with Large Report Download
+
 ## 4.8.6 - 2020-10-13
 
 ### Fixed

--- a/bundle/src/main/java/com/adobe/acs/commons/reports/api/ReportExecutor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/reports/api/ReportExecutor.java
@@ -19,15 +19,14 @@
  */
 package com.adobe.acs.commons.reports.api;
 
-import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.resource.Resource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.slf4j.LoggerFactory;
 
 /**
  * Interface for report execution classes to implement. These should be Sling

--- a/bundle/src/main/java/com/adobe/acs/commons/reports/api/ResultsPage.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/reports/api/ResultsPage.java
@@ -21,40 +21,52 @@ package com.adobe.acs.commons.reports.api;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Simple POJO for representing a page of results.
  */
 public final class ResultsPage {
 
-  private final List<Object> results;
+  private final Stream<? extends Object> results;
   private final int pageSize;
   private final int page;
+  private final long resultSize;
 
-  public ResultsPage(List<Object> results, int pageSize, int page) {
+  public ResultsPage(Stream<? extends Object> results, int pageSize, int page, long resultSize) {
     this.results = results;
+    this.resultSize = resultSize;
     this.pageSize = pageSize;
     this.page = page;
   }
 
-  public List<Object> getResults() {
-    return results;
+  public Stream<Object> getResults() {
+    return (Stream<Object>) results;
   }
 
-  public int getResultsStart() {
+  public List<Object> getResultsList() {
+    return results.collect(Collectors.toList());
+  }
+
+  public long getResultsStart() {
     return page != -1 ? (pageSize * page) + 1 : 1;
   }
 
-  public int getResultsEnd() {
-    return page != -1 ? (pageSize * page) + results.size() : results.size();
+  public long getResultsEnd() {
+    return page != -1 ? (pageSize * page) + resultSize : resultSize;
   }
 
   public int getNextPage() {
-    return (results.size() == pageSize && page != -1) ? page + 1 : -1;
+    return (resultSize == pageSize && page != -1) ? page + 1 : -1;
   }
 
   public int getPreviousPage() {
     return page > 0 ? page - 1 : -1;
+  }
+
+  public long getResultSize() {
+    return resultSize;
   }
 
   @Override
@@ -69,14 +81,11 @@ public final class ResultsPage {
 
     final ResultsPage that = (ResultsPage) o;
 
-    return pageSize == that.pageSize
-           && page == that.page
-           && Objects.equals(results, that.results);
+    return pageSize == that.pageSize && page == that.page && Objects.equals(results, that.results);
   }
 
   @Override
   public int hashCode() {
-
     return Objects.hash(results, pageSize, page);
   }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/reports/api/ResultsPage.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/reports/api/ResultsPage.java
@@ -20,7 +20,6 @@
 package com.adobe.acs.commons.reports.api;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -67,25 +66,5 @@ public final class ResultsPage {
 
   public long getResultSize() {
     return resultSize;
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-
-    if (!(o instanceof ResultsPage)) {
-      return false;
-    }
-
-    final ResultsPage that = (ResultsPage) o;
-
-    return pageSize == that.pageSize && page == that.page && Objects.equals(results, that.results);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(results, pageSize, page);
   }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/reports/api/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/reports/api/package-info.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  * #L%
  */
-@org.osgi.annotation.versioning.Version("1.1.0")
+@org.osgi.annotation.versioning.Version("2.0.0")
 package com.adobe.acs.commons.reports.api;
 
 

--- a/bundle/src/main/java/com/adobe/acs/commons/reports/internal/ReportCSVExportServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/reports/internal/ReportCSVExportServlet.java
@@ -29,8 +29,6 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
-import javax.jcr.Node;
-import javax.jcr.RepositoryException;
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 

--- a/bundle/src/main/java/com/adobe/acs/commons/reports/internal/ReportCSVExportServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/reports/internal/ReportCSVExportServlet.java
@@ -26,12 +26,21 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
 
+import com.adobe.acs.commons.reports.api.ReportCellCSVExporter;
+import com.adobe.acs.commons.reports.api.ReportException;
 import com.adobe.acs.commons.reports.api.ReportExecutor;
+import com.adobe.acs.commons.reports.api.ResultsPage;
+import com.day.cq.commons.jcr.JcrConstants;
+import com.day.text.csv.Csv;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -43,13 +52,6 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.adobe.acs.commons.reports.api.ReportCellCSVExporter;
-import com.adobe.acs.commons.reports.api.ReportException;
-import com.adobe.acs.commons.reports.api.ReportExecutor;
-import com.adobe.acs.commons.reports.api.ResultsPage;
-import com.day.cq.commons.jcr.JcrConstants;
-import com.day.text.csv.Csv;
 
 /**
  * Servlet for exporting the results of the report to CSV.
@@ -71,7 +73,7 @@ public class ReportCSVExportServlet extends SlingSafeMethodsServlet {
     log.trace("doGet");
 
     // set response parameters
-    response.setContentType("text/csv");
+    response.setContentType("text/csv;charset=UTF-8");
     response.setHeader("Content-disposition",
         "attachment; filename="
             + URLEncoder.encode(request.getResource().getValueMap().get(JcrConstants.JCR_TITLE, "report"), "UTF-8")
@@ -88,7 +90,6 @@ public class ReportCSVExportServlet extends SlingSafeMethodsServlet {
       List<ReportCellCSVExporter> exporters = writeHeaders(request, csv);
 
       Resource configCtr = request.getResource().getChild("config");
-
       if (configCtr != null && configCtr.listChildren().hasNext()) {
         Iterator<Resource> children = configCtr.listChildren();
         while (children.hasNext()) {
@@ -105,13 +106,11 @@ public class ReportCSVExportServlet extends SlingSafeMethodsServlet {
       } else {
         throw new IOException("No configurations found for " + request.getResource());
       }
-
     } catch (ReportException e) {
       throw new ServletException("Exception extracting report to CSV", e);
     } finally {
       IOUtils.closeQuietly(writer);
     }
-
   }
 
   private List<ReportCellCSVExporter> writeHeaders(SlingHttpServletRequest request, final Csv csv) throws IOException {
@@ -122,9 +121,9 @@ public class ReportCSVExportServlet extends SlingSafeMethodsServlet {
       if (!StringUtils.isEmpty(className)) {
         try {
           log.debug("Finding ReportCellCSVExporter for {}", className);
-          @SuppressWarnings({"unchecked", "squid:S2658"}) // class name is from a trusted source
-          Class<ReportCellCSVExporter> clazz =
-                  (Class<ReportCellCSVExporter>) Class.forName(className, true, dynamicClassLoaderManager.getDynamicClassLoader());
+          @SuppressWarnings({ "unchecked", "squid:S2658" }) // class name is from a trusted source
+          Class<ReportCellCSVExporter> clazz = (Class<ReportCellCSVExporter>) Class.forName(className, true,
+              dynamicClassLoaderManager.getDynamicClassLoader());
           ReportCellCSVExporter exporter = column.adaptTo(clazz);
           log.debug("Loaded ReportCellCSVExporter {}", exporter);
           if (exporter != null) {
@@ -147,29 +146,28 @@ public class ReportCSVExportServlet extends SlingSafeMethodsServlet {
     Class<?> executorClass = ReportExecutorProvider.INSTANCE.getReportExecutor(dynamicClassLoaderManager, config);
 
     ReportExecutor executor = Optional.ofNullable(request.adaptTo(executorClass))
-        .filter(model -> model instanceof ReportExecutor)
-        .map(model -> (ReportExecutor) model)
+        .filter(model -> model instanceof ReportExecutor).map(model -> (ReportExecutor) model)
         .orElseThrow(() -> new ReportException("Failed to get report executor"));
 
     executor.setConfiguration(config);
     log.debug("Retrieved executor {}", executor);
 
     ResultsPage queryResult = executor.getAllResults();
-    List<? extends Object> results = queryResult.getResults();
-    log.debug("Retrieved {} results", results.size());
+    Stream<? extends Object> results = queryResult.getResults();
+    log.debug("Retrieved {} results", queryResult.getResultSize());
 
-    for (Object result : results) {
+    results.forEach(r -> {
       List<String> row = new ArrayList<>();
       try {
         for (ReportCellCSVExporter exporter : exporters) {
-          row.add(exporter.getValue(result));
+          row.add(exporter.getValue(r));
         }
         csv.writeRow(row.toArray(new String[row.size()]));
         writer.flush();
       } catch (Exception e) {
         log.warn("Exception writing row: " + row, e);
       }
-    }
+    });
 
     log.debug("Results written successfully");
 

--- a/bundle/src/main/java/com/adobe/acs/commons/reports/models/PathListReportExecutor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/reports/models/PathListReportExecutor.java
@@ -19,20 +19,6 @@
  */
 package com.adobe.acs.commons.reports.models;
 
-import com.adobe.acs.commons.reports.api.ReportException;
-import com.adobe.acs.commons.reports.api.ReportExecutor;
-import com.adobe.acs.commons.reports.api.ResultsPage;
-import com.github.jknack.handlebars.Handlebars;
-import com.github.jknack.handlebars.Template;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
-import org.apache.sling.models.annotations.Model;
-import org.apache.sling.models.annotations.injectorspecific.Self;
-import org.apache.sling.models.annotations.injectorspecific.SlingObject;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,6 +28,20 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import com.adobe.acs.commons.reports.api.ReportException;
+import com.adobe.acs.commons.reports.api.ReportExecutor;
+import com.adobe.acs.commons.reports.api.ResultsPage;
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Template;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.Self;
+import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 
 @Model(adaptables = SlingHttpServletRequest.class)
 public class PathListReportExecutor implements ReportExecutor {
@@ -83,23 +83,21 @@ public class PathListReportExecutor implements ReportExecutor {
 
     @Override
     public ResultsPage getAllResults() throws ReportException {
-        return new ResultsPage(getResources(extractPaths()), config.getPageSize(), currentPage);
+        List<Object> results = getResources(extractPaths());
+        return new ResultsPage(results.stream(), config.getPageSize(), currentPage, (long) results.size());
     }
 
     @Override
     public ResultsPage getResults() throws ReportException {
         final List<String> paths = extractPaths();
         List<String> sublistPaths = paths.subList(getFrom(currentPage), getTo(paths.size()));
-        return new ResultsPage(getResources(sublistPaths), config.getPageSize(), currentPage);
+        List<Object> results = getResources(sublistPaths);
+        return new ResultsPage(results.stream(), config.getPageSize(), currentPage, (long) results.size());
     }
 
     List<Object> getResources(final List<String> paths) {
-        return Optional.ofNullable(paths)
-                       .map(Collection::stream)
-                       .orElseGet(Stream::empty)
-                       .map(path -> resourceResolver.getResource(path))
-                       .filter(Objects::nonNull)
-                       .collect(Collectors.toList());
+        return Optional.ofNullable(paths).map(Collection::stream).orElseGet(Stream::empty)
+                .map(path -> resourceResolver.getResource(path)).filter(Objects::nonNull).collect(Collectors.toList());
     }
 
     private int getFrom(final int page) {

--- a/bundle/src/main/java/com/adobe/acs/commons/reports/models/QueryReportExecutor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/reports/models/QueryReportExecutor.java
@@ -24,13 +24,17 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
+import javax.jcr.Node;
 import javax.jcr.NodeIterator;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
@@ -41,6 +45,12 @@ import javax.jcr.query.QueryResult;
 import javax.jcr.query.Row;
 import javax.jcr.query.RowIterator;
 
+import com.adobe.acs.commons.reports.api.ReportException;
+import com.adobe.acs.commons.reports.api.ReportExecutor;
+import com.adobe.acs.commons.reports.api.ResultsPage;
+import com.github.jknack.handlebars.Handlebars;
+import com.github.jknack.handlebars.Template;
+
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -49,12 +59,6 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.annotations.Model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.adobe.acs.commons.reports.api.ReportException;
-import com.adobe.acs.commons.reports.api.ReportExecutor;
-import com.adobe.acs.commons.reports.api.ResultsPage;
-import com.github.jknack.handlebars.Handlebars;
-import com.github.jknack.handlebars.Template;
 
 /**
  * Model for executing report requests.
@@ -78,11 +82,9 @@ public class QueryReportExecutor implements ReportExecutor {
 
   private ResultsPage fetchResults(int limit, int offset) throws ReportException {
     prepareStatement();
-    ResourceResolver resolver = request.getResourceResolver();
-    Session session = resolver.adaptTo(Session.class);
-    List<Object> results = new ArrayList<>();
     try {
-      QueryManager queryMgr = Optional.ofNullable(session)
+      ResourceResolver resolver = request.getResourceResolver();
+      QueryManager queryMgr = Optional.ofNullable(resolver.adaptTo(Session.class))
           .orElseThrow(() -> new ReportException("Failed to get JCR Session")).getWorkspace().getQueryManager();
 
       Query query = queryMgr.createQuery(statement, config.getQueryLanguage());
@@ -95,15 +97,25 @@ public class QueryReportExecutor implements ReportExecutor {
         log.debug("Fetching all results");
       }
       QueryResult result = query.execute();
+
       NodeIterator nodes = result.getNodes();
 
-      while (nodes.hasNext()) {
-        results.add(resolver.getResource(nodes.nextNode().getPath()));
-      }
+      Spliterator<Node> spliterator = Spliterators.spliteratorUnknownSize(nodes,
+          Spliterator.ORDERED | Spliterator.NONNULL);
+
+      Stream<Resource> results = StreamSupport.stream(spliterator, false).map(n -> {
+        try {
+          return resolver.getResource(n.getPath());
+        } catch (RepositoryException e) {
+          log.warn("Failed to get path from node: {}", n, e);
+          return null;
+        }
+      });
+
+      return new ResultsPage(results, config.getPageSize(), page, nodes.getSize());
     } catch (RepositoryException re) {
       throw new ReportException("Exception executing search results", re);
     }
-    return new ResultsPage(results, config.getPageSize(), page);
   }
 
   @Override
@@ -174,7 +186,7 @@ public class QueryReportExecutor implements ReportExecutor {
   private void prepareStatement() throws ReportException {
     try {
       Map<String, String> parameters = getParamPatternMap(request);
-      Template template =  new Handlebars().compileInline(config.getQuery());
+      Template template = new Handlebars().compileInline(config.getQuery());
       statement = template.apply(parameters);
       log.trace("Loaded statement: {}", statement);
     } catch (IOException ioe) {

--- a/bundle/src/main/java/com/adobe/acs/commons/reports/models/QueryReportExecutor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/reports/models/QueryReportExecutor.java
@@ -103,14 +103,7 @@ public class QueryReportExecutor implements ReportExecutor {
       Spliterator<Node> spliterator = Spliterators.spliteratorUnknownSize(nodes,
           Spliterator.ORDERED | Spliterator.NONNULL);
 
-      Stream<Resource> results = StreamSupport.stream(spliterator, false).map(n -> {
-        try {
-          return resolver.getResource(n.getPath());
-        } catch (RepositoryException e) {
-          log.warn("Failed to get path from node: {}", n, e);
-          return null;
-        }
-      });
+      Stream<Resource> results = StreamSupport.stream(spliterator, false).map(n -> getResource(n, resolver));
 
       return new ResultsPage(results, config.getPageSize(), page, nodes.getSize());
     } catch (RepositoryException re) {
@@ -176,6 +169,15 @@ public class QueryReportExecutor implements ReportExecutor {
       }
     }
     return StringUtils.join(params, "&");
+  }
+
+  private Resource getResource(Node node, ResourceResolver resolver) {
+    try {
+      return resolver.getResource(node.getPath());
+    } catch (RepositoryException e) {
+      log.warn("Failed to get path from node: {}", node, e);
+      return null;
+    }
   }
 
   @Override

--- a/bundle/src/test/java/com/adobe/acs/commons/reports/api/ResultsPageTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/reports/api/ResultsPageTest.java
@@ -22,6 +22,8 @@ package com.adobe.acs.commons.reports.api;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.Test;
@@ -72,6 +74,15 @@ public class ResultsPageTest {
     log.info("testGetResults");
     ResultsPage results = new ResultsPage(RESULTS, 4, 1, -1);
     assertEquals(RESULTS, results.getResults());
+    log.info("Test successful!");
+  }
+
+  @Test
+  public void testGetResultsList() {
+    log.info("testGetResultsList");
+    List<Object> resList = RESULTS.collect(Collectors.toList());
+    ResultsPage results = new ResultsPage(resList.stream(), 4, 1, -1);
+    assertEquals(resList, results.getResultsList());
     log.info("Test successful!");
   }
 

--- a/bundle/src/test/java/com/adobe/acs/commons/reports/api/ResultsPageTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/reports/api/ResultsPageTest.java
@@ -21,9 +21,8 @@ package com.adobe.acs.commons.reports.api;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -33,77 +32,78 @@ public class ResultsPageTest {
 
   private static final Logger log = LoggerFactory.getLogger(ResultsPageTest.class);
 
-  private static final List<Object> RESULTS = Arrays.asList("result1", "result2", "result3", "result4");
+  private static final Stream<Object> RESULTS = Arrays
+      .stream(new String[] { "result1", "result2", "result3", "result4" });
 
   @Test
   public void testGetNextPage() {
     log.info("testGetNextPage");
-    
-    ResultsPage hasMore = new ResultsPage(RESULTS, 4, 1);
+
+    ResultsPage hasMore = new ResultsPage(RESULTS, 4, 1, 4);
     assertEquals(2, hasMore.getNextPage());
-    
-    ResultsPage noMore = new ResultsPage(RESULTS, 5, 1);
+
+    ResultsPage noMore = new ResultsPage(RESULTS, 5, 1, 4);
     assertEquals(-1, noMore.getNextPage());
-    
-    ResultsPage all = new ResultsPage(RESULTS, 4, -1);
+
+    ResultsPage all = new ResultsPage(RESULTS, 4, -1, 4);
     assertEquals(-1, all.getNextPage());
-    
+
     log.info("Test successful!");
   }
 
   @Test
   public void testGetPreviousPage() {
     log.info("testGetPreviousPage");
-    
-    ResultsPage hasPrevious = new ResultsPage(RESULTS, 4, 1);
+
+    ResultsPage hasPrevious = new ResultsPage(RESULTS, 4, 1, -1L);
     assertEquals(0, hasPrevious.getPreviousPage());
-    
-    ResultsPage noPrevious = new ResultsPage(RESULTS, 5, 0);
+
+    ResultsPage noPrevious = new ResultsPage(RESULTS, 5, 0, -1);
     assertEquals(-1, noPrevious.getPreviousPage());
-    
-    ResultsPage all = new ResultsPage(RESULTS, 4, -1);
+
+    ResultsPage all = new ResultsPage(RESULTS, 4, -1, -1);
     assertEquals(-1, all.getPreviousPage());
-    
+
     log.info("Test successful!");
   }
 
   @Test
   public void testGetResults() {
     log.info("testGetResults");
-    ResultsPage results = new ResultsPage(RESULTS, 4, 1);
+    ResultsPage results = new ResultsPage(RESULTS, 4, 1, -1);
     assertEquals(RESULTS, results.getResults());
     log.info("Test successful!");
   }
-  
+
   @Test
-  public void testGetResultsEnd(){
+  public void testGetResultsEnd() {
     log.info("testGetResultsEnd");
-    
-    ResultsPage hasMore = new ResultsPage(RESULTS, 4, 1);
+
+    ResultsPage hasMore = new ResultsPage(RESULTS, 4, 1, 4);
     assertEquals(8, hasMore.getResultsEnd());
-    
-    ResultsPage first = new ResultsPage(RESULTS, 5, 0);
+
+    ResultsPage first = new ResultsPage(RESULTS, 5, 0, 4);
     assertEquals(4, first.getResultsEnd());
-    
-    ResultsPage all = new ResultsPage(RESULTS, 4, -1);
+
+    ResultsPage all = new ResultsPage(RESULTS, 4, -1, 4);
     assertEquals(4, all.getResultsEnd());
-    
+
     log.info("Test successful!");
   }
-  
+
   @Test
-  public void testGetResultsStart(){
+  public void testGetResultsStart() {
     log.info("testGetResultsStart");
-    
-    ResultsPage hasPrevious = new ResultsPage(RESULTS, 4, 1);
+
+    ResultsPage hasPrevious = new ResultsPage(RESULTS, 4, 1, -1);
     assertEquals(5, hasPrevious.getResultsStart());
-    
-    ResultsPage noPrevious = new ResultsPage(RESULTS, 4, 0);
+
+    ResultsPage noPrevious = new ResultsPage(RESULTS, 4, 0, -1);
     assertEquals(1, noPrevious.getResultsStart());
-    
-    ResultsPage all = new ResultsPage(RESULTS, 4, -1);
+
+    ResultsPage all = new ResultsPage(RESULTS, 4, -1, -1);
     assertEquals(1, all.getResultsStart());
-    
+
     log.info("Test successful!");
   }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/reports/models/PathListReportExecutorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/reports/models/PathListReportExecutorTest.java
@@ -19,25 +19,23 @@
  */
 package com.adobe.acs.commons.reports.models;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-
+import com.adobe.acs.commons.reports.api.ReportException;
+import com.adobe.acs.commons.reports.api.ResultsPage;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-
-import com.adobe.acs.commons.reports.api.ReportException;
-import com.adobe.acs.commons.reports.api.ResultsPage;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 public class PathListReportExecutorTest {
 
@@ -184,6 +182,17 @@ public class PathListReportExecutorTest {
         assertEquals(0, executor.currentPage);
     }
 
+    @Test
+    public void testSetPageReturnsPositiveNumbers() {
+        PathListReportExecutor executor = new PathListReportExecutor();
+
+        executor.setPage(10);
+        assertEquals(10, executor.currentPage);
+        executor.setPage(0);
+        assertEquals(0, executor.currentPage);
+    }
+
+
     private class ResultsTestObject {
         private final List<String> providedPaths;
         private final List<String> expectedPaths;
@@ -200,8 +209,8 @@ public class PathListReportExecutorTest {
             this.expectedPaths = expectedPaths;
         }
 
-        ResultsPage getResultsPage() {
-            return resultsPage;
+        ResultsPage getResultsPage() throws ReportException {
+            return reportExecutor.getResults();
         }
 
         PathListReportExecutor getReportExecutor() {

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/report-builder/report-page/results.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/report-builder/report-page/results.jsp
@@ -8,7 +8,7 @@
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
 
-	   http://www.apache.org/licenses/LICENSE-2.0
+       http://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,74 +24,69 @@
 <c:set var="results" value="${reportExecutor.results}" scope="request" />
 <sling2:listChildren resource="${sling2:getRelativeResource(resource,'columns')}" var="columns" />
 <coral-drawer direction="up" class="report__details">
-	<pre>${reportExecutor.details}</pre>
+    <pre>${reportExecutor.details}</pre>
 </coral-drawer>
 <div>Results <fmt:formatNumber value="${results.resultsStart}" /> - <fmt:formatNumber value="${results.resultsEnd}" /></div>
 <div class="report__result-container">
-	<table is="coral-table" selectable>
-		<colgroup>
-			<col is="coral-table-column" sortable="stortable" data-foundation-layout-table-column-name="Index" sortabletype="number">
-			<sling2:listChildren resource="${sling2:getRelativeResource(resource,'columns')}" var="columns" />
-			<c:forEach var="col" items="${columns}">
-				<col is="coral-table-column" sortable="stortable" data-foundation-layout-table-column-name="${sling2:encode(col.valueMap.heading,'HTML_ATTR')}">
-			</c:forEach>
-		</colgroup>
-        <thead is="coral-table-head" sticky>
-            <tr is="coral-table-row">
-            	<th is="coral-table-headercell">
-            		#
-            	</th>
-            	<sling2:listChildren resource="${sling2:getRelativeResource(resource,'columns')}" var="columns" />
-				<c:forEach var="col" items="${columns}">
-					<th is="coral-table-headercell">
-						<sling2:encode value="${col.valueMap.heading}" mode="HTML" />
-					</th>
-				</c:forEach>
-            </tr>
-        </thead>
-        <tbody is="coral-table-body">
-        	<c:catch var="ex">
-	        	<c:forEach var="result" items="${results.results}" varStatus="status">
-	        		
-	        		<tr is="coral-table-row">
-	        			<td is="coral-table-cell" value="${status.index + results.resultsStart}">
-	        				<fmt:formatNumber value="${status.index + results.resultsStart}" />
-	        			</td>
-	        			<sling2:listChildren resource="${sling2:getRelativeResource(resource,'columns')}" var="columns" />
-			        	<c:forEach var="col" items="${columns}">
-							<c:set var="result" value="${result}" scope="request" />
-							<sling:include path="columns/${col.name}" resourceType="${col.resourceType}" />
-						</c:forEach>
-					</tr>
-				</c:forEach>
-			</c:catch>
-			<c:if test = "${ex != null}">
-				<script>
-					var $not = $("<div/>");
-					$not.attr('class','coral-Alert coral-Alert--error coral-Alert--large');
-					$not.html('<i class="coral-Alert-typeIcon coral-Icon coral-Icon--sizeS coral-Icon--alert"></i><strong class="coral-Alert-title">Error</strong><div class="coral-Alert-message">Exception executing report: ${ex} ${ex.message}</div>');
-					$('.notifications').append($not);
-					setTimeout(function(){
-						$not.remove();
-					},
-					20000);
-				</script>
-			</c:if>
-		</tbody>
-	</table>
+    <c:catch var="ex">
+        <table is="coral-table" selectable>
+            <colgroup>
+                <col is="coral-table-column" sortable="stortable" data-foundation-layout-table-column-name="Index" sortabletype="number">
+                <sling2:listChildren resource="${sling2:getRelativeResource(resource,'columns')}" var="columns" />
+                <c:forEach var="col" items="${columns}">
+                    <col is="coral-table-column" sortable="stortable" data-foundation-layout-table-column-name="${sling2:encode(col.valueMap.heading,'HTML_ATTR')}">
+                </c:forEach>
+            </colgroup>
+            <thead is="coral-table-head" sticky>
+                <tr is="coral-table-row">
+                    <th is="coral-table-headercell" scope="col">
+                        #
+                    </th>
+                    <sling2:listChildren resource="${sling2:getRelativeResource(resource,'columns')}" var="columns" />
+                    <c:forEach var="col" items="${columns}">
+                        <th is="coral-table-headercell" scope="col">
+                            <sling2:encode value="${col.valueMap.heading}" mode="HTML" />
+                        </th>
+                    </c:forEach>
+                </tr>
+            </thead>
+            <tbody is="coral-table-body">
+                <c:forEach var="result" items="${results.resultsList}" varStatus="status">
+                    <tr is="coral-table-row">
+                        <td is="coral-table-cell" value="${status.index + results.resultsStart}">
+                            <fmt:formatNumber value="${status.index + results.resultsStart}" />
+                        </td>
+                        <sling2:listChildren resource="${sling2:getRelativeResource(resource,'columns')}" var="columns" />
+                        <c:forEach var="col" items="${columns}">
+                            <c:set var="result" value="${result}" scope="request" />
+                            <sling:include path="columns/${col.name}" resourceType="${col.resourceType}" />
+                        </c:forEach>
+                    </tr>
+                </c:forEach>
+            </tbody>
+        </table>
+    </c:catch>
+
+    <c:if test = "${ex != null}">
+        <div class="coral-Alert coral-Alert--error coral-Alert--large">
+            <i class="coral-Alert-typeIcon coral-Icon coral-Icon--sizeS coral-Icon--alert"></i>
+            <strong class="coral-Alert-title">Error</strong>
+            <div class="coral-Alert-message">Exception executing report: ${ex} ${ex.message}</div>
+        </div>
+    </c:if>
 </div>
 <div class="pagination">
-	<c:if test="${results.previousPage != -1}">
-		<a href="${resource.path}.results.html?page=0&${reportExecutor.parameters}" data-page="0" class="coral-Button coral-Button--square pagination__link pagination__prev">
-			First
-		</a>
-		<a href="${resource.path}.results.html?page=${results.previousPage}&${reportExecutor.parameters}" data-page="${results.previousPage}" class="coral-Button coral-Button--square pagination__link pagination__prev">
-			Previous
-		</a>
-	</c:if>
-	<c:if test="${results.nextPage != -1}">
-		<a href="${resource.path}.results.html?page=${results.nextPage}&${reportExecutor.parameters}" data-page="${results.nextPage}" class="coral-Button coral-Button--square pagination__link pagination__next">
-			Next
-		</a>
-	</c:if>
+    <c:if test="${results.previousPage != -1}">
+        <a href="${resource.path}.results.html?page=0&${reportExecutor.parameters}" data-page="0" class="coral-Button coral-Button--square pagination__link pagination__prev">
+            First
+        </a>
+        <a href="${resource.path}.results.html?page=${results.previousPage}&${reportExecutor.parameters}" data-page="${results.previousPage}" class="coral-Button coral-Button--square pagination__link pagination__prev">
+            Previous
+        </a>
+    </c:if>
+    <c:if test="${results.nextPage != -1}">
+        <a href="${resource.path}.results.html?page=${results.nextPage}&${reportExecutor.parameters}" data-page="${results.nextPage}" class="coral-Button coral-Button--square pagination__link pagination__next">
+            Next
+        </a>
+    </c:if>
 </div>


### PR DESCRIPTION
Primary Changes:

 - uses stream instead of getting results as a list
 - fixes a problem where the alert wasn't appearing when the result writing failed (made it a big red box instead of trying to show the toast)
