### PR TITLE
Fix #2707: Lower priority of RedirectFilter to run after WCMRequestFilter

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
@@ -112,7 +112,7 @@ import static org.osgi.framework.Constants.SERVICE_ID;
         configurationPolicy = ConfigurationPolicy.REQUIRE, property = {
         SERVICE_DESCRIPTION + "=A request filter implementing support for virtual redirects",
         SLING_FILTER_SCOPE + "=" + EngineConstants.FILTER_SCOPE_REQUEST,
-        SERVICE_RANKING + ":Integer=10000",
+        SERVICE_RANKING + ":Integer=1900",
         "jmx.objectname=" + "com.adobe.acs.commons:type=Redirect Manager",
         EventConstants.EVENT_TOPIC + "=" + ReplicationAction.EVENT_TOPIC,
         EventConstants.EVENT_TOPIC + "=" + ReplicationEvent.EVENT_TOPIC

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/package-info.java
@@ -17,5 +17,5 @@
  * limitations under the License.
  * #L%
  */
-@org.osgi.annotation.versioning.Version("6.0.1")
+@org.osgi.annotation.versioning.Version("6.0.2")
 package com.adobe.acs.commons.redirects.filter;


### PR DESCRIPTION
Fix  https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/2707
