### PR TITLE
Fixed #2450 - Write BOM to the beginning of the CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ### Fixed
 - #2441 - Memory Exhaustion with Large Report Download
+- #2450 - Non-Latin letters shown as "?" in the downloaded report
 
 ## 4.8.6 - 2020-10-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ### Fixed
 - #2441 - Memory Exhaustion with Large Report Download
 - #2450 - Non-Latin letters shown as "?" in the downloaded report
+- #2446 - One page is displayed in multiple lines in Report Builder export CSV file 
 
 ## 4.8.6 - 2020-10-13
 

--- a/bundle/src/main/java/com/adobe/acs/commons/reports/internal/ReportCSVExportServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/reports/internal/ReportCSVExportServlet.java
@@ -80,6 +80,10 @@ public class ReportCSVExportServlet extends SlingSafeMethodsServlet {
     Writer writer = null;
     try {
       writer = response.getWriter();
+
+      // write the BOM to indicate this is a UTF-8 file
+      writer.write("\uFEFF");
+
       // initialize the csv
       final Csv csv = new Csv();
       csv.writeInit(writer);


### PR DESCRIPTION
@joerghoh, @shsteimer -- do you think we should assume UTF-8 compatibility in external tools?  If so this patch is gold.  Otherwise, we might consider changing output encoding for CSV.  In honesty, there's nothing in the CSV format that notes which encoding format is mandated; and there's even ways to force Excel to assume UTF-8 without the BOM.  But this makes life easier for folks using standard tools, so I think it's worth considering this patch as-is.