### PR TITLE
#2560 Fixed support for type module scripts for versioned clientlibs

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/SaxElementUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/SaxElementUtils.java
@@ -31,6 +31,7 @@ public class SaxElementUtils {
 
     public static final String CSS_TYPE = "text/css";
     public static final String JS_TYPE = "text/javascript";
+    public static final String JS_MODULE_TYPE = "module";
 
     public static boolean isCss(final String elementName, final Attributes attrs) {
         final String type = attrs.getValue("", "type");
@@ -48,7 +49,7 @@ public class SaxElementUtils {
         final String src = attrs.getValue("", "src");
 
         return StringUtils.equals("script", elementName)
-                && (type == null || StringUtils.equals(type, JS_TYPE))
+                && (type == null || StringUtils.equals(type, JS_TYPE) || StringUtils.equals(type, JS_MODULE_TYPE))
                 && StringUtils.startsWith(src, "/")
                 && !StringUtils.startsWith(src, "//")
                 && StringUtils.endsWith(src, LibraryType.JS.extension);

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/SaxElementUtilsTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/SaxElementUtilsTest.java
@@ -79,6 +79,12 @@ public class SaxElementUtilsTest {
                                 "src", "/js.js",
                                 "type", SaxElementUtils.JS_TYPE)));
 
+        assertTrue("JS Module Happy Path",
+                SaxElementUtils.isJavaScript("script",
+                        makeAtts(
+                                "src", "/js.js",
+                                "type", SaxElementUtils.JS_MODULE_TYPE)));
+
         assertTrue("JS Happy Path - Optional Type Attribute",
                 SaxElementUtils.isJavaScript("script",
                         makeAtts(


### PR DESCRIPTION
Fix: added support for type module to isJavascript() within SaxElementUtils

Versioned clientlibs now rewrite for `<script type="module"..`
<img width="844" alt="Screen Shot 2021-09-06 at 12 12 52 PM" src="https://user-images.githubusercontent.com/3621147/132150980-8e7d9bcb-7fd8-45ab-ac1c-f9960647f34a.png">
