### PR TITLE
#2673 NPE In Redirect Manager

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
@@ -259,9 +259,9 @@ public class RedirectFilter extends AnnotatedStandardMBean
         ReplicationEvent replicationEvent = ReplicationEvent.fromEvent(event);
         if(enabled && replicationEvent != null){
             String redirectSubPath = config.bucketName() + "/" + config.configName();
-            String[] paths = replicationEvent.getReplicationAction().getPaths();
-            if(paths != null) {
-                for (String path : paths) {
+            String[] replicationPaths = replicationEvent.getReplicationAction().getPaths();
+            if(replicationPaths != null) {
+                for (String path : replicationPaths) {
                     if (path.contains(redirectSubPath)) {
                         // loading redirect configurations can be expensive and needs to run
                         // asynchronously,

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/package-info.java
@@ -17,5 +17,5 @@
  * limitations under the License.
  * #L%
  */
-@org.osgi.annotation.versioning.Version("6.0.0")
+@org.osgi.annotation.versioning.Version("6.0.1")
 package com.adobe.acs.commons.redirects.filter;

--- a/bundle/src/test/java/com/adobe/acs/commons/it/build/ScrMetadataIT.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/it/build/ScrMetadataIT.java
@@ -141,6 +141,7 @@ public class ScrMetadataIT {
         COMPONENT_PROPERTIES_TO_IGNORE.add("com.adobe.acs.commons.redirects.filter.RedirectFilter:storagePath");
         COMPONENT_PROPERTIES_TO_IGNORE.add("com.adobe.acs.commons.redirects.filter.RedirectFilter:mapUrls");
         COMPONENT_PROPERTIES_TO_IGNORE.add("com.adobe.acs.commons.redirects.filter.RedirectFilter:enabled");
+        COMPONENT_PROPERTIES_TO_IGNORE.add("com.adobe.acs.commons.redirects.filter.RedirectFilter:event.topics");
 
         COMPONENT_PROPERTIES_TO_IGNORE_FOR_TYPE_CHANGE = new HashSet<>();
         COMPONENT_PROPERTIES_TO_IGNORE_FOR_TYPE_CHANGE.add("com.adobe.acs.commons.fam.impl.ThrottledTaskRunnerImpl:max.cpu");

--- a/bundle/src/test/java/com/adobe/acs/commons/redirects/filter/RedirectFilterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirects/filter/RedirectFilterTest.java
@@ -594,28 +594,31 @@ public class RedirectFilterTest {
 
     @Test
     public void testNotEnabledDeactivate() throws Exception {
-        RedirectFilter filter = spy(new RedirectFilter());
-
         RedirectFilter.Configuration configuration = mock(RedirectFilter.Configuration.class);
         when(configuration.enabled()).thenReturn(false);
 
+        RedirectFilter redirectFilter = spy(new RedirectFilter());
+        redirectFilter.activate(configuration, context.bundleContext());
+
         // #2673 : ensure no NPE in deactivate() when filter is disabled
-        filter.deactivate();
+        redirectFilter.deactivate();
     }
 
     @Test
     public void testNotEnabledOnChange() throws Exception {
-        RedirectFilter filter = spy(new RedirectFilter());
 
         RedirectFilter.Configuration configuration = mock(RedirectFilter.Configuration.class);
         when(configuration.enabled()).thenReturn(false);
         when(configuration.bucketName()).thenReturn("settings");
         when(configuration.configName()).thenReturn("redirects");
 
+        RedirectFilter redirectFilter = spy(new RedirectFilter());
+        redirectFilter.activate(configuration, context.bundleContext());
+
         ResourceChange event = new ResourceChange(ResourceChange.ChangeType.CHANGED,
                 "/conf/global/setting/redirects/rule", false, null, null, null);
 
         // #2673 : ensure no NPE in onChange() when filter is disabled
-        filter.onChange(Collections.singletonList(event));
+        redirectFilter.onChange(Collections.singletonList(event));
     }
 }


### PR DESCRIPTION
The patch is to prevent NPE when user edit redirect rules, but the filter is disabled in the OSGi configuration, i.e. OSGi config exists, but the `enable` flag is not set., 