### PR TITLE
Fix: count clipboard items only on paste action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ### Fixed
 
 #2691 - Fixed support for type module scripts for versioned clientlibs 
+#2694 - Fixed parsys-limiter counting clipboard items also when the action is not paste
 
 ## 5.0.10 - 2021-08-31
 

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/configure-limit-parsys/touchui-limit-parsys.js
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/configure-limit-parsys/touchui-limit-parsys.js
@@ -115,7 +115,7 @@
         return children;
     }
 
-    function isWithinLimit(parsysEditable){
+    function isWithinLimit(parsysEditable, itemsToAdd){
         var isWithin = true, currentLimit = "";
 
         currentLimit = _findPropertyFromDesign(parsysEditable, Granite.author.pageDesign, ACS_COMPONENTS_LIMIT);
@@ -124,8 +124,7 @@
         }
         var limit = parseInt(currentLimit);
         var children = getChildEditables(parsysEditable);
-        //Take into account also the number of components in the clipboard in case this is a "paste"
-        var itemsToAdd = Granite.author.clipboard.length < 1 ? 1 : Granite.author.clipboard.length;
+        itemsToAdd = itemsToAdd ? itemsToAdd : 1;
         isWithin = children.length - 1 + itemsToAdd <= limit;
 
         if(!isWithin){
@@ -162,7 +161,7 @@
                 return function (editableBefore) {
                     // only prevent copy but not move operations (if previous operation was cut)
                     if(!Granite.author.clipboard.shouldCut()) {
-                        if(!isWithinLimit(editableBefore.getParent())){
+                        if(!isWithinLimit(editableBefore.getParent(), Granite.author.clipboard.length)){
                             return;
                         }
                     }


### PR DESCRIPTION
Fix for https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/2694 