### PR TITLE
Fix for #2666: Redirect Map Manager Not visible with version 5.0.6

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/acs-commons/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/acs-commons/.content.xml
@@ -3,6 +3,10 @@
     jcr:primaryType="sling:OrderedFolder"
     jcr:title="ACS AEM Commons"
     id="acs-commons">
+    <dynamic-deck-dynamo/>
+    <exporters-tags/>
+    <redirect-manager/>
+    <sort-nodes/>
     <generic-lists/>
 
     <reports/>
@@ -11,7 +15,6 @@
     <content-packagers/>
     <automatic-package-replication/>
     <dispatcher-flush/>
-    <redirect-manager/>
     <redirect-maps/>
     <version-replicator/>
 

--- a/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/acs-commons/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/acs-commons/.content.xml
@@ -11,6 +11,7 @@
     <content-packagers/>
     <automatic-package-replication/>
     <dispatcher-flush/>
+    <redirect-manager/>
     <redirect-maps/>
     <version-replicator/>
 

--- a/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/acs-commons/redirect-manager/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/acs-commons/redirect-manager/.content.xml
@@ -3,7 +3,7 @@
     jcr:primaryType="nt:unstructured"
     jcr:title="Manage Redirects"
     jcr:description="Manage redirects"
-    icon="forward"
+    icon="orbit"
     href="/apps/acs-commons/content/redirect-manager/redirects.html"
     id="acs-commons__redirect-manager"
     target="_blank"/>

--- a/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/acs-commons/redirect-maps/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/acs-commons/redirect-maps/.content.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+          jcr:primaryType="nt:unstructured"
+          jcr:title="Redirect Maps"
+          jcr:description="Define redirect Apache httpd redirect maps."
+          icon="forward"
+          href="/acs-commons.html/etc/acs-commons/redirect-maps"
+          id="acs-commons__redirect-maps"
+          target="_blank"/>


### PR DESCRIPTION
The patch restores the Redirect Maps icon in Tools -> ACS AEM Commons 

See https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/2666

Note that I changed the icon for Redirect Manager so that the two tools have different icons. 