### PR TITLE
Rely on TopologyEvent only instead of refering to DiscoveryService which c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-5.0.4...HEAD
 
+## 5.0.8
+
+### Fixed
+- #2650 - Rely on TopologyEvent only instead of refering to DiscoveryService which causes circular reference errors
+
 ## 5.0.6 - 2021-06-12
 
 ### Changed

--- a/bundle/src/main/java/com/adobe/acs/commons/util/impl/DiscoveryServiceHelper.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/util/impl/DiscoveryServiceHelper.java
@@ -19,7 +19,6 @@
  */
 package com.adobe.acs.commons.util.impl;
 
-import org.apache.sling.discovery.DiscoveryService;
 import org.apache.sling.discovery.TopologyEvent;
 import org.apache.sling.discovery.TopologyEventListener;
 import org.apache.sling.discovery.TopologyView;
@@ -28,7 +27,6 @@ import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
 
 import com.adobe.acs.commons.util.ClusterLeader;
 
@@ -41,9 +39,6 @@ import com.adobe.acs.commons.util.ClusterLeader;
  */
 @Component
 public class DiscoveryServiceHelper implements TopologyEventListener {
-
-    @Reference
-    DiscoveryService discoveryService;
 
     private BundleContext bundleContext;
 
@@ -64,9 +59,6 @@ public class DiscoveryServiceHelper implements TopologyEventListener {
     @Activate
     public void activate(BundleContext bundleContext) {
         this.bundleContext = bundleContext;
-        if (discoveryService.getTopology().getLocalInstance().isLeader()) {
-            registerClusterLeader();
-        }
     }
 
     @Deactivate


### PR DESCRIPTION
…auses circular reference (#2650)