### PR TITLE
Packagers always say that it's an ACL package, even when it isn't

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/packager/main.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/packager/main.jsp
@@ -49,7 +49,7 @@
     <div class="notification success hidden">
         <h2>Success</h2>
 
-        <p>A new ACL package has been created at: <a class="package-manager-link" target="_blank" x-cq-linkchecker="skip" href=""><span
+        <p>A new package has been created at: <a class="package-manager-link" target="_blank" x-cq-linkchecker="skip" href=""><span
                 class="package-path"></span></a></p>
 
         <ul class="filters"></ul>


### PR DESCRIPTION
This file is shared across all packagers, so calling it an ACL package is misleading. There is probably a better way of doing this so that it indicates the type of package based on the packager used, but going with quick and dirty for now.