### PR TITLE
Simplify leader handling in JcrPackageReplicationStatusEventHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-4.7.2...HEAD
 
+### Fixed
+- #2492 - NPE in JcrPackageReplicationStatusEventHandler
+
 ## 4.11.0 - 2020-12-11
 
 ### Fixed

--- a/bundle/src/test/java/com/adobe/acs/commons/replication/status/impl/JcrPackageReplicationStatusEventHandlerTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/replication/status/impl/JcrPackageReplicationStatusEventHandlerTest.java
@@ -35,8 +35,6 @@ import org.apache.sling.api.resource.LoginException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceResolverFactory;
-import org.apache.sling.api.resource.ValueMap;
-import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.event.jobs.Job;
 import org.apache.sling.event.jobs.JobManager;
 import org.junit.Assert;
@@ -56,8 +54,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+
+import org.apache.sling.discovery.DiscoveryService;
 import org.apache.sling.discovery.InstanceDescription;
-import org.apache.sling.discovery.TopologyEvent;
 import org.apache.sling.discovery.TopologyView;
 
 import static org.junit.Assert.assertEquals;
@@ -91,6 +90,9 @@ public class JcrPackageReplicationStatusEventHandlerTest {
 
     @Mock
     Job job;
+
+    @Mock
+    DiscoveryService discoveryService;
 
     @Mock
     Resource contentResource1;
@@ -194,13 +196,11 @@ public class JcrPackageReplicationStatusEventHandlerTest {
         final Event event = new Event(ReplicationAction.EVENT_TOPIC, eventParams);
 
         final ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
-        TopologyEvent te = mock(TopologyEvent.class);
         TopologyView view = mock(TopologyView.class);
         InstanceDescription instanceDescription = mock(InstanceDescription.class);
-        when(te.getNewView()).thenReturn(view);
+        when(discoveryService.getTopology()).thenReturn(view);
         when(view.getLocalInstance()).thenReturn(instanceDescription);
         when(instanceDescription.isLeader()).thenReturn(true);
-        eventHandler.handleTopologyEvent(te);
         eventHandler.handleEvent(event);
 
         verify(jobManager, times(1)).addJob(eq("acs-commons/replication/package"), captor.capture());


### PR DESCRIPTION
This solves the NPE being thrown when TopologyEvent.getNewView() returns
null.
This closes #2492