### PR TITLE
Prevent emitting buffered response twice in case AEMEnvironmentFilter is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-4.7.2...HEAD
 
+### Fixed
+- #2475 - Content rendered twice on publisher when environment indicator is enabled
 
 ## 4.10.0 - 2020-11-19
 

--- a/bundle/src/main/java/com/adobe/acs/commons/http/injectors/AbstractHtmlRequestInjector.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/http/injectors/AbstractHtmlRequestInjector.java
@@ -85,7 +85,7 @@ public abstract class AbstractHtmlRequestInjector implements Filter {
                 
                 if (injectionIndex != -1) {
                     // prevent the captured response from being given out a 2nd time via the implicit close()
-                    originalResponse.resetBuffer();
+                    originalResponse.setFlushBufferOnClose(false);
                     final PrintWriter printWriter = response.getWriter();
 
                     // Write all content up to the injection index

--- a/bundle/src/main/java/com/adobe/acs/commons/quickly/impl/QuicklyFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/quickly/impl/QuicklyFilter.java
@@ -104,7 +104,7 @@ public class QuicklyFilter implements Filter {
                 final int bodyIndex = contents.indexOf("</body>");
                 if (bodyIndex != -1) {
                     // prevent the captured response from being given out a 2nd time via the implicit close()
-                    capturedResponse.resetBuffer();
+                    capturedResponse.setFlushBufferOnClose(false);
                     final PrintWriter printWriter = response.getWriter();
     
                     printWriter.write(contents.substring(0, bodyIndex));

--- a/bundle/src/main/java/com/adobe/acs/commons/util/BufferedHttpServletResponse.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/BufferedHttpServletResponse.java
@@ -76,5 +76,12 @@ public class BufferedHttpServletResponse extends HttpServletResponseWrapper impl
     public BufferedServletOutput getBufferedServletOutput() {
         return bufferedOutput;
     }
+    
+    /** 
+     * Calls {@link BufferedServletOutput#setFlushBufferOnClose(boolean)}.
+     */
+    public void setFlushBufferOnClose(boolean flushBufferOnClose) {
+        bufferedOutput.setFlushBufferOnClose(flushBufferOnClose);
+    }
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/util/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/package-info.java
@@ -20,7 +20,7 @@
 /**
  * Miscellaneous Utilities.
  */
-@Version("4.4.0")
+@Version("4.5.0")
 
 package com.adobe.acs.commons.util;
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
enabled and output is of type writer but no html

This closes #2475