### PR TITLE
Sort Nodes: tool to sort JCR nodes by node name or title

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/sorter/NodeSorter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/sorter/NodeSorter.java
@@ -1,0 +1,49 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.sorter;
+
+import javax.jcr.Node;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Comparator;
+
+public interface NodeSorter {
+
+    /**
+     * The name of a sorter, e.g. 'byTitle' or 'byMyCustomProperty'
+     * It will be used to find the actual sorter from the {@link SortNodesOperation#RP_SORTER_NAME}
+     * request parameter
+     */
+    String getName();
+
+    /**
+     * Optional label to show in the UI drop-down to select a sorter.
+    */
+    default String getLabel(){
+        return getName();
+    }
+
+    /**
+     * Create a comparator to sort nodes.
+     * Implementations can read additional parameters from request, e.g.
+     * whether search should be case-sensitive, ascending/descending, etc.
+     */
+    Comparator<Node> createComparator(HttpServletRequest request);
+
+ }

--- a/bundle/src/main/java/com/adobe/acs/commons/sorter/SortNodesOperation.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/sorter/SortNodesOperation.java
@@ -41,8 +41,21 @@ import java.util.List;
 import static org.apache.sling.servlets.post.PostOperation.PROP_OPERATION_NAME;
 
 /**
- * The <code>SortNodesOperation</code> class implements the
- * {@link #OPERATION_SORT} operation for the Sling POST servlet.
+ * The <code>SortNodesOperation</code> class implements the {@link #OPERATION_SORT} operation for the Sling POST servlet.
+ * <p>
+ * Use this operation to alphabetize JCR nodes. For example, the following command line sorts the children of the /content/sample page:
+ * <pre>
+ *     curl -u admin:admin -F":operation=acs-commons:sortNodes" http://localhost:4502/content/sample
+ * </pre>
+ * </p>
+ *
+ * You can use optional {@link #RP_CASE_SENSITIVE} and {@link #RP_SORT_BY_TITLE} parameters to control whether to sort by
+ * by node name (default) or by jcr:title and whether the sort should be case-sensitive:
+ * <pre>
+ *     curl -u admin:admin -F":operation=acs-commons:sortNodes" \
+ *     -F":byTitle:true" -F":caseSensitive:true" \
+ *     http://localhost:4502/content/someFolder
+ * </pre>
  */
 @Component(property = {
         PROP_OPERATION_NAME + "=" + SortNodesOperation.OPERATION_SORT
@@ -51,9 +64,10 @@ public class SortNodesOperation implements PostOperation {
     private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     /**
-     * Name of the sort operation
+     * Name of the sort operation.
+     * The acs-commons: prefix is to void name clash with other PostOperations .
      */
-    public static final String OPERATION_SORT = "sort";
+    public static final String OPERATION_SORT = "acs-commons:sortNodes";
 
     /**
      * Name of the request parameter indicating whether to sort nodes by jcr:title
@@ -69,21 +83,51 @@ public class SortNodesOperation implements PostOperation {
      */
     public static final String RP_CASE_SENSITIVE = ":caseSensitive";
 
+    /**
+     * Name of the request parameter indicating whether the sort  should move non-hierarchy nodes to the top
+     *
+     * The default value is true which means jcr:content, rep:policy  and such will be sorted first by their node names
+     * followed by other,hierarchy nodes, e.g :
+     * <pre>
+     *   +  /parent
+     *      -  jcr:content
+     *      -  rep:policy
+     *      -  a
+     *      -  b
+     *      -  c
+     *      -  p
+     * </pre>
+     * If user forces it to <code>false</code> then nodes will be sorted regardless of their hierarchy type:
+     * <pre>
+     *   +  /parent
+     *      -  a
+     *      -  b
+     *      -  c
+     *      -  jcr:content
+     *      -  p
+     *      -  rep:policy
+     * </pre>
+     */
+    public static final String RP_NOT_HIERARCHY_FIRST = ":nonHierarchyFirst";
+
     @Override
     public void run(SlingHttpServletRequest slingRequest, PostResponse response, SlingPostProcessor[] processors) {
         try {
             long t0 = System.currentTimeMillis();
             boolean byTitle = Boolean.parseBoolean(slingRequest.getParameter(RP_SORT_BY_TITLE));
             boolean caseSensitive = Boolean.parseBoolean(slingRequest.getParameter(RP_CASE_SENSITIVE));
+            boolean nonHierarchyFirst = slingRequest.getParameter(RP_NOT_HIERARCHY_FIRST) == null || Boolean.parseBoolean(slingRequest.getParameter(RP_NOT_HIERARCHY_FIRST));
 
             Node targetNode = slingRequest.getResource().adaptTo(Node.class);
             if (targetNode == null) {
                 response.setStatus(HttpServletResponse.SC_NOT_FOUND,"Missing target node to sort: " + slingRequest.getResource().getPath());
                 return;
             }
+            response.setPath(targetNode.getPath());
             response.setLocation(targetNode.getPath());
+            if(targetNode.getParent() != null) response.setParentLocation(targetNode.getParent().getPath());
 
-            Comparator<Node> comparator = createComparator(byTitle, caseSensitive);
+            Comparator<Node> comparator = createComparator(nonHierarchyFirst, byTitle, caseSensitive);
             List<Node> children = getSortedNodes(targetNode, comparator);
 
             Node prev = null;
@@ -99,9 +143,9 @@ public class SortNodesOperation implements PostOperation {
             }
             targetNode.getSession().save();
 
-            response.setTitle("Content sorted " + targetNode.getPath());
+            response.setTitle("Content sorted " + response.getPath());
 
-            log.info("all done, " + children.size() + " nodes sorted in " + (System.currentTimeMillis()-t0) + " ms");
+            log.info("{} nodes sorted in {} ms", children.size(), System.currentTimeMillis()-t0 );
         } catch (RepositoryException e) {
             response.setError(e);
         }
@@ -130,21 +174,26 @@ public class SortNodesOperation implements PostOperation {
     /**
      * Create a comparator to sort nodes
      *
+     * @param nonHierarchyFirst   whether non-hierarchy nodes should go first
      * @param byTitle   whether to sort by jcr:title. If <code>false</code> then sort by node name.
      * @param caseSensitive whether comparison should be case-sensitive
      * @return  comparator
      */
-    static Comparator<Node> createComparator(boolean byTitle, boolean caseSensitive) {
+    static Comparator<Node> createComparator(boolean nonHierarchyFirst, boolean byTitle, boolean caseSensitive) {
 
-        Comparator<Node> comparator = (n1, n2) -> {
-            try {
-                return Boolean.compare(
-                        n1.isNodeType(JcrConstants.NT_HIERARCHYNODE),
-                        n2.isNodeType(JcrConstants.NT_HIERARCHYNODE));
-            } catch (RepositoryException e) {
-                return 0;
-            }
-        };
+        Comparator<Node> comparator = (n1, n2) -> 0;
+
+        if(nonHierarchyFirst){
+            comparator = comparator.thenComparing((n1, n2) -> {
+                try {
+                    return Boolean.compare(
+                            n1.isNodeType(JcrConstants.NT_HIERARCHYNODE),
+                            n2.isNodeType(JcrConstants.NT_HIERARCHYNODE));
+                } catch (RepositoryException e) {
+                    return 0;
+                }
+            });
+        }
 
         if (byTitle) {
             comparator = comparator.thenComparing((n1, n2) -> {

--- a/bundle/src/main/java/com/adobe/acs/commons/sorter/SortNodesOperation.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/sorter/SortNodesOperation.java
@@ -117,7 +117,7 @@ public class SortNodesOperation implements PostOperation {
                 response.setParentLocation(targetNode.getParent().getPath());
             }
 
-            long t0 = System.currentTimeMillis();
+            final long t0 = System.currentTimeMillis();
             Comparator<Node> comparator = getNodeSorter(slingRequest);
             List<Node> children = getSortedNodes(targetNode, comparator);
 
@@ -168,8 +168,8 @@ public class SortNodesOperation implements PostOperation {
         }
         NodeSorter sorter = nodeSorters.get(sorterId);
         if(sorter == null){
-            String msg = "NodeSorter was not found: " + sorterId +
-                    ". Available sorters are: " + nodeSorters.keySet().toString();
+            String msg = "NodeSorter was not found: " + sorterId
+                    + ". Available sorters are: " + nodeSorters.keySet().toString();
             throw new IllegalArgumentException(msg);
         }
         return sorter.createComparator(slingRequest);

--- a/bundle/src/main/java/com/adobe/acs/commons/sorter/SortNodesOperation.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/sorter/SortNodesOperation.java
@@ -58,10 +58,10 @@ import static org.apache.sling.servlets.post.PostOperation.PROP_OPERATION_NAME;
  * by node name (default) or by jcr:title and whether the sort should be case-sensitive:
  * <pre>
  *     curl -u admin:admin -F":operation=acs-commons:sortNodes" \
- *     -F":byTitle:true" -F":caseSensitive:true" \
+ *     -F":sorterName:byTitle" -F":caseSensitive:true" \
  *     http://localhost:4502/content/someFolder
  * </pre>
- */
+  */
 @Component(property = {
         PROP_OPERATION_NAME + "=" + SortNodesOperation.OPERATION_SORT
 })

--- a/bundle/src/main/java/com/adobe/acs/commons/sorter/SortNodesOperation.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/sorter/SortNodesOperation.java
@@ -1,0 +1,177 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.sorter;
+
+import com.day.cq.commons.JcrLabeledResource;
+import org.apache.jackrabbit.JcrConstants;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.servlets.post.PostOperation;
+import org.apache.sling.servlets.post.PostResponse;
+import org.apache.sling.servlets.post.SlingPostProcessor;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.servlet.http.HttpServletResponse;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.apache.sling.servlets.post.PostOperation.PROP_OPERATION_NAME;
+
+/**
+ * The <code>SortNodesOperation</code> class implements the
+ * {@link #OPERATION_SORT} operation for the Sling POST servlet.
+ */
+@Component(property = {
+        PROP_OPERATION_NAME + "=" + SortNodesOperation.OPERATION_SORT
+})
+public class SortNodesOperation implements PostOperation {
+    private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    /**
+     * Name of the sort operation
+     */
+    public static final String OPERATION_SORT = "sort";
+
+    /**
+     * Name of the request parameter indicating whether to sort nodes by jcr:title
+     *
+     * If this request parameter is missing then nodes will be sorted by node name.
+     */
+    public static final String RP_SORT_BY_TITLE = ":byTitle";
+
+    /**
+     * Name of the request parameter indicating whether the sort  should be case sensitive
+     *
+     * If this request parameter is missing then the sort will be case insensitive
+     */
+    public static final String RP_CASE_SENSITIVE = ":caseSensitive";
+
+    @Override
+    public void run(SlingHttpServletRequest slingRequest, PostResponse response, SlingPostProcessor[] processors) {
+        try {
+            long t0 = System.currentTimeMillis();
+            boolean byTitle = Boolean.parseBoolean(slingRequest.getParameter(RP_SORT_BY_TITLE));
+            boolean caseSensitive = Boolean.parseBoolean(slingRequest.getParameter(RP_CASE_SENSITIVE));
+
+            Node targetNode = slingRequest.getResource().adaptTo(Node.class);
+            if (targetNode == null) {
+                response.setStatus(HttpServletResponse.SC_NOT_FOUND,"Missing target node to sort: " + slingRequest.getResource().getPath());
+                return;
+            }
+            response.setLocation(targetNode.getPath());
+
+            Comparator<Node> comparator = createComparator(byTitle, caseSensitive);
+            List<Node> children = getSortedNodes(targetNode, comparator);
+
+            Node prev = null;
+            for (int i = 0; i < children.size(); i++) {
+                Node n = children.get(children.size() - 1 - i);
+                if (prev != null) {
+                    log.trace("orderBefore: {}, {}", n.getName(), prev.getName());
+
+                    targetNode.orderBefore(n.getName(), prev.getName());
+                }
+                response.onChange("ordered", n.getPath(), prev == null ? "" : prev.getName());
+                prev = n;
+            }
+            targetNode.getSession().save();
+
+            response.setTitle("Content sorted " + targetNode.getPath());
+
+            log.info("all done, " + children.size() + " nodes sorted in " + (System.currentTimeMillis()-t0) + " ms");
+        } catch (RepositoryException e) {
+            response.setError(e);
+        }
+    }
+
+    /**
+     * Collect child nodes and sort them using the supplied Comparator
+     *
+     * @param   node   the node who's children need to be sorted
+     * @param   comparator    the comparator to sort nodes
+     * @return  list of sorted nodes
+     * @throws RepositoryException  if something went wrong
+     */
+    List<Node> getSortedNodes(Node node, Comparator<Node> comparator) throws RepositoryException {
+        List<Node> children = new ArrayList<>();
+        NodeIterator it = node.getNodes();
+        while (it.hasNext()) {
+            Node child = it.nextNode();
+            children.add(child);
+        }
+
+        children.sort(comparator);
+        return children;
+    }
+
+    /**
+     * Create a comparator to sort nodes
+     *
+     * @param byTitle   whether to sort by jcr:title. If <code>false</code> then sort by node name.
+     * @param caseSensitive whether comparison should be case-sensitive
+     * @return  comparator
+     */
+    static Comparator<Node> createComparator(boolean byTitle, boolean caseSensitive) {
+
+        Comparator<Node> comparator = (n1, n2) -> {
+            try {
+                return Boolean.compare(
+                        n1.isNodeType(JcrConstants.NT_HIERARCHYNODE),
+                        n2.isNodeType(JcrConstants.NT_HIERARCHYNODE));
+            } catch (RepositoryException e) {
+                return 0;
+            }
+        };
+
+        if (byTitle) {
+            comparator = comparator.thenComparing((n1, n2) -> {
+                try {
+                    String title1 = new JcrLabeledResource(n1).getTitle();
+                    if (title1 == null) title1 = n1.getName();
+                    String title2 = new JcrLabeledResource(n2).getTitle();
+                    if (title2 == null) title2 = n2.getName();
+                    return caseSensitive ? title1.compareTo(title2) :
+                            title1.compareToIgnoreCase(title2);
+                } catch (RepositoryException e) {
+                    return 0;
+                }
+            });
+        } else {
+            comparator = comparator.thenComparing((n1, n2) -> {
+                try {
+                    String name1 = n1.getName();
+                    String name2 = n2.getName();
+                    return caseSensitive ? name1.compareTo(name2) :
+                            name1.compareToIgnoreCase(name2);
+                } catch (RepositoryException e) {
+                    return 0;
+                }
+            });
+        }
+        return comparator;
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/sorter/SortNodesOperation.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/sorter/SortNodesOperation.java
@@ -113,10 +113,10 @@ public class SortNodesOperation implements PostOperation {
     @Override
     public void run(SlingHttpServletRequest slingRequest, PostResponse response, SlingPostProcessor[] processors) {
         try {
-            long t0 = System.currentTimeMillis();
-            boolean byTitle = Boolean.parseBoolean(slingRequest.getParameter(RP_SORT_BY_TITLE));
-            boolean caseSensitive = Boolean.parseBoolean(slingRequest.getParameter(RP_CASE_SENSITIVE));
-            boolean nonHierarchyFirst = slingRequest.getParameter(RP_NOT_HIERARCHY_FIRST) == null || Boolean.parseBoolean(slingRequest.getParameter(RP_NOT_HIERARCHY_FIRST));
+            final long t0 = System.currentTimeMillis();
+            final boolean byTitle = Boolean.parseBoolean(slingRequest.getParameter(RP_SORT_BY_TITLE));
+            final boolean caseSensitive = Boolean.parseBoolean(slingRequest.getParameter(RP_CASE_SENSITIVE));
+            final boolean nonHierarchyFirst = slingRequest.getParameter(RP_NOT_HIERARCHY_FIRST) == null || Boolean.parseBoolean(slingRequest.getParameter(RP_NOT_HIERARCHY_FIRST));
 
             Node targetNode = slingRequest.getResource().adaptTo(Node.class);
             if (targetNode == null) {
@@ -125,7 +125,9 @@ public class SortNodesOperation implements PostOperation {
             }
             response.setPath(targetNode.getPath());
             response.setLocation(targetNode.getPath());
-            if(targetNode.getParent() != null) response.setParentLocation(targetNode.getParent().getPath());
+            if(targetNode.getParent() != null) {
+                response.setParentLocation(targetNode.getParent().getPath());
+            }
 
             Comparator<Node> comparator = createComparator(nonHierarchyFirst, byTitle, caseSensitive);
             List<Node> children = getSortedNodes(targetNode, comparator);
@@ -199,9 +201,13 @@ public class SortNodesOperation implements PostOperation {
             comparator = comparator.thenComparing((n1, n2) -> {
                 try {
                     String title1 = new JcrLabeledResource(n1).getTitle();
-                    if (title1 == null) title1 = n1.getName();
+                    if (title1 == null) {
+                        title1 = n1.getName();
+                    }
                     String title2 = new JcrLabeledResource(n2).getTitle();
-                    if (title2 == null) title2 = n2.getName();
+                    if (title2 == null) {
+                        title2 = n2.getName();
+                    }
                     return caseSensitive ? title1.compareTo(title2) :
                             title1.compareToIgnoreCase(title2);
                 } catch (RepositoryException e) {

--- a/bundle/src/main/java/com/adobe/acs/commons/sorter/SortersPojo.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/sorter/SortersPojo.java
@@ -34,7 +34,7 @@ public class SortersPojo extends WCMUsePojo {
 
     @Override
     public void activate(){
-
+        // no op
     }
 
     public Collection<NodeSorter> getAvailableSorters(){

--- a/bundle/src/main/java/com/adobe/acs/commons/sorter/SortersPojo.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/sorter/SortersPojo.java
@@ -1,0 +1,45 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.sorter;
+
+import com.adobe.cq.sightly.WCMUsePojo;
+import org.osgi.annotation.versioning.ProviderType;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Produce a list of available sorters to populate the drop-down on the sort-nodes.html page.
+ */
+@ProviderType
+public class SortersPojo extends WCMUsePojo {
+
+    @Override
+    public void activate(){
+
+    }
+
+    public Collection<NodeSorter> getAvailableSorters(){
+        NodeSorter[] sorters = getSlingScriptHelper().getServices(NodeSorter.class, null);
+        return sorters == null ? Collections.emptyList() : Arrays.asList(sorters);
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/sorter/impl/HierarchyNodeComparator.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/sorter/impl/HierarchyNodeComparator.java
@@ -1,0 +1,45 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.sorter.impl;
+
+import org.apache.jackrabbit.JcrConstants;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import java.util.Comparator;
+
+class HierarchyNodeComparator implements Comparator<Node> {
+    public static final String RP_NOT_HIERARCHY_FIRST = ":nonHierarchyFirst";
+
+    public static HierarchyNodeComparator INSTANCE = new HierarchyNodeComparator();
+
+    private HierarchyNodeComparator(){}
+
+    @Override
+    public int compare(Node n1, Node n2) {
+        try {
+            return Boolean.compare(
+                    n1.isNodeType(JcrConstants.NT_HIERARCHYNODE),
+                    n2.isNodeType(JcrConstants.NT_HIERARCHYNODE));
+        } catch (RepositoryException e) {
+            return 0;
+        }
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/sorter/impl/HierarchyNodeComparator.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/sorter/impl/HierarchyNodeComparator.java
@@ -30,7 +30,9 @@ class HierarchyNodeComparator implements Comparator<Node> {
 
     public static HierarchyNodeComparator INSTANCE = new HierarchyNodeComparator();
 
-    private HierarchyNodeComparator(){}
+    private HierarchyNodeComparator(){
+        // ensure singleton
+    }
 
     @Override
     public int compare(Node n1, Node n2) {

--- a/bundle/src/main/java/com/adobe/acs/commons/sorter/impl/NodeNameSorter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/sorter/impl/NodeNameSorter.java
@@ -45,8 +45,8 @@ public class NodeNameSorter implements NodeSorter {
     @Override
     public Comparator<Node> createComparator(HttpServletRequest request) {
         boolean caseSensitive = Boolean.parseBoolean(request.getParameter(RP_CASE_SENSITIVE));
-        boolean nonHierarchyFirst = request.getParameter(RP_NOT_HIERARCHY_FIRST) == null ||
-                Boolean.parseBoolean(request.getParameter(RP_NOT_HIERARCHY_FIRST));
+        boolean nonHierarchyFirst = request.getParameter(RP_NOT_HIERARCHY_FIRST) == null
+                || Boolean.parseBoolean(request.getParameter(RP_NOT_HIERARCHY_FIRST));
         Comparator<Node> parentComparator = nonHierarchyFirst ? HierarchyNodeComparator.INSTANCE : (n1, n2) -> 0;
         return parentComparator.thenComparing((n1, n2) -> {
             try {

--- a/bundle/src/main/java/com/adobe/acs/commons/sorter/impl/NodeNameSorter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/sorter/impl/NodeNameSorter.java
@@ -1,0 +1,63 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.sorter.impl;
+
+import com.adobe.acs.commons.sorter.NodeSorter;
+import org.osgi.service.component.annotations.Component;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Comparator;
+
+import static com.adobe.acs.commons.sorter.impl.HierarchyNodeComparator.RP_NOT_HIERARCHY_FIRST;
+
+@Component
+public class NodeNameSorter implements NodeSorter {
+    public static final String SORTER_NAME = "byName";
+    public static final String RP_CASE_SENSITIVE = ":caseSensitive";
+
+    public String getName(){
+        return SORTER_NAME;
+    }
+
+    public String getLabel(){
+        return "By Node Name";
+    }
+
+    @Override
+    public Comparator<Node> createComparator(HttpServletRequest request) {
+        boolean caseSensitive = Boolean.parseBoolean(request.getParameter(RP_CASE_SENSITIVE));
+        boolean nonHierarchyFirst = request.getParameter(RP_NOT_HIERARCHY_FIRST) == null ||
+                Boolean.parseBoolean(request.getParameter(RP_NOT_HIERARCHY_FIRST));
+        Comparator<Node> parentComparator = nonHierarchyFirst ? HierarchyNodeComparator.INSTANCE : (n1, n2) -> 0;
+        return parentComparator.thenComparing((n1, n2) -> {
+            try {
+                String name1 = n1.getName();
+                String name2 = n2.getName();
+                return caseSensitive ? name1.compareTo(name2) :
+                        name1.compareToIgnoreCase(name2);
+            } catch (RepositoryException e) {
+                return 0;
+            }
+        });
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/sorter/impl/NodeTitleSorter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/sorter/impl/NodeTitleSorter.java
@@ -1,0 +1,70 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.sorter.impl;
+
+import com.adobe.acs.commons.sorter.NodeSorter;
+import com.day.cq.commons.JcrLabeledResource;
+import org.osgi.service.component.annotations.Component;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Comparator;
+
+import static com.adobe.acs.commons.sorter.impl.HierarchyNodeComparator.RP_NOT_HIERARCHY_FIRST;
+
+@Component
+public class NodeTitleSorter implements NodeSorter {
+
+    public static final String SORTER_NAME = "byTitle";
+    public static final String RP_CASE_SENSITIVE = ":caseSensitive";
+
+    public String getName(){
+        return SORTER_NAME;
+    }
+
+    public String getLabel(){
+        return "By Node Title";
+    }
+
+    @Override
+    public Comparator<Node> createComparator(HttpServletRequest request) {
+        boolean caseSensitive = Boolean.parseBoolean(request.getParameter(RP_CASE_SENSITIVE));
+        boolean nonHierarchyFirst = request.getParameter(RP_NOT_HIERARCHY_FIRST) == null ||
+                Boolean.parseBoolean(request.getParameter(RP_NOT_HIERARCHY_FIRST));
+        Comparator<Node> parentComparator = nonHierarchyFirst ? HierarchyNodeComparator.INSTANCE : (n1, n2) -> 0;
+        return parentComparator.thenComparing((n1, n2) -> {
+            try {
+                String title1 = new JcrLabeledResource(n1).getTitle();
+                if (title1 == null) {
+                    title1 = n1.getName();
+                }
+                String title2 = new JcrLabeledResource(n2).getTitle();
+                if (title2 == null) {
+                    title2 = n2.getName();
+                }
+                return caseSensitive ? title1.compareTo(title2) :
+                        title1.compareToIgnoreCase(title2);
+            } catch (RepositoryException e) {
+                return 0;
+            }
+        });
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/sorter/impl/NodeTitleSorter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/sorter/impl/NodeTitleSorter.java
@@ -47,8 +47,8 @@ public class NodeTitleSorter implements NodeSorter {
     @Override
     public Comparator<Node> createComparator(HttpServletRequest request) {
         boolean caseSensitive = Boolean.parseBoolean(request.getParameter(RP_CASE_SENSITIVE));
-        boolean nonHierarchyFirst = request.getParameter(RP_NOT_HIERARCHY_FIRST) == null ||
-                Boolean.parseBoolean(request.getParameter(RP_NOT_HIERARCHY_FIRST));
+        boolean nonHierarchyFirst = request.getParameter(RP_NOT_HIERARCHY_FIRST) == null
+                || Boolean.parseBoolean(request.getParameter(RP_NOT_HIERARCHY_FIRST));
         Comparator<Node> parentComparator = nonHierarchyFirst ? HierarchyNodeComparator.INSTANCE : (n1, n2) -> 0;
         return parentComparator.thenComparing((n1, n2) -> {
             try {

--- a/bundle/src/main/java/com/adobe/acs/commons/sorter/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/sorter/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+/**
+ * Miscellaneous Utilities.
+ */
+@Version("1.0.0")
+
+package com.adobe.acs.commons.sorter;
+import org.osgi.annotation.versioning.Version;

--- a/bundle/src/test/java/com/adobe/acs/commons/sorter/SortNodesOperationTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/sorter/SortNodesOperationTest.java
@@ -204,7 +204,7 @@ public class SortNodesOperationTest {
         sorter.run(request, response, null);
 
         verify(response).setError(errCaptor.capture());
-        assertEquals("NodeSorter was not found: sorterNA. Available sorters are: [:nodeNameSorter, :nodeTitleSorter]",
+        assertEquals("NodeSorter was not found: sorterNA. Available sorters are: [byName, byTitle]",
                 errCaptor.getValue().getMessage());
     }
 

--- a/bundle/src/test/java/com/adobe/acs/commons/sorter/SortNodesOperationTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/sorter/SortNodesOperationTest.java
@@ -1,0 +1,155 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.sorter;
+
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.servlets.post.PostResponse;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Spy;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class SortNodesOperationTest {
+    @Rule
+    public final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
+
+    @Spy
+    private SortNodesOperation sorter = new SortNodesOperation();
+
+    @Before
+    public void setUp(){
+        context.build()
+                .resource("/sortable", JCR_PRIMARYTYPE, "cq:Page")
+                .resource("/sortable/page2", JCR_PRIMARYTYPE, "cq:Page")
+                .resource("/sortable/page2/jcr:content", JCR_PRIMARYTYPE, "cq:PageContent", "jcr:title", "A: Page-2")
+                .resource("/sortable/jcr:content", JCR_PRIMARYTYPE, "nt:unstructured")
+                .resource("/sortable/page1", JCR_PRIMARYTYPE, "cq:Page")
+                .resource("/sortable/Page3/jcr:content", JCR_PRIMARYTYPE, "cq:PageContent", "jcr:title", "C: Page-3")
+                .resource("/sortable/Page3", JCR_PRIMARYTYPE, "cq:Page")
+                .resource("/sortable/page1/jcr:content", JCR_PRIMARYTYPE, "cq:PageContent", "jcr:title", "a: Page-1")
+                .resource("/sortable/rep:policy", JCR_PRIMARYTYPE, "rep:ACL");
+    }
+
+    /**
+     * by node name, case insensitive
+     */
+    @Test
+    public void testSortByNameCaseInsensitive() throws RepositoryException {
+        Comparator<Node> comparator =  SortNodesOperation.createComparator(false, false);
+        Node node = context.resourceResolver().getResource("/sortable").adaptTo(Node.class);
+        List<Node> list = sorter.getSortedNodes(node, comparator);
+
+        assertSortOrder(Arrays.asList("jcr:content", "rep:policy", "page1", "page2", "Page3"), list);
+
+    }
+
+    /**
+     * by node name, case sensitive
+     */
+    @Test
+    public void testSortByNameCaseSensitive() throws RepositoryException {
+        Comparator<Node> comparator =  SortNodesOperation.createComparator(false, true);
+        Node node = context.resourceResolver().getResource("/sortable").adaptTo(Node.class);
+        List<Node> list = sorter.getSortedNodes(node, comparator);
+
+        assertSortOrder(Arrays.asList("jcr:content", "rep:policy", "Page3", "page1", "page2"), list);
+
+    }
+
+    /**
+     * by title, case insensitive
+     */
+    @Test
+    public void testSortByTitleCaseInsensitive() throws RepositoryException {
+        Comparator<Node> comparator =  SortNodesOperation.createComparator(true, false);
+        Node node = context.resourceResolver().getResource("/sortable").adaptTo(Node.class);
+        List<Node> list = sorter.getSortedNodes(node, comparator);
+
+        assertSortOrder(Arrays.asList("jcr:content", "rep:policy", "page1" /*a: Page-1*/, "page2" /*A: Page-2*/, "Page3" /*C: Page-3*/), list);
+
+    }
+
+    /**
+     * by title, case sensitive
+     */
+    @Test
+    public void testSortByTitleCaseSensitive() throws RepositoryException {
+        Comparator<Node> comparator =  SortNodesOperation.createComparator(true, true);
+        Node node = context.resourceResolver().getResource("/sortable").adaptTo(Node.class);
+        List<Node> list = sorter.getSortedNodes(node, comparator);
+
+        assertSortOrder(Arrays.asList("jcr:content", "rep:policy", "page2" /*A: Page-2*/, "Page3" /*C: Page-3*/, "page1" /*a: Page-1*/), list);
+    }
+
+    @Test
+    public void testDefaultRequestParameters() throws RepositoryException {
+        Resource resource  = context.resourceResolver().getResource("/sortable");
+        MockSlingHttpServletRequest request = context.request();
+        request.setResource(resource);
+        sorter.run(context.request(), mock(PostResponse.class), null);
+
+        List<Node> children = new ArrayList<>();
+        resource.getChildren().forEach(r -> children.add(r.adaptTo(Node.class)));
+
+        assertSortOrder(Arrays.asList("jcr:content", "rep:policy", "page1", "page2", "Page3"), children);
+    }
+
+    @Test
+    public void testRequestParameters() throws RepositoryException {
+        Resource resource  = context.resourceResolver().getResource("/sortable");
+        MockSlingHttpServletRequest request = context.request();
+        request.addRequestParameter(SortNodesOperation.RP_SORT_BY_TITLE, "true");
+        request.addRequestParameter(SortNodesOperation.RP_CASE_SENSITIVE, "true");
+        request.setResource(resource);
+        sorter.run(context.request(), mock(PostResponse.class), null);
+
+        List<Node> children = new ArrayList<>();
+        resource.getChildren().forEach(r -> children.add(r.adaptTo(Node.class)));
+
+        assertSortOrder(Arrays.asList("jcr:content", "rep:policy", "page2" /*A: Page-2*/, "Page3" /*C: Page-3*/, "page1" /*a: Page-1*/), children);
+    }
+
+    private static void assertSortOrder(List<String> expected, List<Node> list){
+        List<String> actual = list.stream().map(n -> {
+            try {
+                return n.getName();
+            } catch (RepositoryException e) {
+                throw new RuntimeException(e);
+            }
+        }).collect(Collectors.toList());
+        assertEquals(expected, actual);
+
+    }
+ }

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/sort-nodes/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/sort-nodes/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+          xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Component"
+    jcr:title="Sort Nodes"
+    cq:defaultView="html"
+    sling:resourceSuperType="acs-commons/components/utilities/app-page"
+    componentGroup=".hidden"/>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/sort-nodes/clientlibs/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/sort-nodes/clientlibs/.content.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ #%L
+  ~ ACS AEM Commons Bundle
+  ~ %%
+  ~ Copyright (C) 2013 Adobe
+  ~ %%
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~ #L%
+  -->
+
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
+          xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          jcr:primaryType="cq:ClientLibraryFolder"
+          categories="[acs-commons.sort-nodes]"/>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/sort-nodes/clientlibs/js.txt
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/sort-nodes/clientlibs/js.txt
@@ -1,0 +1,3 @@
+#base=js
+
+app.js

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/sort-nodes/clientlibs/js/app.js
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/sort-nodes/clientlibs/js/app.js
@@ -1,0 +1,45 @@
+(function (window, document, $) {
+    "use strict";
+
+    $(document).on("click", ".sort-nodes-button", function (e) {
+    	e.preventDefault();
+        var form = $(this).closest('form');
+        var data = form.serialize();
+        var pathInput = $(form).find(".js-coral-pathbrowser-input");
+        var path = pathInput[0].value;
+        if(!path){
+			pathInput.attr("required", "true");
+            return;
+        }
+        $.ajax({
+            url: path,
+            type: "POST",
+            data: data
+        }).success(function(response){
+			var changes = response.changes;
+            var html = changes.reverse().map(function(c){ return "<li>" + c.argument[0] + "</li>"; } ).join("");
+
+            var dialog = new Coral.Dialog();
+            dialog.id = 'dialogSuccess';
+            dialog.header.innerHTML = 'Success';
+    		dialog.content.innerHTML = html;
+            dialog.footer.innerHTML = '<button class="ok-button" is="coral-button" variant="primary" icon="check" coral-close>OK</button>';
+            dialog.variant = 'success';
+            dialog.closable = "on";
+            dialog.show();
+
+        }).error(function(response){
+            var dialog = new Coral.Dialog();
+            dialog.id = 'dialogFailure';
+            dialog.header.innerHTML = 'Failure';
+    		dialog.content.innerHTML = response.responseJSON["status.message"];
+    		dialog.footer.innerHTML = '<button class="error-button" is="coral-button" variant="primary" icon="check" coral-close>OK</button>';
+            dialog.variant = 'error';
+            dialog.closable = "on";
+            dialog.show();
+        });
+
+
+    });
+
+})(window, document, $);

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/sort-nodes/sort-nodes.html
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/sort-nodes/sort-nodes.html
@@ -44,29 +44,31 @@
         <form id="sort-nodes-form" action="" enctype="multipart/form-data" method="post" novalidate=""
               class="coral-Form coral-Form--vertical foundation-layout-util-vmargin foundation-form" data-foundation-form-ajax="true" data-foundation-form-loadingmask="true">
             <input type="hidden" name=":http-equiv-accept" value="application/json"/>
-            <input type="hidden" name=":operation" value="sort"/>
+            <input type="hidden" name=":operation" value="acs-commons:sortNodes"/>
             <section  class="coral-Form-fieldset">
                 <div  class="coral-Form-fieldwrapper">
                     <label class="coral-Form-fieldlabel">Path *</label>
                     <span  class="coral-Form-field coral-PathBrowser" data-init="pathbrowser" data-root-path="/content" data-option-loader="granite.ui.pathBrowser.pages.folder"
-                           data-picker-src="/libs/wcm/core/content/common/pathbrowser/column.html/content?predicate=hierarchyNotFile" data-crumb-root="content" data-picker-multiselect="false" data-root-path-valid-selection="true">
-    <span class="coral-InputGroup coral-InputGroup--block">
-        <input  class="coral-InputGroup-input js-coral-pathbrowser-input" type="text" name="./destinationPath" autocomplete="off" is="coral-textfield" placeholder="/content/someFolder">
-        <span class="coral-InputGroup-button">
-            <button  class="js-coral-pathbrowser-button" type="button" title="Browse" is="coral-button" icon="folderSearch" iconsize="S"></button>
-        </span>
-    </span>
-</span>
+                           data-picker-src="/libs/wcm/core/content/common/pathbrowser/column.html/content?predicate=hierarchyNotFile"
+                           data-crumb-root="content" data-picker-multiselect="false" data-root-path-valid-selection="true">
+                        <span class="coral-InputGroup coral-InputGroup--block">
+                            <input  class="coral-InputGroup-input js-coral-pathbrowser-input" type="text" name="./destinationPath" autocomplete="off"
+                                    is="coral-textfield" placeholder="/content/someFolder">
+                            <span class="coral-InputGroup-button">
+                                <button  class="js-coral-pathbrowser-button" type="button" title="Browse" is="coral-button" icon="folderSearch" iconsize="S"></button>
+                            </span>
+                        </span>
+                    </span>
                 </div>
 
                 <div  class="foundation-field-edit coral-Form-fieldwrapper coral-Form-fieldwrapper--singleline">
                     <coral-checkbox  data-allowBulkEdit="true" name="./:byTitle" value="true" class="coral-Form-field">
-                        <coral-checkbox-label>Sort By Title</coral-checkbox-label>
+                        <coral-checkbox-label>Sort By Title. If unchecked nodes will be sorted by name</coral-checkbox-label>
                     </coral-checkbox>
                 </div>
                 <div  class="foundation-field-edit coral-Form-fieldwrapper coral-Form-fieldwrapper--singleline">
                     <coral-checkbox  data-allowBulkEdit="true" name="./:caseSensitive" value="true" class="coral-Form-field">
-                        <coral-checkbox-label>Case Sensitive</coral-checkbox-label>
+                        <coral-checkbox-label>Case Sensitive Sort</coral-checkbox-label>
                     </coral-checkbox>
                 </div>
 

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/sort-nodes/sort-nodes.html
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/sort-nodes/sort-nodes.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<head>
+    <link rel="shortcut icon" href="/libs/granite/core/content/login/favicon.ico">
+</head>
+<body class="coral--light foundation-layout-util-maximized-alt">
+<sly data-sly-call="${clientLib.all @ categories=['coralui3','granite.ui.coral.foundation','granite.ui.shell','cq.authoring.dialog', 'acs-commons.sort-nodes']}"
+     data-sly-use.clientLib="/libs/granite/sightly/templates/clientlib.html"/>
+
+<coral-shell-header aria-hidden="false" aria-label="Header Bar"
+                    class="coral--dark granite-shell-header coral3-Shell-header"
+                    role="region">
+    <coral-shell-header-home aria-level="2" class="globalnav-toggle" data-globalnav-toggle-href="/" role="heading">
+        <a class="coral3-Shell-homeAnchor" href="/"
+           icon="adobeExperienceManagerColor" is="coral-shell-homeanchor"
+           style="display: inline-block; padding-right: 0;">
+            <coral-icon
+                    aria-label="adobe experience manager color"
+                    class="coral3-Icon coral3-Shell-homeAnchor-icon coral3-Icon--adobeExperienceManagerColor coral3-Icon--sizeM"
+                    icon="adobeExperienceManagerColor" role="img"
+                    size="M"></coral-icon>
+            <coral-shell-homeanchor-label>Adobe Experience Manager
+            </coral-shell-homeanchor-label>
+        </a>
+        <span style="line-height: 2.375rem;">/ ACS AEM Commons / ${properties.jcr:title} </span>
+    </coral-shell-header-home>
+</coral-shell-header>
+
+
+<div class="foundation-layout-panel">
+    <div class="foundation-layout-panel-header">
+        <betty-titlebar>
+            <betty-titlebar-title>
+                <span aria-level="1" class="granite-title" role="heading">${properties.jcr:title}</span>
+            </betty-titlebar-title>
+            <betty-titlebar-primary></betty-titlebar-primary>
+            <betty-titlebar-secondary>
+            </betty-titlebar-secondary>
+        </betty-titlebar>
+    </div>
+    <div class="content-container-inner" style="width:60%; margin:0 auto;">
+
+
+
+        <form id="sort-nodes-form" action="" enctype="multipart/form-data" method="post" novalidate=""
+              class="coral-Form coral-Form--vertical foundation-layout-util-vmargin foundation-form" data-foundation-form-ajax="true" data-foundation-form-loadingmask="true">
+            <input type="hidden" name=":http-equiv-accept" value="application/json"/>
+            <input type="hidden" name=":operation" value="sort"/>
+            <section  class="coral-Form-fieldset">
+                <div  class="coral-Form-fieldwrapper">
+                    <label class="coral-Form-fieldlabel">Path *</label>
+                    <span  class="coral-Form-field coral-PathBrowser" data-init="pathbrowser" data-root-path="/content" data-option-loader="granite.ui.pathBrowser.pages.folder"
+                           data-picker-src="/libs/wcm/core/content/common/pathbrowser/column.html/content?predicate=hierarchyNotFile" data-crumb-root="content" data-picker-multiselect="false" data-root-path-valid-selection="true">
+    <span class="coral-InputGroup coral-InputGroup--block">
+        <input  class="coral-InputGroup-input js-coral-pathbrowser-input" type="text" name="./destinationPath" autocomplete="off" is="coral-textfield" placeholder="/content/someFolder">
+        <span class="coral-InputGroup-button">
+            <button  class="js-coral-pathbrowser-button" type="button" title="Browse" is="coral-button" icon="folderSearch" iconsize="S"></button>
+        </span>
+    </span>
+</span>
+                </div>
+
+                <div  class="foundation-field-edit coral-Form-fieldwrapper coral-Form-fieldwrapper--singleline">
+                    <coral-checkbox  data-allowBulkEdit="true" name="./:byTitle" value="true" class="coral-Form-field">
+                        <coral-checkbox-label>Sort By Title</coral-checkbox-label>
+                    </coral-checkbox>
+                </div>
+                <div  class="foundation-field-edit coral-Form-fieldwrapper coral-Form-fieldwrapper--singleline">
+                    <coral-checkbox  data-allowBulkEdit="true" name="./:caseSensitive" value="true" class="coral-Form-field">
+                        <coral-checkbox-label>Case Sensitive</coral-checkbox-label>
+                    </coral-checkbox>
+                </div>
+
+            </section>
+
+            <coral-actionbar-item class="coral3-ActionBar-item">
+                <button class="coral3-Button coral3-Button--primary sort-nodes-button" icon="checkCircle" iconsize="S"
+                        is="coral-button"
+                        size="M" variant="primary">
+                    <coral-icon alt="" class="coral3-Icon coral3-Icon--sizeS coral3-Icon--checkCircle" icon="reorder"
+                                size="S"></coral-icon>
+                    <coral-button-label>
+                        Sort Nodes
+                    </coral-button-label>
+                </button>
+            </coral-actionbar-item>
+        </form>
+    </div>
+</div>
+</body>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/sort-nodes/sort-nodes.html
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/sort-nodes/sort-nodes.html
@@ -48,27 +48,49 @@
             <section  class="coral-Form-fieldset">
                 <div  class="coral-Form-fieldwrapper">
                     <label class="coral-Form-fieldlabel">Path *</label>
-                    <span  class="coral-Form-field coral-PathBrowser" data-init="pathbrowser" data-root-path="/content" data-option-loader="granite.ui.pathBrowser.pages.folder"
-                           data-picker-src="/libs/wcm/core/content/common/pathbrowser/column.html/content?predicate=hierarchyNotFile"
-                           data-crumb-root="content" data-picker-multiselect="false" data-root-path-valid-selection="true">
-                        <span class="coral-InputGroup coral-InputGroup--block">
-                            <input  class="coral-InputGroup-input js-coral-pathbrowser-input" type="text" name="./destinationPath" autocomplete="off"
-                                    is="coral-textfield" placeholder="/content/someFolder">
-                            <span class="coral-InputGroup-button">
-                                <button  class="js-coral-pathbrowser-button" type="button" title="Browse" is="coral-button" icon="folderSearch" iconsize="S"></button>
-                            </span>
-                        </span>
-                    </span>
-                </div>
 
-                <div  class="foundation-field-edit coral-Form-fieldwrapper coral-Form-fieldwrapper--singleline">
-                    <coral-checkbox  data-allowBulkEdit="true" name="./:byTitle" value="true" class="coral-Form-field">
-                        <coral-checkbox-label>Sort By Title. If unchecked nodes will be sorted by name</coral-checkbox-label>
-                    </coral-checkbox>
+
+
+                    <span class="coral-PathBrowser coral-Form-field"
+                          data-init="pathbrowser" data-root-path="/"
+                          data-option-loader="granite.ui.pathBrowser.pages.hierarchyNotFile"
+                          data-picker-src="/libs/wcm/core/content/common/pathbrowser/column.html/content?predicate=hierarchyNotFile"
+                          data-picker-title="Select Source Path"
+                          data-delay="30000"
+                          data-picker-multiselect="false" data-root-path-valid-selection="false">
+                     <span
+                             class="coral-InputGroup coral-InputGroup--block">
+                        <input
+                                class="coral-InputGroup-input js-coral-pathbrowser-input coral-Textfield source"
+                                is="coral-textfield" placeholder="Select/Enter source path"
+                                name="./destinationPath" value="" aria-invalid="false"
+                                aria-haspopup="true" aria-expanded="false" aria-owns="coral-26"
+                                required placeholder="/content/someFolder">
+                        <span class="coral-InputGroup-button">
+                           <button
+                                   class="js-coral-pathbrowser-button coral-Button coral-Button--secondary"
+                                   type="button" title="Browse" is="coral-button"
+                                   icon="folderSearch" iconsize="S" size="M" variant="secondary">
+                              <coral-icon
+                                      class="coral-Icon coral-Icon--sizeS coral-Icon--folderSearch"
+                                      icon="folderSearch" size="S" role="img"
+                                      aria-label="folder search"></coral-icon>
+                           </button>
+                        </span>
+                     </span>
+                  </span>
+
+                </div>
+                <div class="foundation-field-edit coral-Form-fieldwrapper coral-Form-fieldwrapper--singleline"
+                     data-sly-use.defs="com.adobe.acs.commons.sorter.SortersPojo">
+                    <label class="coral-Form-fieldlabel">Sorter</label>
+                    <coral-select class="coral-Form-field" id="sorterDefinitionSelector" name=":sorterName" data-sly-list="${defs.availableSorters}">
+                        <coral-select-item value="${item.name}">${item.label}</coral-select-item>
+                    </coral-select>
                 </div>
                 <div  class="foundation-field-edit coral-Form-fieldwrapper coral-Form-fieldwrapper--singleline">
                     <coral-checkbox  data-allowBulkEdit="true" name="./:caseSensitive" value="true" class="coral-Form-field">
-                        <coral-checkbox-label>Case Sensitive Sort</coral-checkbox-label>
+                        <coral-checkbox-label>Case Sensitive</coral-checkbox-label>
                     </coral-checkbox>
                 </div>
 

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/sort-nodes/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/sort-nodes/.content.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:Page">
+    <jcr:content
+        jcr:primaryType="cq:PageContent"
+        jcr:title="Sort Nodes"
+        sling:resourceType="acs-commons/components/utilities/sort-nodes"/>
+</jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/sort-nodes/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/sort-nodes/.content.xml
@@ -3,6 +3,6 @@
     jcr:primaryType="cq:Page">
     <jcr:content
         jcr:primaryType="cq:PageContent"
-        jcr:title="Sort Nodes"
+        jcr:title="Sort JCR Nodes"
         sling:resourceType="acs-commons/components/utilities/sort-nodes"/>
 </jcr:root>

--- a/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/acs-commons/sort-nodes/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/acs-commons/sort-nodes/.content.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+    jcr:primaryType="nt:unstructured"
+    jcr:title="Sort Nodes"
+    jcr:description="Sort nodes by name or title"
+    icon="reorder"
+    href="/apps/acs-commons/content/sort-nodes.html"
+    id="acs-commons__sort-nodes"
+    target="_blank"/>


### PR DESCRIPTION
Sometimes it is useful to re-order nodes in the repository by node name or title so that:
1. Nodes are sorted in all views in AEM TouchUI. Only the List View of the 'collectionpage' container in AEM supports sorting, other views like Card and Column print items in the default order which is by jcr:created.  This makes it difficult to browse pages or tags with large number of children. 
2. Node iterators in Java return sorted data. 
3. User can choose whether to sort by node name or jcr:title

The patch extends the Sling POST Servlet with the _acs-commons:sortNodes_ operation and and a simple GUI to execute it:

####  sort children of /content/someFolder by node name, case-insensitive (defaults)
```
curl -F":operation=acs-commons:sortNodes" http://localhost:4502/content/someFolder
```
####  sort children of /content/someFolder by jcr:title, case-sensitive 
```
curl -F":operation=acs-commons:sortNodes" \
-F":sorterName=byTitle" \
-F":caseSensitive=true" \
http://localhost:4502/content/someFolder
```

#### AEM GUI
In AEM, navigate to the Tools > ACS AEM Commons > Sort JCR Nodes

In the path field, enter the the target path to sort. You can choose whether to sort by node name (default) or by jcr:title and whether sort should be case-sensitive.

![image](https://user-images.githubusercontent.com/2543854/110210726-15c68480-7ea4-11eb-960e-c31c974c16ff.png)

### Request Parameters
#### `:sorterName`
To select the actual sorter to execute, the `:sorterName` request parameter is used. Out of the box, the SortNodesOperation supports the following sorters:

| Sorter | Description |
| --------------- | --------------- | 
| `byName` | Sort nodes by node name (default) |
| `byTitle` |Sort nodes by jcr:title. The code will use the value of the jcr:title property of the underlying node or of it's jcr:content child node if it exists or default to node name of jcr:title was not found |


#### `:caseSensitive`

Optional boolean parameter to control whether sort should be case sensitive (default: `false`), e.g.
```  
+  /content/someFolder
     -  a           
     -  A           
     -  b           
     -  B           
```
You can turn it off by setting the `-F":caseSensitive=true"` request parameter and the order will change to
```  
+  /content/someFolder
     -  A           
     -  B           
     -  a           
     -  b           
```

#### `:nonHierarchyFirst`

Optional boolean parameter to control whether sort should move non-hierarchy nodes to the top (default: `true`)

The default value is `true` which means jcr:content, rep:policy and such will be sorted first followed by other, hierarchy nodes like cq:Page, e.g. 
```  
+  /content/someFolder
     -  jcr:content // non-hierarchy
     -  rep:policy  // non-hierarchy
     -  a           // cq:Page
     -  b           // cq:Page
     -  c           // cq:Page
     -  p           // cq:Page
```

You can turn it off by setting the `-F":nonHierarchyFirst=false"` parameter
which will switch the mode to sort nodes regardless if they are `nt:hierarchyNode` or not
```  
+  /content/someFolder
     -  a           // cq:Page
     -  b           // cq:Page
     -  c           // cq:Page
     -  jcr:content // non-hierarchy
     -  p           // cq:Page
     -  rep:policy  // non-hierarchy
```

## Extending SortNodesOperation

OSGi services of the com.adobe.acs.commons.sorter.NodeSorter type can be used to implement new node sorters. For example, to register a sorter by _sling:resourceType_  deploy the service below:

```java
import com.adobe.acs.commons.sorter.NodeSorter;
import org.apache.jackrabbit.commons.JcrUtils;
import org.osgi.service.component.annotations.Component;

import javax.jcr.Node;
import javax.jcr.RepositoryException;
import javax.servlet.http.HttpServletRequest;
import java.util.Comparator;


@Component
public class ResourceTypeSorter implements NodeSorter {

    /**
     * A unique name which will be used to find the actual sorter by the
     * <code>:sorterName</code> request parameter
     */
    @Override
    public String getName() {
        return "resourceType";
    }

    /**
     * The label that will appear in the 'Select Sorter' drop-down in UI
     */
    @Override
    public String getLabel() {
        return "By resource type";
    }

    /**
     * Create a comparator to sort nodes.
     * Implementations can read additional parameters from request, e.g.
      * whether search should be case-sensitive, ascending/descending, etc.
    */
    @Override
    public Comparator<Node> createComparator(HttpServletRequest request) {

        return (n1, n2) -> {
            try {
                String val1 = JcrUtils.getStringProperty(n1, "jcr:content/sling:resourceType", "");
                String val2 = JcrUtils.getStringProperty(n2, "jcr:content/sling:resourceType", "");
                return val1.compareTo(val2);
            } catch (RepositoryException e) {
                return 0;
            }
        };
    }

}
```

Once the _ResourceTypeSorter_ service is deployed you should be able to select the new sorter in the UI: 

![image](https://user-images.githubusercontent.com/2543854/110210764-4c040400-7ea4-11eb-8a4d-9050c315461c.png)


or pass it as `-F":sorterName=resourceType"` request parameter to curl:

```
curl -F":operation=acs-commons:sortNodes" -F":sorterName=resourceType" \
   http://localhost:4502/content/we-retail
```
Documentation is in another PR: https://github.com/Adobe-Consulting-Services/adobe-consulting-services.github.io/pull/205
