### PR TITLE
Prevent NPE in Redirect Manager UI when RedirectFilter is not configured

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
@@ -123,6 +123,8 @@ public class RedirectFilter extends AnnotatedStandardMBean
     public static final String ACS_REDIRECTS_RESOURCE_TYPE = "acs-commons/components/utilities/manage-redirects";
     public static final String REDIRECT_RULE_RESOURCE_TYPE = ACS_REDIRECTS_RESOURCE_TYPE + "/redirect-row";
 
+    public static final String DEFAULT_CONFIG_BUCKET = "settings";
+    public static final String DEFAULT_CONFIG_NAME = "redirects";
 
     private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -152,12 +154,12 @@ public class RedirectFilter extends AnnotatedStandardMBean
 
         @AttributeDefinition(name = "Configuration bucket name", description = "name of the parent folder where to store redirect rules."
                 + " Default is settings. ", type = AttributeType.STRING)
-        String bucketName() default "settings";
+        String bucketName() default DEFAULT_CONFIG_BUCKET;
 
         @AttributeDefinition(name = "Configuration Name", description = "The node name to store redirect configurations. Default is 'redirects' "
                 + " which means the default path to store redirects is /conf/global/settings/redirects "
                 + " where 'settings' is the bucket and 'redirects' is the config name", type = AttributeType.STRING)
-        String configName() default  "redirects";
+        String configName() default  DEFAULT_CONFIG_NAME;
     }
 
     @Reference

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/models/Configurations.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/models/Configurations.java
@@ -19,10 +19,12 @@
  */
 package com.adobe.acs.commons.redirects.models;
 
+import com.adobe.acs.commons.redirects.filter.RedirectFilter;
 import com.adobe.acs.commons.redirects.filter.RedirectFilterMBean;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 import org.slf4j.Logger;
@@ -32,6 +34,7 @@ import javax.jcr.query.Query;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
@@ -47,7 +50,7 @@ public class Configurations {
     @SlingObject
     private SlingHttpServletRequest request;
 
-    @OSGiService
+    @OSGiService(injectionStrategy= InjectionStrategy.OPTIONAL)
     private RedirectFilterMBean redirectFilter;
 
     private static final String REDIRECTS_RESOURCE_TYPE = "acs-commons/components/utilities/manage-redirects/redirects";
@@ -58,9 +61,12 @@ public class Configurations {
         log.debug(sql);
         Iterator<Resource> it = request.getResourceResolver().findResources(sql, Query.JCR_SQL2);
         List<RedirectConfiguration> lst = new ArrayList<>();
+        String bucketName = redirectFilter == null ? RedirectFilter.DEFAULT_CONFIG_BUCKET : redirectFilter.getBucket();
+        String configName = redirectFilter == null ? RedirectFilter.DEFAULT_CONFIG_NAME : redirectFilter.getConfigName();
+
         while (it.hasNext()) {
             Resource resource = it.next();
-            String storageSuffix = redirectFilter.getBucket() + "/" + redirectFilter.getConfigName();
+            String storageSuffix = bucketName + "/" + configName;
             RedirectConfiguration cfg = new RedirectConfiguration(resource, storageSuffix);
             lst.add(cfg);
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/models/UpgradeLegacyRedirects.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/models/UpgradeLegacyRedirects.java
@@ -19,6 +19,7 @@
  */
 package com.adobe.acs.commons.redirects.models;
 
+import com.adobe.acs.commons.redirects.filter.RedirectFilter;
 import com.adobe.acs.commons.redirects.filter.RedirectFilterMBean;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.SlingHttpServletRequest;
@@ -28,6 +29,7 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 import org.slf4j.Logger;
@@ -69,11 +71,13 @@ public class UpgradeLegacyRedirects {
 
     @SlingObject
     private SlingHttpServletRequest request;
-    @OSGiService
+
+    @OSGiService(injectionStrategy= InjectionStrategy.OPTIONAL)
     private RedirectFilterMBean redirectFilter;
 
     @PostConstruct
     protected void init() {
+
         ResourceResolver resolver = request.getResourceResolver();
         Resource legacyHome = resolver.getResource(REDIRECTS_HOME_5_0_4);
         if (legacyHome == null) {
@@ -85,7 +89,9 @@ public class UpgradeLegacyRedirects {
             return;
         }
 
-        String globalPath = "/conf/global/" + redirectFilter.getBucket() + "/" + redirectFilter.getConfigName();
+        String bucketName = redirectFilter == null ? RedirectFilter.DEFAULT_CONFIG_BUCKET : redirectFilter.getBucket();
+        String configName = redirectFilter == null ? RedirectFilter.DEFAULT_CONFIG_NAME : redirectFilter.getConfigName();
+        String globalPath = "/conf/global/" + bucketName + "/" + configName;
         Resource globalConf = resolver.getResource(globalPath);
         if (globalConf == null) {
             return;

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/CreateRedirectConfigurationServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/CreateRedirectConfigurationServlet.java
@@ -102,8 +102,7 @@ public class CreateRedirectConfigurationServlet extends SlingAllMethodsServlet {
                 rsp.put("path", config.getPath());
             } else {
                 resolver.revert();
-                String msg = "Configuration already exist: "
-                        + (rootPath + "/" + redirectFilter.getBucket() + "/" + redirectFilter.getConfigName());
+                String msg = "Configuration already exist: " + (rootPath + "/" + bucketName + "/" + configName);
                 rsp.put("message", msg);
                 response.setStatus(HttpServletResponse.SC_CONFLICT);
             }


### PR DESCRIPTION
Updated Sling Models in the Redirect Manager UI  to work if  RedirectFilter is not configured. Previously they threw NPE. 

Raised by @davidjgonzalez in https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/2589

If OSGi config for pid  com.adobe.acs.commons.redirects.filter.RedirectFilter is missing then user will see a yellow warning the UI

![image](https://user-images.githubusercontent.com/2543854/119224226-1fa46f00-bb06-11eb-8334-b04686805f59.png)

No OSGi config does not prevent managing redirects. Users can still add/edit/replicate redirects rules. 

