### PR TITLE
#2645: Redirect Manager: Default CaConfig Configuration not showing up 

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/models/Configurations.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/models/Configurations.java
@@ -57,7 +57,7 @@ public class Configurations {
 
     public Collection<RedirectConfiguration> getConfigurations() {
         String sql = "SELECT * FROM [nt:unstructured] AS s WHERE ISDESCENDANTNODE([/conf]) "
-                + "AND s.[sling:resourceType]='" + REDIRECTS_RESOURCE_TYPE + "'";
+                + "AND (s.[sling:resourceType]='" + REDIRECTS_RESOURCE_TYPE + "' OR s.[jcr:path]='/conf/global/settings/redirects')";
         log.debug(sql);
         Iterator<Resource> it = request.getResourceResolver().findResources(sql, Query.JCR_SQL2);
         List<RedirectConfiguration> lst = new ArrayList<>();


### PR DESCRIPTION
Fix #2645


The default global configuration  created by the repo-init script does not set sling:resourceType which is required to show up in the UI.

It's a regression caused by fixing #2589 

I don't have a better idea than change the JCR-SQL that selects CaConfig configurations :

```
String sql = "SELECT * FROM [nt:unstructured] AS s WHERE ISDESCENDANTNODE([/conf]) "
+ "AND (s.[sling:resourceType]='" + REDIRECTS_RESOURCE_TYPE + "' OR s.[jcr:path]='/conf/global/settings/redirects')";
```

this way it selects the default global config (/conf/global/settings/redirects) and other nodes having the resource type. 

I know it smells :)