### PR TITLE
initial version for release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 # Automates the release steps outlined at https://github.com/Adobe-Consulting-Services/acs-aem-commons/blob/master/RELEASING.md
-name: Release to Sonatype OSSRH (Maven Central)
+name: Release to GitHub and Maven Central
 
 # Only support manual trigger (https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)
 on:
@@ -17,41 +17,38 @@ on:
         description: 'Dry Run? (false to do an actual release)'
         required: true
         default: 'true'
+
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - name: Enforce master branch
         if: github.ref != 'refs/heads/master'
-        uses: actions/github-script@v3
+        uses: actions/github-script@v8
         with:
           script: |
               core.setFailed('Releases can only be triggered from master branch!')
 
       # Check out Git repository
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       # Set up environment with Java and Maven
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           cache: 'maven'
-          distribution: 'adopt'
-          java-version: 8
+          distribution: 'temurin'
+          java-version: 21
           # generate settings.xml with the correct values
-          server-id: ossrh # Value of the distributionManagement/repository/id field of the pom.xml
+          server-id: sonatype-central-portal # Value of the distributionManagement/repository/id field of the pom.xml
           server-username: MAVEN_USERNAME # env variable for username in deploy
           server-password: MAVEN_PASSWORD # env variable for token in deploy
-
-      # Import GPG key from env variable into keychain
-      - name: Import GPG key
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_OWNERTRUST: ${{ secrets.GPG_OWNERTRUST }}
-        run: |
-          echo $GPG_PRIVATE_KEY | base64 --decode | gpg --import --no-tty --batch --yes
-          echo $GPG_OWNERTRUST | base64 --decode | gpg --import-ownertrust --no-tty --batch --yes
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }} # Value of the GPG private key to import
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE # env variable for GPG private key passphrase
 
       - name: Configure git user for release commits
         run: |
@@ -60,42 +57,17 @@ jobs:
 
       # Build and deploy to OSSRH, which will automatically sync to Central Repository
       - name: Build and Deploy ${{ github.event.inputs.releaseVersion }} to Central Repository
-        run: mvn -B clean release:prepare release:perform -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdryRun=${{ github.event.inputs.dryRun }} -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
-
-      - name: Close milestone ${{ github.event.inputs.releaseVersion }}
-        if: !github.event.inputs.dryRun
-        uses: Beakyn/gha-close-milestone@v1.1.1
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          repository: ${{ github.repository }}
-          milestone-title: ${{ github.event.inputs.releaseVersion }}
-
-      - name: Build Changelog
-        id: github_release
-        uses: okcredit/changelog-creator-action@{latest-release}
-        with:
-          milestone: ${{ github.event.inputs.releaseVersion }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          MAVEN_USERNAME: ${{ secrets.SONATYPE_CENTRAL_PORTAL_TOKEN_USER }}
+          MAVEN_PASSWORD: ${{ secrets.SONATYPE_CENTRAL_PORTAL_TOKEN_PASSWORD }}
+        run: mvn -B clean release:prepare release:perform -DreleaseVersion=${{ github.event.inputs.releaseVersion }} -DdryRun=${{ github.event.inputs.dryRun }} -Dnjord.dryRun=${{ github.event.inputs.dryRun }}
 
       - name: Create Release
-        if: !github.event.inputs.dryRun
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.releaseVersion }}
-          release_name: ${{ steps.github_release.outputs.milestone }}
-          body: ${{ steps.github_release.outputs.changelog }}
+          generate_release_notes: true
           draft: ${{ github.event.inputs.dryRun }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create Draft Release
-        if: !github.event.inputs.dryRun
-        uses: actions/create-release@v1
-        with:
-          release_name: ${{ steps.github_release.outputs.milestone }}
-          body: ${{ steps.github_release.outputs.changelog }}
-          draft: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This requires the following organisation or repository secrets:

1.  `GPG_PRIVATE_KEY`, the private key for signing the release
1. `GPG_PASSPHRASE`, the passphrase for using the private key
1. `OSSRH_TOKEN_USER`, the user name of a user for OSSRH for deploying to Maven Central, https://central.sonatype.org/publish/publish-guide/
1. `OSSRH_TOKEN_PASSWORD`, the token of a user for OSSRH for deploying to Maven Central, should be created via https://oss.sonatype.org/#profile;User%20Token. Used instead of password to decouple from the named user's credentials.

@davidjgonzalez Can you set those up?