### PR TITLE
Added older-than milliseconds feature to workflowremover 

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/NumberfieldComponent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/NumberfieldComponent.java
@@ -17,10 +17,21 @@
  * limitations under the License.
  * #L%
  */
-/**
- * Form components for MCP
- */
-@Version("5.3.0")
 package com.adobe.acs.commons.mcp.form;
 
-import org.osgi.annotation.versioning.Version;
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * date picker field component
+ */
+@ProviderType
+public class NumberfieldComponent extends FieldComponent {
+    public NumberfieldComponent(){
+      setResourceType("granite/ui/components/coral/foundation/form/numberfield");
+    }
+
+    @Override
+    public void init() {
+      // Nothing special happens here
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/WorkflowRemover.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/WorkflowRemover.java
@@ -20,6 +20,7 @@
 
 package com.adobe.acs.commons.mcp.impl.processes;
 
+import com.adobe.acs.commons.mcp.form.NumberfieldComponent;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -69,6 +70,10 @@ public class WorkflowRemover extends ProcessDefinition {
     @FormField(name = "Workflows Older Than", description = "only remove workflows older than the specified date",
             component = DatePickerComponent.class)
     public String olderThanVal;
+
+    @FormField(name = "Workflows Older Than Milliseconds", description = "only remove workflows that were started longer than the specified milliseconds ago",
+            component = NumberfieldComponent.class)
+    public long olderThanMillis;
 
     @FormField(
             name = "Workflow Models",
@@ -125,7 +130,7 @@ public class WorkflowRemover extends ProcessDefinition {
 
             parseParameters();
 
-            workflowInstanceRemover.removeWorkflowInstances(rr, modelIds, statuses, payloads, olderThan, BATCH_SIZE,
+            workflowInstanceRemover.removeWorkflowInstances(rr, modelIds, statuses, payloads, olderThan, olderThanMillis, BATCH_SIZE,
                     MAX_DURATION_MINS);
 
             WorkflowRemovalStatus status = workflowInstanceRemover.getStatus();
@@ -185,6 +190,10 @@ public class WorkflowRemover extends ProcessDefinition {
 
     public Calendar getOlderThan() {
         return olderThan;
+    }
+
+    public long getOlderThanMillis() {
+        return olderThanMillis;
     }
 
     public List<String> getStatuses() {

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/removal/WorkflowInstanceRemover.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/removal/WorkflowInstanceRemover.java
@@ -52,13 +52,15 @@ public interface WorkflowInstanceRemover {
      * @param statuses WF Statuses to remove
      * @param payloads Regexes; WF Payloads to remove
      * @param olderThan UTC time in milliseconds; only delete WF's started after this time
+     * @param olderThanMillis Milliseconds; only delete WF's started after this milliseconds ago
      * @return the number of WF instances removed
      */
     int removeWorkflowInstances(final ResourceResolver resourceResolver,
                                 final Collection<String> modelIds,
                                 final Collection<String> statuses,
                                 final Collection<Pattern> payloads,
-                                final Calendar olderThan) throws PersistenceException, WorkflowRemovalException, InterruptedException, WorkflowRemovalForceQuitException;
+                                final Calendar olderThan,
+                                final long olderThanMillis) throws PersistenceException, WorkflowRemovalException, InterruptedException, WorkflowRemovalForceQuitException;
 
 
     /**
@@ -69,6 +71,7 @@ public interface WorkflowInstanceRemover {
      * @param statuses WF Statuses to remove
      * @param payloads Regexes; WF Payloads to remove
      * @param olderThan UTC time in milliseconds; only delete WF's started after this time
+     * @param olderThanMillis Milliseconds; only delete WF's started after this milliseconds ago
      * @param batchSize number of workflow instances to delete per JCR save
      * @return the number of WF instances removed
      */
@@ -77,6 +80,7 @@ public interface WorkflowInstanceRemover {
                                 final Collection<String> statuses,
                                 final Collection<Pattern> payloads,
                                 final Calendar olderThan,
+                                final long olderThanMillis,
                                 final int batchSize) throws PersistenceException, WorkflowRemovalException, InterruptedException, WorkflowRemovalForceQuitException;
 
 
@@ -88,6 +92,7 @@ public interface WorkflowInstanceRemover {
      * @param statuses WF Statuses to remove
      * @param payloads Regexes; WF Payloads to remove
      * @param olderThan UTC time in milliseconds; only delete WF's started after this time
+     * @param olderThanMillis Milliseconds; only delete WF's started after this milliseconds ago
      * @param batchSize number of workflow instances to delete per JCR save
      * @param maxDurationInMins max number of mins the workflow removal process is allowed to run
      * @return the number of WF instances removed
@@ -97,6 +102,7 @@ public interface WorkflowInstanceRemover {
                                 final Collection<String> statuses,
                                 final Collection<Pattern> payloads,
                                 final Calendar olderThan,
+                                final long olderThanMillis,
                                 final int batchSize,
                                 final int maxDurationInMins) throws PersistenceException, WorkflowRemovalException,
             InterruptedException, WorkflowRemovalForceQuitException;

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/removal/impl/WorkflowInstanceRemoverScheduler.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/removal/impl/WorkflowInstanceRemoverScheduler.java
@@ -133,6 +133,13 @@ public class WorkflowInstanceRemoverScheduler implements Runnable {
     public static final String PROP_WORKFLOWS_OLDER_THAN = "workflow.older-than";
 
 
+    private long olderThanMillis = 0L;
+
+    @Property(label = "Older Than Milliseconds",
+        description = "Only remove Workflow Instances whose payloads start date was at least desired Milliseconds ago",
+        longValue = 0)
+    public static final String PROP_WORKFLOWS_OLDER_THAN_MILLIS = "workflow.older-than-millis";
+
     private static final int DEFAULT_BATCH_SIZE = 1000;
     private int batchSize = DEFAULT_BATCH_SIZE;
     @Property(label = "Batch Size",
@@ -162,7 +169,8 @@ public class WorkflowInstanceRemoverScheduler implements Runnable {
                     models,
                     statuses,
                     payloads,
-                    olderThan, 
+                    olderThan,
+                    olderThanMillis,
                     batchSize,
                     maxDuration);
 
@@ -220,6 +228,8 @@ public class WorkflowInstanceRemoverScheduler implements Runnable {
             olderThan = Calendar.getInstance();
             olderThan.setTimeInMillis(olderThanTs);
         }
+
+        olderThanMillis = PropertiesUtil.toLong(config.get(PROP_WORKFLOWS_OLDER_THAN_MILLIS), 0);
         
         batchSize = PropertiesUtil.toInteger(config.get(PROP_BATCH_SIZE), DEFAULT_BATCH_SIZE);
         if (batchSize < 1) {

--- a/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/removal/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/workflow/bulk/removal/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Bulk Workflow Removal.
  */
-@org.osgi.annotation.versioning.Version("3.1.0")
+@org.osgi.annotation.versioning.Version("4.0.0")
 package com.adobe.acs.commons.workflow.bulk.removal;

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/WorkflowRemoverTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/WorkflowRemoverTest.java
@@ -209,7 +209,7 @@ public class WorkflowRemoverTest {
         remover.performCleanupActivity(actionManager);
 
         Mockito.verify(workflowInstanceRemover, Mockito.times(1)).removeWorkflowInstances(Mockito.eq(ctx.resourceResolver()),
-                Mockito.eq(remover.getModelIds()), Mockito.eq(remover.getStatuses()), Mockito.eq(remover.getPayloads()), Mockito.eq(remover.getOlderThan()),
+                Mockito.eq(remover.getModelIds()), Mockito.eq(remover.getStatuses()), Mockito.eq(remover.getPayloads()), Mockito.eq(remover.getOlderThan()), Mockito.eq(remover.getOlderThanMillis()),
                 Mockito.anyInt(), Mockito.anyInt());
 
     }


### PR DESCRIPTION
to be able to remove Workflows older than a defined time period.

This is required to set the OSGi configuration that it purges workflow instances which were started for more than XY Milliseconds ago.
The existing workflow.older-than property does only allow to define a static UTC-Timestamp which is useless in a scheduled service.