### PR TITLE
RobotsServletTest: normalize line endings before asserting responses

### DIFF
--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/RobotsServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/RobotsServletTest.java
@@ -208,9 +208,12 @@ public class RobotsServletTest {
     }
 
     private void assertResponse(InputStream resourceAsStream, MockSlingHttpServletResponse response) throws IOException {
-        String output = response.getOutputAsString();
-        String expected = IOUtils.toString(resourceAsStream, StandardCharsets.UTF_8.name());
+        String output = normalizeLineEndings(response.getOutputAsString());
+        String expected = normalizeLineEndings(IOUtils.toString(resourceAsStream, StandardCharsets.UTF_8.name()));
         assertEquals(expected, output);
     }
 
+    private String normalizeLineEndings(String txt){
+        return txt.replaceAll("\r?\n", "\n");
+    }
 }


### PR DESCRIPTION
ACS Commons build fails on Windows because RobotsServletTest assumes unix line separator ('\n') . This small patch normalizes the line endings before passing strings to assertEquals.