### PR TITLE
Remove HALT option from MCP as it can result in corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-5.0.4...HEAD
 
+# 5.0.10
+
+- #2660 - Remove Halt button from MCP as it's use can result in repository corruption.
+
 ## 5.0.8
 
 ### Fixed

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-controlled-processes/clientlibs/js/scriptRunner.js
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-controlled-processes/clientlibs/js/scriptRunner.js
@@ -292,8 +292,15 @@ var ScriptRunner = {
                         innerHTML: response
                     },
                     footer: {
+                        innerHTML: '<button id="okButton" is="coral-button" variant="default" coral-close>Close</button>'
+
+                        /*
+                        - https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/2660
+                        - Remove Halt button as this is reported to result in Oak repo corruption sometimes
+
                         innerHTML: (!ended ? '<button id="haltButton" is="coral-button" variant="default">Halt</button>':'') +
                                 '<button id="okButton" is="coral-button" variant="default" coral-close>Close</button>'
+                        */
                     },
                     closable: true,
                     variant: "info"


### PR DESCRIPTION
![2021-08-11 at 5 57 PM](https://user-images.githubusercontent.com/1451868/129108900-dabf7bdf-25a9-4939-855e-0b2593f5e210.jpg)

Removed Halt from MCP process modal as this can result in repo corruption sometimes (per Leo B.)
