### PR TITLE
Adding (backwards compatible) options to the i18nprovider / injector to:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-4.7.2...HEAD
 
+### Added
+- #2518 - Extended the I18N provider / injector mechanism with more options 
+
 ## 4.11.2 - 2021-01-05
 
 ### Fixed

--- a/bundle/src/main/java/com/adobe/acs/commons/i18n/I18nProvider.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/i18n/I18nProvider.java
@@ -51,7 +51,7 @@ public interface I18nProvider {
      */
     default String translate(String key, Resource resource, boolean localeIgnoreContent){
         return translate(key, resource);
-    };
+    }
 
     /**
      * Provides the translated value based on resource
@@ -89,7 +89,7 @@ public interface I18nProvider {
      */
     default I18n i18n(Resource resource, boolean localeIgnoreContent){
         return i18n(resource);
-    };
+    }
 
     /**
      * Provides the i18n map based on the underlying resource

--- a/bundle/src/main/java/com/adobe/acs/commons/i18n/I18nProvider.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/i18n/I18nProvider.java
@@ -43,6 +43,19 @@ public interface I18nProvider {
     /**
      * Provides the translated value based on resource
      *
+     * @param key      i18n key
+     * @param resource underlying resource
+     * @param localeIgnoreContent if true only the path is used to determine the language.
+     * @see com.day.cq.wcm.api.Page#getLanguage(boolean)
+     * @return translated string
+     */
+    default String translate(String key, Resource resource, boolean localeIgnoreContent){
+        return translate(key, resource);
+    };
+
+    /**
+     * Provides the translated value based on resource
+     *
      * @param key    i18n key
      * @param locale locale
      * @return translated string
@@ -65,6 +78,18 @@ public interface I18nProvider {
      * @return i18n map
      */
     I18n i18n(Resource resource);
+
+    /**
+     * Provides the i18n map based on the underlying resource
+     *
+     * @param resource underlying resource
+     * @param localeIgnoreContent if true only the path is used to determine the language.
+     * @see com.day.cq.wcm.api.Page#getLanguage(boolean)
+     * @return i18n map
+     */
+    default I18n i18n(Resource resource, boolean localeIgnoreContent){
+        return i18n(resource);
+    };
 
     /**
      * Provides the i18n map based on the underlying resource

--- a/bundle/src/main/java/com/adobe/acs/commons/i18n/impl/I18nProviderImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/i18n/impl/I18nProviderImpl.java
@@ -106,7 +106,12 @@ public class I18nProviderImpl extends AbstractGuavaCacheMBean<String,I18n> imple
 
     @Override
     public String translate(final String key, final Resource resource) {
-        final I18n i18n = i18n(resource);
+        return translate(key, resource,false);
+    }
+
+    @Override
+    public String translate(String key, Resource resource, boolean localeIgnoreContent) {
+        final I18n i18n = i18n(resource, localeIgnoreContent);
         if (i18n != null) {
             return i18n.get(key);
         }
@@ -126,13 +131,18 @@ public class I18nProviderImpl extends AbstractGuavaCacheMBean<String,I18n> imple
 
     @Override
     public I18n i18n(final Resource resource) {
-        final I18n cached = cache.getIfPresent(resource.getPath());
+        return i18n(resource, false);
+    }
+
+    @Override
+    public I18n i18n(Resource resource, boolean localeIgnoreContent) {
+        final I18n cached = cache.getIfPresent(resource.getPath() + localeIgnoreContent);
         if (cached != null) {
             return cached;
         }
 
-        final I18n i18n = i18n(getResourceBundleFromPageLocale(resource));
-        cache.put(resource.getPath(), i18n);
+        final I18n i18n = i18n(getResourceBundleFromPageLocale(resource, localeIgnoreContent));
+        cache.put(resource.getPath() + localeIgnoreContent, i18n);
         return i18n;
     }
 
@@ -150,14 +160,14 @@ public class I18nProviderImpl extends AbstractGuavaCacheMBean<String,I18n> imple
         return new I18n(resourceBundle);
     }
 
-    private ResourceBundle getResourceBundleFromPageLocale(final Resource resource) {
-        return getResourceBundle(getLocaleFromResource(resource));
+    private ResourceBundle getResourceBundleFromPageLocale(final Resource resource, boolean localeIgnoreContent) {
+        return getResourceBundle(getLocaleFromResource(resource, localeIgnoreContent));
     }
 
-    private Locale getLocaleFromResource(final Resource resource) {
+    private Locale getLocaleFromResource(final Resource resource, boolean localeIgnoreContent) {
         final Page page = getResourcePage(resource);
         if (page != null) {
-            return page.getLanguage(false);
+            return page.getLanguage(localeIgnoreContent);
         }
 
         return null;

--- a/bundle/src/main/java/com/adobe/acs/commons/i18n/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/i18n/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Http Injectors.
  */
-@org.osgi.annotation.versioning.Version("4.0.0")
+@org.osgi.annotation.versioning.Version("4.1.0")
 package com.adobe.acs.commons.i18n;

--- a/bundle/src/main/java/com/adobe/acs/commons/models/injectors/annotation/I18N.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/models/injectors/annotation/I18N.java
@@ -49,6 +49,18 @@ public @interface I18N {
     String SOURCE = "i18n";
 
     /**
+     * if true only the path is used to determine the language.
+     * @see com.day.cq.wcm.api.Page#getLanguage(boolean)
+     */
+    boolean localeIgnoreContent() default false;
+
+    /**
+     * Forces retrieving the i18n from the underlying resource, even if a request is being adapted.
+     * @return
+     */
+    boolean forceRetrievalFromUnderlyingResource() default false;
+
+    /**
      * Represents the i18nKey
      *
      * @return

--- a/bundle/src/main/java/com/adobe/acs/commons/models/injectors/annotation/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/models/injectors/annotation/package-info.java
@@ -17,7 +17,7 @@
  * limitations under the License.
  * #L%
  */
-@org.osgi.annotation.versioning.Version("3.5.0")
+@org.osgi.annotation.versioning.Version("3.6.0")
 package com.adobe.acs.commons.models.injectors.annotation;
 
 

--- a/bundle/src/main/java/com/adobe/acs/commons/models/injectors/impl/I18nInjector.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/models/injectors/impl/I18nInjector.java
@@ -24,6 +24,7 @@ import com.adobe.acs.commons.models.injectors.annotation.I18N;
 import com.adobe.acs.commons.util.impl.ReflectionUtil;
 import com.day.cq.i18n.I18n;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.spi.DisposalCallbackRegistry;
 import org.apache.sling.models.spi.Injector;
@@ -31,7 +32,6 @@ import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
-import javax.servlet.http.HttpServletRequest;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Type;
 
@@ -59,35 +59,84 @@ public class I18nInjector implements Injector {
 
         if (annotatedElement.isAnnotationPresent(I18N.class) && canAdaptToString(adaptable, type)) {
             //skipping javax.Inject for performance reasons. Only supports direct injection.
-            String key = getI18nKey(name, annotatedElement);
-
-            if (adaptable instanceof HttpServletRequest) {
-                HttpServletRequest request = (HttpServletRequest) adaptable;
-                return i18nProvider.translate(key, request);
-            } else {
-                Resource resource = getResource(adaptable);
-                return i18nProvider.translate(key, resource);
-            }
+            return i18nStringAdaptation(adaptable, name, annotatedElement);
         }else if(canAdaptToObject(adaptable, type)){
-            if (adaptable instanceof HttpServletRequest) {
-                HttpServletRequest request = (HttpServletRequest) adaptable;
-                return i18nProvider.i18n(request);
-            } else {
-                Resource resource = getResource(adaptable);
-                return i18nProvider.i18n(resource);
-            }
+            return i18nObjectAdaptation(adaptable, annotatedElement);
         }
 
         return null;
     }
 
+    private I18n i18nObjectAdaptation(Object adaptable, AnnotatedElement annotatedElement) {
+        if (adaptable instanceof SlingHttpServletRequest) {
+            SlingHttpServletRequest request = (SlingHttpServletRequest) adaptable;
+
+            boolean forceLocaleRetrievalFromUnderlyingResource = isLocaleRetrievalFromUnderlyingResourceForced(annotatedElement);
+
+            if(forceLocaleRetrievalFromUnderlyingResource){
+                boolean localeIgnoreContent = getLocaleIgnoreContent(annotatedElement);
+                return i18nProvider.i18n(request.getResource(), localeIgnoreContent);
+            }else{
+                return i18nProvider.i18n(request);
+            }
+
+        } else {
+            boolean localeIgnoreContent = getLocaleIgnoreContent(annotatedElement);
+            Resource resource = getResource(adaptable);
+            return i18nProvider.i18n(resource,localeIgnoreContent);
+        }
+    }
+
+    private String i18nStringAdaptation(Object adaptable, String name, AnnotatedElement annotatedElement) {
+        boolean localeIgnoreContent = getLocaleIgnoreContent(annotatedElement);
+
+        String key = getI18nKey(name, annotatedElement);
+
+        if (adaptable instanceof SlingHttpServletRequest) {
+            boolean forceLocaleRetrievalFromUnderlyingResource = isLocaleRetrievalFromUnderlyingResourceForced(annotatedElement);
+            SlingHttpServletRequest request = (SlingHttpServletRequest) adaptable;
+
+            if(forceLocaleRetrievalFromUnderlyingResource){
+                return i18nProvider.translate(key, request.getResource(), localeIgnoreContent);
+            }else{
+                return i18nProvider.translate(key, request);
+            }
+
+        } else {
+            Resource resource = getResource(adaptable);
+            return i18nProvider.translate(key, resource,localeIgnoreContent);
+        }
+    }
+
+    private boolean isLocaleRetrievalFromUnderlyingResourceForced(AnnotatedElement annotatedElement) {
+
+        if(annotatedElement.isAnnotationPresent(I18N.class)){
+            I18N annotation = annotatedElement.getAnnotation(I18N.class);
+            return annotation.forceRetrievalFromUnderlyingResource();
+        }
+
+        return false;
+    }
+
+    private boolean getLocaleIgnoreContent(AnnotatedElement annotatedElement) {
+
+        if(annotatedElement.isAnnotationPresent(I18N.class)){
+            I18N annotation = annotatedElement.getAnnotation(I18N.class);
+            return annotation.localeIgnoreContent();
+        }
+
+        return false;
+    }
+
     private String getI18nKey(String name, AnnotatedElement annotatedElement) {
 
-        I18N annotation = annotatedElement.getAnnotation(I18N.class);
-        String annotationKey = annotation.value();
+        if(annotatedElement.isAnnotationPresent(I18N.class)) {
+            I18N annotation = annotatedElement.getAnnotation(I18N.class);
+            String annotationKey = annotation.value();
 
-        if (StringUtils.isNotEmpty(annotationKey)) {
-            return annotationKey;
+            if (StringUtils.isNotEmpty(annotationKey)) {
+                return annotationKey;
+            }
         }
 
         return name;

--- a/bundle/src/test/java/com/adobe/acs/commons/i18n/impl/I18nProviderImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/i18n/impl/I18nProviderImplTest.java
@@ -59,8 +59,8 @@ import com.day.cq.wcm.api.Page;
 @RunWith(MockitoJUnitRunner.class)
 public final class I18nProviderImplTest {
 
-    private static final Locale LOCALE = Locale.US,
-                                LOCALE_ALTERNATE = Locale.FRENCH;
+    private static final Locale LOCALE = Locale.US;
+    private static final Locale LOCALE_ALTERNATE = Locale.FRENCH;
 
     private static final String I18N_KEY = "i18nKey";
     private static final String TRANSLATED_FROM_ENGLISH = "Translated from English!";
@@ -80,7 +80,9 @@ public final class I18nProviderImplTest {
     private ResourceBundleProvider resourceBundleProvider;
 
     @Mock
-    private ResourceBundle resourceBundle, resourceBundleAlternate;
+    private ResourceBundle resourceBundle;
+    @Mock
+    private ResourceBundle resourceBundleAlternate;
 
     @Mock
     private Resource resource;

--- a/bundle/src/test/java/com/adobe/acs/commons/i18n/impl/I18nProviderImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/i18n/impl/I18nProviderImplTest.java
@@ -63,15 +63,15 @@ public final class I18nProviderImplTest {
                                 LOCALE_ALTERNATE = Locale.FRENCH;
 
     private static final String I18N_KEY = "i18nKey";
-    private static final String TRANSLATED_FROM_ENGLISH = "Translated from English!",
-                                TRANSLATED_FROM_FRENCH = "Bonjour!";
+    private static final String TRANSLATED_FROM_ENGLISH = "Translated from English!";
+    private static final String TRANSLATED_FROM_FRENCH = "Bonjour!";
 
     private final I18nProviderImpl i18nProvider = spy(new I18nProviderImpl());
-    private final HashMap<String, Object> resourceBundleProviderProps = new HashMap<>(),
-                                          resourceBundleProviderPropsAlternatve = new HashMap<>();
+    private final HashMap<String, Object> resourceBundleProviderProps = new HashMap<>();
+    private final HashMap<String, Object> resourceBundleProviderPropsAlternatve = new HashMap<>();
 
-    private final Map<String, String> i18nMap = new HashMap<>(),
-                                      i18nMapAlternate = new HashMap<>();
+    private final Map<String, String> i18nMap = new HashMap<>();
+    private final Map<String, String> i18nMapAlternate = new HashMap<>();
 
     @Mock
     private Config config;
@@ -140,7 +140,8 @@ public final class I18nProviderImplTest {
 
     @Test
     public void test_translate_resource() {
-        final I18n mocked = mock(I18n.class), mockedAlternate = mock(I18n.class);
+        final I18n mocked = mock(I18n.class);
+        final I18n mockedAlternate = mock(I18n.class);
         when(mocked.get(I18N_KEY)).thenReturn(TRANSLATED_FROM_ENGLISH);
         when(mockedAlternate.get(I18N_KEY)).thenReturn(TRANSLATED_FROM_FRENCH);
 

--- a/bundle/src/test/java/com/adobe/acs/commons/i18n/impl/I18nProviderImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/i18n/impl/I18nProviderImplTest.java
@@ -59,14 +59,19 @@ import com.day.cq.wcm.api.Page;
 @RunWith(MockitoJUnitRunner.class)
 public final class I18nProviderImplTest {
 
-    private static final Locale LOCALE = Locale.US;
+    private static final Locale LOCALE = Locale.US,
+                                LOCALE_ALTERNATE = Locale.FRENCH;
+
     private static final String I18N_KEY = "i18nKey";
-    private static final String TRANSLATED_FROM_ENGLISH = "Translated from English!";
+    private static final String TRANSLATED_FROM_ENGLISH = "Translated from English!",
+                                TRANSLATED_FROM_FRENCH = "Bonjour!";
 
     private final I18nProviderImpl i18nProvider = spy(new I18nProviderImpl());
-    private final HashMap<String, Object> resourceBundleProviderProps = new HashMap<>();
+    private final HashMap<String, Object> resourceBundleProviderProps = new HashMap<>(),
+                                          resourceBundleProviderPropsAlternatve = new HashMap<>();
 
-    private final Map<String, String> i18nMap = new HashMap<>();
+    private final Map<String, String> i18nMap = new HashMap<>(),
+                                      i18nMapAlternate = new HashMap<>();
 
     @Mock
     private Config config;
@@ -75,7 +80,7 @@ public final class I18nProviderImplTest {
     private ResourceBundleProvider resourceBundleProvider;
 
     @Mock
-    private ResourceBundle resourceBundle;
+    private ResourceBundle resourceBundle, resourceBundleAlternate;
 
     @Mock
     private Resource resource;
@@ -95,15 +100,17 @@ public final class I18nProviderImplTest {
         resourceBundleProviderProps.put(Constants.SERVICE_RANKING, 11);
 
         when(resourceBundleProvider.getResourceBundle(LOCALE)).thenReturn(resourceBundle);
+        when(resourceBundleProvider.getResourceBundle(LOCALE_ALTERNATE)).thenReturn(resourceBundleAlternate);
+
         when(resource.getPath()).thenReturn("/some/path");
 
         i18nMap.put(I18N_KEY, TRANSLATED_FROM_ENGLISH);
-
-        final Answer<String> answer = (Answer<String>) invocationOnMock -> i18nMap.get(invocationOnMock.getArguments()[1]);
+        i18nMapAlternate.put(I18N_KEY, TRANSLATED_FROM_FRENCH);
 
         doReturn(resourcePage).when(i18nProvider).getResourcePage(resource);
 
         when(resourcePage.getLanguage(false)).thenReturn(LOCALE);
+        when(resourcePage.getLanguage(true)).thenReturn(LOCALE_ALTERNATE);
 
         when(config.getTtl()).thenReturn(10L);
         when(config.maxSizeCount()).thenReturn(10L);
@@ -133,16 +140,20 @@ public final class I18nProviderImplTest {
 
     @Test
     public void test_translate_resource() {
-        final I18n mocked = mock(I18n.class);
+        final I18n mocked = mock(I18n.class), mockedAlternate = mock(I18n.class);
         when(mocked.get(I18N_KEY)).thenReturn(TRANSLATED_FROM_ENGLISH);
+        when(mockedAlternate.get(I18N_KEY)).thenReturn(TRANSLATED_FROM_FRENCH);
+
         doReturn(mocked).when(i18nProvider).i18n(resourceBundle);
+        doReturn(mockedAlternate).when(i18nProvider).i18n(resourceBundleAlternate);
 
         doReturn(resourcePage).when(i18nProvider).getResourcePage(resource);
 
-        when(resourceBundleProvider.getResourceBundle(LOCALE)).thenReturn(resourceBundle);
-
         final String translated = i18nProvider.translate(I18N_KEY, resource);
         assertEquals(TRANSLATED_FROM_ENGLISH, translated);
+
+        final String translatedAlternate = i18nProvider.translate(I18N_KEY, resource, true);
+        assertEquals(TRANSLATED_FROM_FRENCH, translatedAlternate);
     }
 
     @Test
@@ -181,7 +192,6 @@ public final class I18nProviderImplTest {
 
     @Test
     public void test_translate_resource_null()  {
-        doReturn(null).when(i18nProvider).i18n(resource);
         assertNull(i18nProvider.translate(null, resource));
     }
 

--- a/bundle/src/test/java/com/adobe/acs/commons/models/injectors/impl/I18NInjectorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/models/injectors/impl/I18NInjectorTest.java
@@ -75,14 +75,20 @@ public class I18NInjectorTest {
         context.registerService(Injector.class, i18nInjector);
         context.registerService(StaticInjectAnnotationProcessorFactory.class, new I18NAnnotationProcessorFactory());
         context.addModelsForClasses(TestModelI18nValueImpl.class);
-        when(i18nService.translate("com.acs.commmons.test", context.currentResource())).thenReturn("Translated from english");
-        when(i18nService.translate("anotherValidI18nField", context.currentResource())).thenReturn("FromNameValue");
+        when(i18nService.translate("com.acs.commmons.test", context.currentResource(), false)).thenReturn("Translated from english");
+        when(i18nService.translate("anotherValidI18nField", context.currentResource(), false)).thenReturn("FromNameValue");
+
+        when(i18nService.translate("com.acs.commmons.test.resource", context.currentResource(), true)).thenReturn("Translated from english - resource");
+        when(i18nService.translate("anotherValidI18nFieldResource", context.currentResource(), true)).thenReturn("FromNameValue - resource");
+
 
         when(i18nService.translate("com.acs.commmons.test", context.request())).thenReturn("Translated from english");
         when(i18nService.translate("anotherValidI18nField", context.request())).thenReturn("FromNameValue");
 
+
         when(i18nService.i18n(context.request())).thenReturn(i18n);
-        when(i18nService.i18n(context.currentResource())).thenReturn(i18n);
+        when(i18nService.i18n(context.currentResource(), false)).thenReturn(i18n);
+        when(i18nService.i18n(context.currentResource(), true)).thenReturn(i18n);
 
     }
 
@@ -113,11 +119,15 @@ public class I18NInjectorTest {
         assertNotNull(adapted);
         assertEquals("Translated from english", adapted.getValidI18nField());
         assertEquals("FromNameValue", adapted.getAnotherValidI18nField());
+        assertEquals("Translated from english - resource", adapted.getValidI18nFieldResource());
+        assertEquals("FromNameValue - resource", adapted.getAnotherValidI18nFieldResource());
         assertNull("we should skip javax.Inject", adapted.getInjectField());
         assertSame(i18n, adapted.getI18n());
+        assertSame(i18n, adapted.getAlternateI18n());
 
         if (adaptable instanceof Resource) {
-            verify(i18nService, times(1)).i18n((Resource) adaptable);
+            verify(i18nService, times(1)).i18n((Resource) adaptable, true);
+            verify(i18nService, times(1)).i18n((Resource) adaptable, false);
         } else if (adaptable instanceof HttpServletRequest) {
             verify(i18nService, times(1)).i18n((HttpServletRequest) adaptable);
         }

--- a/bundle/src/test/java/com/adobe/acs/commons/models/injectors/impl/model/TestModelI18nValue.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/models/injectors/impl/model/TestModelI18nValue.java
@@ -32,4 +32,10 @@ public interface TestModelI18nValue {
     String getInjectField();
 
     I18n getI18n();
+
+    String getValidI18nFieldResource();
+
+    String getAnotherValidI18nFieldResource();
+
+    I18n getAlternateI18n();
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/models/injectors/impl/model/impl/TestModelI18nValueImpl.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/models/injectors/impl/model/impl/TestModelI18nValueImpl.java
@@ -38,14 +38,24 @@ public class TestModelI18nValueImpl implements TestModelI18nValue {
     @I18N("com.acs.commmons.test")
     private String validI18nField;
 
+    @I18N(value = "com.acs.commmons.test.resource", localeIgnoreContent = true, forceRetrievalFromUnderlyingResource = true)
+    private String validI18nFieldResource;
+
     @I18N
     private String invalidI18nField;
 
     @I18N
     private String anotherValidI18nField;
 
+    @I18N(localeIgnoreContent = true, forceRetrievalFromUnderlyingResource = true)
+    private String anotherValidI18nFieldResource;
+
     @Inject
     private I18n i18n;
+
+    @I18N(forceRetrievalFromUnderlyingResource = true, localeIgnoreContent = true)
+    private I18n alternateI18n;
+
 
     @Inject
     private String injectField;
@@ -74,5 +84,20 @@ public class TestModelI18nValueImpl implements TestModelI18nValue {
     @Override
     public I18n getI18n() {
         return i18n;
+    }
+
+    @Override
+    public String getValidI18nFieldResource() {
+        return validI18nFieldResource;
+    }
+
+    @Override
+    public String getAnotherValidI18nFieldResource() {
+        return anotherValidI18nFieldResource;
+    }
+
+    @Override
+    public I18n getAlternateI18n() {
+        return alternateI18n;
     }
 }


### PR DESCRIPTION
Adding (backwards compatible) options to the i18nprovider / injector to:


localeIgnoreContent: this will control the getLocale(boolean localeIgnoreContent) on the CQ Page object, so you have control 

forceRetrievalFromUnderLyingResource - this will force retrieving the i18n from the underlying resource, even if a sling request is being passed.