### PR TITLE
Issue 2548

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
@@ -43,6 +43,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
@@ -101,7 +102,8 @@ import static org.osgi.framework.Constants.SERVICE_ID;
 /**
  * A request filter that implements support for virtual redirects.
  */
-@Component(service = {Filter.class, RedirectFilterMBean.class, EventHandler.class}, property = {
+@Component(service = {Filter.class, RedirectFilterMBean.class, EventHandler.class},
+        configurationPolicy = ConfigurationPolicy.REQUIRE,property = {
         SERVICE_DESCRIPTION + "=A request filter implementing support for virtual redirects",
         SLING_FILTER_SCOPE + "=" + EngineConstants.FILTER_SCOPE_REQUEST,
         SERVICE_RANKING + ":Integer=10000",
@@ -156,7 +158,7 @@ public class RedirectFilter extends AnnotatedStandardMBean
             policy = ReferencePolicy.DYNAMIC,
             policyOption = ReferencePolicyOption.GREEDY
     )
-    private LocationHeaderAdjuster urlAdjuster;
+    private volatile LocationHeaderAdjuster urlAdjuster;
 
     private ServiceRegistration<?> listenerRegistration;
     private boolean enabled;

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/manage-redirects.html
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/manage-redirects.html
@@ -39,6 +39,15 @@
         </betty-titlebar>
     </div>
     <div class="content-container-inner" style="width:60%; margin:0 auto;">
+        <coral-alert size="L" variant="warning" data-sly-test=${context.disabled}>
+            <coral-alert-header>OSGi CONFIGURATION MISSING</coral-alert-header>
+            <coral-alert-content>RedirecFilter is disabled and requires an OSGi configuration to start.
+                Please create an OSGi configuration for PID <i>com.adobe.acs.commons.redirects.filter.RedirectFilter</i>
+                <p>
+                    For more information, see the <a target="_blank" href="https://adobe-consulting-services.github.io/acs-aem-commons/features/redirect-manager/index.html">ACS AEM Commons Redirect Manager feature doc page</a>.
+                </p>
+            </coral-alert-content>
+        </coral-alert>
         <coral-tabview>
             <coral-tablist target="main-panel-1">
                 <coral-tab>Manage</coral-tab>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/serverlibs/context.js
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/serverlibs/context.js
@@ -3,10 +3,12 @@ use(function () {
     var ResourceUtil = Packages.org.apache.sling.api.resource.ResourceUtil;
 
     var redirectHome = "/conf/acs-commons/redirects";
+    var enabled = false;
     var filters = sling.getServices(Packages.javax.servlet.Filter, null);
     for(var i=0; i < filters.length; i++ ){
         if(filters[i] instanceof RedirectFilter){
             redirectHome = filters[i].storagePath;
+            enabled = true;
         }
     }
 
@@ -18,6 +20,7 @@ use(function () {
         "nt:unstructured", true);
 
     return {
+        disabled: !enabled, // will trigger an alert on manage-redirects.html
         redirectResource: redirectResource
      };
 });

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/serverlibs/context.js
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/serverlibs/context.js
@@ -2,7 +2,7 @@ use(function () {
     var RedirectFilter = Packages.com.adobe.acs.commons.redirects.filter.RedirectFilter;
     var ResourceUtil = Packages.org.apache.sling.api.resource.ResourceUtil;
 
-    var redirectHome;
+    var redirectHome = "/conf/acs-commons/redirects";
     var filters = sling.getServices(Packages.javax.servlet.Filter, null);
     for(var i=0; i < filters.length; i++ ){
         if(filters[i] instanceof RedirectFilter){


### PR DESCRIPTION
1. Declare RedirectFilter#urlAdjuster volatile to properly handle an osgi dynamic reference
2. RedirectFilter is diabled by default and requires an OSGi to start. If the OSGi configuration is missing then users will see a warning in the UI: 
![image](https://user-images.githubusercontent.com/2543854/111128691-3cf91200-8586-11eb-8596-c9e0640681a6.png)
they still can edit the rules through.

this was also reflected in the documentation in https://github.com/Adobe-Consulting-Services/adobe-consulting-services.github.io/pull/208