### PR TITLE
VersionedClientLibs broken in AEM 6.5.7

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/SaxElementUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/SaxElementUtils.java
@@ -26,7 +26,8 @@ import com.adobe.granite.ui.clientlibs.LibraryType;
 
 public class SaxElementUtils {
 
-    private SaxElementUtils() {}
+    private SaxElementUtils() {
+    }
 
     public static final String CSS_TYPE = "text/css";
     public static final String JS_TYPE = "text/javascript";

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/SaxElementUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/SaxElementUtils.java
@@ -26,40 +26,31 @@ import com.adobe.granite.ui.clientlibs.LibraryType;
 
 public class SaxElementUtils {
 
-    private SaxElementUtils() {
-    }
+    private SaxElementUtils() {}
 
     public static final String CSS_TYPE = "text/css";
     public static final String JS_TYPE = "text/javascript";
-    
+
     public static boolean isCss(final String elementName, final Attributes attrs) {
         final String type = attrs.getValue("", "type");
         final String href = attrs.getValue("", "href");
 
-        if (StringUtils.equals("link", elementName)
+        return StringUtils.equals("link", elementName)
                 && StringUtils.equals(type, CSS_TYPE)
                 && StringUtils.startsWith(href, "/")
                 && !StringUtils.startsWith(href, "//")
-                && StringUtils.endsWith(href, LibraryType.CSS.extension)) {
-            return true;
-        }
-
-        return false;
+                && StringUtils.endsWith(href, LibraryType.CSS.extension);
     }
-    
+
     public static boolean isJavaScript(final String elementName, final Attributes attrs) {
         final String type = attrs.getValue("", "type");
         final String src = attrs.getValue("", "src");
 
-        if (StringUtils.equals("script", elementName)
-                && StringUtils.equals(type, JS_TYPE)
+        return StringUtils.equals("script", elementName)
+                && (type == null || StringUtils.equals(type, JS_TYPE))
                 && StringUtils.startsWith(src, "/")
                 && !StringUtils.startsWith(src, "//")
-                && StringUtils.endsWith(src, LibraryType.JS.extension)) {
-            return true;
-        }
-
-        return false;
+                && StringUtils.endsWith(src, LibraryType.JS.extension);
     }
-    
+
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/SaxElementUtilsTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/SaxElementUtilsTest.java
@@ -33,90 +33,95 @@ public class SaxElementUtilsTest {
 
     @Test
     public void testIsCss() throws Exception {
-        assertTrue("CSS Happy Path", 
+        assertTrue("CSS Happy Path",
                 SaxElementUtils.isCss("link",
                         makeAtts(
                                 "href", "/css.css",
                                 "type", "text/css")));
-        
-        assertFalse("CSS - not a link", 
+
+        assertFalse("CSS - not a link",
                 SaxElementUtils.isCss("notlink",
                         makeAtts(
                                 "href", "/css.css",
                                 "type", "text/css")));
-        
-        assertFalse("CSS - not a path to css file", 
+
+        assertFalse("CSS - not a path to css file",
                 SaxElementUtils.isCss("link",
                         makeAtts(
                                 "href", "/css.notcss",
                                 "type", "text/css")));
 
-        assertFalse("CSS - relative path", 
+        assertFalse("CSS - relative path",
                 SaxElementUtils.isCss("link",
                         makeAtts(
                                 "href", "css.css",
                                 "type", "text/css")));
 
-        assertFalse("CSS - external path", 
+        assertFalse("CSS - external path",
                 SaxElementUtils.isCss("link",
                         makeAtts(
                                 "href", "http://www.adobe.com/css.css",
                                 "type", "text/css")));
 
-        
-        assertFalse("CSS - wrongtype", 
+
+        assertFalse("CSS - wrongtype",
                 SaxElementUtils.isCss("link",
                         makeAtts(
                                 "href", "/css.css",
                                 "type", "text/notcss")));
     }
-    
+
     @Test
     public void testIsJavascript() throws Exception {
-        assertTrue("JS Happy Path", 
+        assertTrue("JS Happy Path",
                 SaxElementUtils.isJavaScript("script",
                         makeAtts(
                                 "src", "/js.js",
                                 "type", SaxElementUtils.JS_TYPE)));
-        
-        assertFalse("JS - not a link", 
+
+        assertTrue("JS Happy Path - Optional Type Attribute",
+                SaxElementUtils.isJavaScript("script",
+                        makeAtts(
+                                "src", "/js.js")));
+
+        assertFalse("JS - not a link",
                 SaxElementUtils.isJavaScript("notscript",
                         makeAtts(
                                 "src", "/js.js",
                                 "type", SaxElementUtils.JS_TYPE)));
-        
-        assertFalse("JS - not a path to js file", 
+
+        assertFalse("JS - not a path to js file",
                 SaxElementUtils.isJavaScript("script",
                         makeAtts(
                                 "src", "/js.notjs",
                                 "type", SaxElementUtils.JS_TYPE)));
 
-        assertFalse("JS - relative path", 
+        assertFalse("JS - relative path",
                 SaxElementUtils.isJavaScript("script",
                         makeAtts(
                                 "src", "js.js",
                                 "type", SaxElementUtils.JS_TYPE)));
 
-        assertFalse("JS - external path", 
+        assertFalse("JS - external path",
                 SaxElementUtils.isJavaScript("script",
                         makeAtts(
                                 "src", "http://www.adobe.com/js.js",
                                 "type", SaxElementUtils.JS_TYPE)));
 
-        
-        assertFalse("JS - wrongtype", 
+
+        assertFalse("JS - wrongtype",
                 SaxElementUtils.isJavaScript("script",
                         makeAtts(
                                 "src", "/js.js",
                                 "type", "not" + SaxElementUtils.JS_TYPE)));
     }
-    
+
     private Attributes makeAtts( String... strings ) {
         AttributesImpl atts = new AttributesImpl();
         for( int i = 0; i < strings.length/2; i++) {
             String key = strings[i*2];
             String value = strings[i*2 + 1];
-            atts.addAttribute("", key, "", "CDATA", value); 
+            atts.addAttribute("", key, "", "CDATA", value);
         }
         return atts;
     }


### PR DESCRIPTION
HTML 5 / HTML 5.2 made the type attribute optional. AEM 6.5.7 has taken this on board, the HTMLLibraryManager no longer adds the type attribute to script tags.

This updates the VersionClientLibs so that it will still work in both cases.