### PR TITLE
Fixed cache refresh on versioned clientlibs request when enforceMd5 is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-5.0.4...HEAD
 
+### Fixed
+- #2562 - Fixed cache refresh on versioned clientlibs request when enforceMd5 is false (default).
+
 ### Added
 - #2536 - Extended renovator MCP Process to handle audit trail entries of moved assets and pages.
 

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactory.java
@@ -135,7 +135,8 @@ public final class VersionedClientlibsTransformerFactory extends AbstractGuavaCa
     private static final String MD5_PREFIX = "ACSHASH";
 
     // pattern used to parse paths in the filter - group 1 = path; group 2 = md5; group 3 = extension
-    private static final Pattern FILTER_PATTERN = Pattern.compile("(.*?)\\.(?:min.)?" + MD5_PREFIX + "([a-zA-Z0-9]+)\\.(js|css)");
+    private static final Pattern FILTER_PATTERN = Pattern.compile("(.*?)\\.(?:min.)?([a-zA-Z0-9]+)\\.(js|css)");
+    private static final Pattern FILTER_PATTERN_ENFORCE_MD5 = Pattern.compile("(.*?)\\.(?:min.)?" + MD5_PREFIX + "([a-zA-Z0-9]+)\\.(js|css)");
 
     private static final String PROXY_PREFIX = "/etc.clientlibs/";
     private static final String PROXIED_STATIC_RESOURCE_PATH = "/resources/";
@@ -415,7 +416,12 @@ public final class VersionedClientlibsTransformerFactory extends AbstractGuavaCa
     @Nonnull
     UriInfo getUriInfo(@Nullable final String uri, @Nonnull SlingHttpServletRequest request) {
         if (uri != null) {
-            Matcher matcher = FILTER_PATTERN.matcher(uri);
+            Matcher matcher;
+            if (enforceMd5) {
+                matcher = FILTER_PATTERN_ENFORCE_MD5.matcher(uri);
+            } else {
+                matcher = FILTER_PATTERN.matcher(uri);
+            }
             if (matcher.matches()) {
                 final String libraryPath = matcher.group(1);
                 final String md5 = matcher.group(2);

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/VersionedClientlibsTransformerFactoryTest.java
@@ -651,7 +651,7 @@ public class VersionedClientlibsTransformerFactoryTest {
 
     @Test
     public void doFilter_notFoundInCache_md5Match() throws Exception {
-        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.min.ACSHASH" + INPUTSTREAM_MD5 + ".js");
+        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.min." + INPUTSTREAM_MD5 + ".js");
 
         HtmlLibrary library = mock(HtmlLibrary.class);
         when(library.getInputStream(false)).thenReturn(INPUTSTREAM);
@@ -665,7 +665,7 @@ public class VersionedClientlibsTransformerFactoryTest {
 
     @Test
     public void doFilter_notFoundInCache_md5MisMatch() throws Exception {
-        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.min.ACSHASHfoobar.js");
+        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.min.foobar.js");
 
         HtmlLibrary library = mock(HtmlLibrary.class);
         when(library.getInputStream(false)).thenReturn(INPUTSTREAM );
@@ -679,7 +679,7 @@ public class VersionedClientlibsTransformerFactoryTest {
 
     @Test
     public void doFilter_notFoundInCacheWithDot_md5MisMatch() throws Exception {
-        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.path.min.ACSHASHfoobar.js");
+        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.path.min.foobar.js");
 
         HtmlLibrary library = mock(HtmlLibrary.class);
         when(library.getInputStream(false)).thenReturn(INPUTSTREAM );
@@ -702,6 +702,25 @@ public class VersionedClientlibsTransformerFactoryTest {
 
     @Test
     public void doFilter_foundInCache_md5Match() throws Exception {
+        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.min." + INPUTSTREAM_MD5 + ".js");
+        factory.getCache().put(new VersionedClientLibraryMd5CacheKey("/etc/clientlibs/some", LibraryType.JS), INPUTSTREAM_MD5);
+
+        HtmlLibrary htmlLibrary = mock(HtmlLibrary.class);
+        when(htmlLibrary.getLibraryPath()).thenReturn("/etc/clientlibs/some");
+        when(htmlLibraryManager.getLibrary(LibraryType.JS, "/etc/clientlibs/some")).thenReturn(htmlLibrary);
+
+        filter.doFilter(slingRequest, slingResponse, filterChain);
+
+        verifyNo404();
+
+        verify(htmlLibraryManager).getLibrary(LibraryType.JS, "/etc/clientlibs/some");
+        verify(htmlLibrary, never()).getInputStream(false);
+    }
+
+    @Test
+    public void doFilter_foundInCache_md5Match_enforceMd5() throws Exception {
+        PrivateAccessor.setField(factory, "enforceMd5", true);
+
         when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.min.ACSHASH" + INPUTSTREAM_MD5 + ".js");
         factory.getCache().put(new VersionedClientLibraryMd5CacheKey("/etc/clientlibs/some", LibraryType.JS), INPUTSTREAM_MD5);
 
@@ -712,11 +731,14 @@ public class VersionedClientlibsTransformerFactoryTest {
         filter.doFilter(slingRequest, slingResponse, filterChain);
 
         verifyNo404();
+
+        verify(htmlLibraryManager).getLibrary(LibraryType.JS, "/etc/clientlibs/some");
+        verify(htmlLibrary, never()).getInputStream(false);
     }
 
     @Test
     public void doFilter_foundInCacheWithDot_md5Match() throws Exception {
-        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.path.min.ACSHASH" + INPUTSTREAM_MD5 + ".js");
+        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.path.min." + INPUTSTREAM_MD5 + ".js");
         factory.getCache().put(new VersionedClientLibraryMd5CacheKey("/etc/clientlibs/some.path", LibraryType.JS), INPUTSTREAM_MD5);
 
         HtmlLibrary htmlLibrary = mock(HtmlLibrary.class);
@@ -730,7 +752,7 @@ public class VersionedClientlibsTransformerFactoryTest {
 
     @Test
     public void doFilter_foundInCache_md5MisMatch() throws Exception {
-        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.min.ACSHASHfoobar.js");
+        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.min.foobar.js");
         factory.getCache().put(new VersionedClientLibraryMd5CacheKey("/etc/clientlibs/some", LibraryType.JS), INPUTSTREAM_MD5);
 
         HtmlLibrary htmlLibrary = mock(HtmlLibrary.class);
@@ -744,7 +766,7 @@ public class VersionedClientlibsTransformerFactoryTest {
 
     @Test
     public void doFilter_foundInCacheWithDot_md5MisMatch() throws Exception {
-        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.path.min.ACSHASHfoobar.js");
+        when(slingRequest.getRequestURI()).thenReturn("/etc/clientlibs/some.path.min.foobar.js");
         factory.getCache().put(new VersionedClientLibraryMd5CacheKey("/etc/clientlibs/some.path", LibraryType.JS), INPUTSTREAM_MD5);
 
         HtmlLibrary htmlLibrary = mock(HtmlLibrary.class);
@@ -791,7 +813,7 @@ public class VersionedClientlibsTransformerFactoryTest {
     
         assertEquals(PATH +".css", attributesCaptor.getValue().getValue(0));
     }
-    
+
     private void verifyNothingHappened() throws IOException, ServletException {
         verifyNoInteractions(htmlLibraryManager);
         verifyNo404();


### PR DESCRIPTION
- Fix wrong url's in tests where enforceMd5 is false (default)
- Added extra test for cache hit when enforceMd5 is true
- Verify no cache refresh is executed on a cache hit
- Fixed #2562 getUriInfo splitting the url incorrectly when enforceMd5 is false
- Added entry to CHANGELOG.md