### PR TITLE
Issue - 2580 - Etag log level changed for already committed response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-5.0.4...HEAD
 
+### Changed
+- #2593 - Etag log level changed from error to warn for already committed response
+
 ### Added
 - #2585 - Added option in workflow-remover to define a millisecond delta for the workflows to be cleared.
 

--- a/bundle/src/main/java/com/adobe/acs/commons/etag/impl/EtagMessageDigestServletFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/etag/impl/EtagMessageDigestServletFilter.java
@@ -168,7 +168,7 @@ public class EtagMessageDigestServletFilter implements Filter {
                 return;
             }
             if (slingHttpServletResponse.isCommitted()) {
-                log.error("Can not send ETag header because response is already committed, try to give this filter a higher ranking!");
+                log.warn("Can not send ETag header because response is already committed, try to give this filter a higher ranking!");
                 return;
             }
 


### PR DESCRIPTION
https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/2580 changing log level from error to warn