### PR TITLE
More optimizations for Shared Component Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## Unreleased ([details][unreleased changes details])
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
-[unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-5.0.6...HEAD
+[unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-5.0.14...HEAD
+
+### Fixed
+
+- #2730 - Optimized Shared Component Properties feature with request attribute caching and injector reliance on BVP
 
 ## 5.0.14 - 2021-10-20
 

--- a/bundle/src/main/java/com/adobe/acs/commons/models/injectors/impl/SharedValueMapValueInjector.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/models/injectors/impl/SharedValueMapValueInjector.java
@@ -151,10 +151,10 @@ public class SharedValueMapValueInjector implements Injector {
         }
     }
 
-    ValueMap getValueMapFromBindings(final SlingBindings bindings,
-                                     final SharedComponentProperties.ValueTypes valueType,
-                                     final Resource resource,
-                                     final String rootPagePath) {
+    private ValueMap getValueMapFromBindings(final SlingBindings bindings,
+                                             final SharedComponentProperties.ValueTypes valueType,
+                                             final Resource resource,
+                                             final String rootPagePath) {
         // if the merged path in bindings matches the resource path, just assume that the merged properties in
         // bindings are sufficient
         if (valueType == SharedComponentProperties.ValueTypes.MERGED
@@ -224,20 +224,18 @@ public class SharedValueMapValueInjector implements Injector {
     /**
      * Get shared properties ValueMap the current resource.
      */
-    protected ValueMap getSharedProperties(Resource resource) {
-        return Optional.ofNullable(sharedComponentProperties.getSharedPropertiesPath(resource))
-                .map(resource.getResourceResolver()::getResource)
-                .map(Resource::getValueMap)
+    protected ValueMap getSharedProperties(final Resource resource) {
+        return Optional.ofNullable(sharedComponentProperties)
+                .map(scp -> scp.getSharedProperties(resource))
                 .orElse(ValueMap.EMPTY);
     }
 
     /**
      * Get global properties ValueMap for the current resource.
      */
-    protected ValueMap getGlobalProperties(Resource resource) {
-        return Optional.ofNullable(sharedComponentProperties.getGlobalPropertiesPath(resource))
-                .map(resource.getResourceResolver()::getResource)
-                .map(Resource::getValueMap)
+    protected ValueMap getGlobalProperties(final Resource resource) {
+        return Optional.ofNullable(sharedComponentProperties)
+                .map(scp -> scp.getGlobalProperties(resource))
                 .orElse(ValueMap.EMPTY);
     }
 
@@ -245,10 +243,12 @@ public class SharedValueMapValueInjector implements Injector {
      * Get merged properties ValueMap for the current resource.
      */
     protected ValueMap getMergedProperties(Resource resource) {
-        return sharedComponentProperties.mergeProperties(
-                getGlobalProperties(resource),
-                getSharedProperties(resource),
-                resource);
+        return Optional.ofNullable(sharedComponentProperties)
+                .map(scp -> scp.mergeProperties(
+                        getGlobalProperties(resource),
+                        getSharedProperties(resource),
+                        resource))
+                .orElse(resource.getValueMap());
     }
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/models/injectors/impl/SharedValueMapValueInjector.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/models/injectors/impl/SharedValueMapValueInjector.java
@@ -74,10 +74,12 @@ public class SharedValueMapValueInjector implements Injector {
         final ValueMap valueMap;
         if (sharedComponentProperties != null) {
             valueMap = getValueMap(adaptable, element);
-        } else {
+        } else if (getValueType(element) == SharedComponentProperties.ValueTypes.MERGED) {
             valueMap = Optional.ofNullable(getResource(adaptable))
                     .map(Resource::getValueMap)
                     .orElse(ValueMap.EMPTY);
+        } else {
+            valueMap = ValueMap.EMPTY;
         }
 
         return ReflectionUtil.convertValueMapValue(valueMap, name, declaredType);

--- a/bundle/src/main/java/com/adobe/acs/commons/models/injectors/impl/SharedValueMapValueInjector.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/models/injectors/impl/SharedValueMapValueInjector.java
@@ -118,7 +118,7 @@ public class SharedValueMapValueInjector implements Injector {
         final String rootPagePath = sharedComponentProperties.getSharedPropertiesPagePath(resource);
         if (rootPagePath == null) {
             // when we have a resource but no root page path, we can at least satisfy MERGED with the resource valuemap
-            return valueType == SharedComponentProperties.ValueTypes.MERGED ? resource.getValueMap() : null;
+            return valueType == SharedComponentProperties.ValueTypes.MERGED ? resource.getValueMap() : ValueMap.EMPTY;
         }
 
         // first: attempt to retrieve from bindings

--- a/bundle/src/main/java/com/adobe/acs/commons/models/injectors/impl/SharedValueMapValueInjector.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/models/injectors/impl/SharedValueMapValueInjector.java
@@ -21,36 +21,49 @@ package com.adobe.acs.commons.models.injectors.impl;
 
 import com.adobe.acs.commons.models.injectors.annotation.SharedValueMapValue;
 import com.adobe.acs.commons.util.impl.ReflectionUtil;
-import com.adobe.acs.commons.wcm.PageRootProvider;
 import com.adobe.acs.commons.wcm.properties.shared.SharedComponentProperties;
 import com.day.cq.commons.jcr.JcrConstants;
-import com.day.cq.wcm.api.Page;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.Property;
 import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.ReferenceCardinality;
+import org.apache.felix.scr.annotations.ReferencePolicyOption;
 import org.apache.felix.scr.annotations.Service;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.models.spi.DisposalCallbackRegistry;
 import org.apache.sling.models.spi.Injector;
 import org.osgi.framework.Constants;
 
+import javax.servlet.ServletRequest;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.adobe.acs.commons.models.injectors.impl.InjectorUtils.getResource;
 
+/**
+ * The SharedValueMapValueInjector depends on two other services related to script bindings executing first.
+ * 1. The {@link com.adobe.acs.commons.wcm.properties.shared.impl.SharedComponentPropertiesBindingsValuesProvider}
+ * defines bindings for "globalProperties", "sharedProperties", and "mergedProperties".
+ * 2. The {@code org.apache.sling.models.impl.injectors.BindingsInjector} provides those
+ */
 @Component
 @Service
 @Property(name = Constants.SERVICE_RANKING, intValue = 4500)
 public class SharedValueMapValueInjector implements Injector {
-    @Reference
-    private PageRootProvider pageRootProvider;
+
+    /**
+     * Bind if available, check for null when reading.
+     */
+    @Reference(policyOption = ReferencePolicyOption.GREEDY, cardinality = ReferenceCardinality.OPTIONAL_UNARY)
+    private SharedComponentProperties sharedComponentProperties;
 
     @Override
     public String getName() {
@@ -64,63 +77,120 @@ public class SharedValueMapValueInjector implements Injector {
             return null;
         }
 
-        Resource resource = getResource(adaptable);
+        final ValueMap valueMap = getValueMap(adaptable, element);
 
-        if (resource != null) {
-            String rootPagePath = pageRootProvider.getRootPagePath(resource.getPath());
-            if (StringUtils.isNotBlank(rootPagePath)) {
-                ValueMap valueMap = null;
-                switch (element.getAnnotation(SharedValueMapValue.class).type()) {
-                    case MERGED:
-                        valueMap = getMergedProperties(rootPagePath, resource);
-                        break;
-                    case SHARED:
-                        valueMap = getSharedProperties(rootPagePath, resource);
-                        break;
-                    case GLOBAL:
-                        valueMap = getGlobalProperties(rootPagePath, resource);
-                        break;
-                    default:
-                        break;
+        if (valueMap != null) {
+            return ReflectionUtil.convertValueMapValue(valueMap, name, declaredType);
+        }
+
+        return null;
+    }
+
+    private ValueMap getValueMap(Object adaptable, AnnotatedElement element) {
+        final SharedComponentProperties.ValueTypes valueType = getValueType(element);
+        if (valueType == null) {
+            return null;
+        }
+
+        final Resource resource = getResource(adaptable);
+        // we always need a resource, if only to determine if cached global properties are valid for the resource path
+        if (resource == null) {
+            return null;
+        }
+
+        // the root page path is used to test the validity of bindings
+        final String rootPagePath = sharedComponentProperties.getSharedPropertiesPagePath(resource);
+        if (rootPagePath == null) {
+            // when we have a resource but no root page path, we can at least satisfy MERGED with the resource valuemap
+            return valueType == SharedComponentProperties.ValueTypes.MERGED ? resource.getValueMap() : null;
+        }
+
+        // first attempt to retrieve from bindings
+        final SlingBindings bindings = getBindings(adaptable);
+        if (bindings != null) {
+            if (valueType == SharedComponentProperties.ValueTypes.MERGED
+                    && resource.getPath().equals(bindings.get(SharedComponentProperties.MERGED_PROPERTIES_PATH))) {
+                return (ValueMap) bindings.get(SharedComponentProperties.MERGED_PROPERTIES);
+            }
+
+            if (rootPagePath.equals(bindings.get(SharedComponentProperties.SHARED_PROPERTIES_PAGE_PATH))) {
+                final ValueMap globalVmBound = (ValueMap) bindings.get(SharedComponentProperties.GLOBAL_PROPERTIES);
+                if (valueType == SharedComponentProperties.ValueTypes.GLOBAL) {
+                    return globalVmBound;
                 }
-                if (valueMap != null) {
-                    return ReflectionUtil.convertValueMapValue(valueMap, name, declaredType);
+
+                final String sharedPropertiesPath = sharedComponentProperties.getSharedPropertiesPath(resource);
+                if (valueType == SharedComponentProperties.ValueTypes.SHARED && sharedPropertiesPath == null) {
+                    return null;
+                }
+
+                if (sharedPropertiesPath != null
+                        && sharedPropertiesPath.equals(bindings.get(SharedComponentProperties.SHARED_PROPERTIES_PATH))) {
+                    final ValueMap sharedVmBound = (ValueMap) bindings.get(SharedComponentProperties.SHARED_PROPERTIES);
+                    if (valueType == SharedComponentProperties.ValueTypes.SHARED) {
+                        return sharedVmBound;
+                    } else if (valueType == SharedComponentProperties.ValueTypes.MERGED) {
+                        return sharedComponentProperties.mergeProperties(globalVmBound, sharedVmBound, resource);
+                    }
+                } else if (sharedPropertiesPath == null && valueType == SharedComponentProperties.ValueTypes.MERGED) {
+                    return sharedComponentProperties.mergeProperties(globalVmBound, null, resource);
                 }
             }
         }
 
+        switch (valueType) {
+            case GLOBAL:
+                return getGlobalProperties(rootPagePath, resource);
+            case SHARED:
+                return getSharedProperties(rootPagePath, resource);
+            case MERGED:
+                return getMergedProperties(rootPagePath, resource);
+        }
+
         return null;
+    }
+
+    private SharedComponentProperties.ValueTypes getValueType(final AnnotatedElement element) {
+        return element.getAnnotation(SharedValueMapValue.class).type();
+    }
+
+    private SlingBindings getBindings(Object adaptable) {
+        if (adaptable instanceof ServletRequest) {
+            ServletRequest request = (ServletRequest) adaptable;
+            return (SlingBindings) request.getAttribute(SlingBindings.class.getName());
+        } else {
+            return null;
+        }
     }
 
     /**
      * Get shared properties ValueMap the current resource.
      */
     protected ValueMap getSharedProperties(String rootPagePath, Resource resource) {
-        String sharedPropsPath = rootPagePath + "/" + JcrConstants.JCR_CONTENT + "/" + SharedComponentProperties.NN_SHARED_COMPONENT_PROPERTIES + "/" + resource.getResourceType();
-        Resource sharedPropsResource = resource.getResourceResolver().getResource(sharedPropsPath);
-        return sharedPropsResource != null ? sharedPropsResource.getValueMap() : ValueMap.EMPTY;
+        return Optional.ofNullable(sharedComponentProperties.getSharedPropertiesPath(resource))
+                .map(resource.getResourceResolver()::getResource)
+                .map(Resource::getValueMap)
+                .orElse(ValueMap.EMPTY);
     }
 
     /**
      * Get global properties ValueMap for the current resource.
      */
     protected ValueMap getGlobalProperties(String rootPagePath, Resource resource) {
-        String globalPropsPath = rootPagePath + "/" + JcrConstants.JCR_CONTENT + "/" + SharedComponentProperties.NN_GLOBAL_COMPONENT_PROPERTIES;
-        Resource globalPropsResource = resource.getResourceResolver().getResource(globalPropsPath);
-        return globalPropsResource != null ? globalPropsResource.getValueMap() : ValueMap.EMPTY;
+        return Optional.ofNullable(sharedComponentProperties.getGlobalPropertiesPath(resource))
+                .map(resource.getResourceResolver()::getResource)
+                .map(Resource::getValueMap)
+                .orElse(ValueMap.EMPTY);
     }
 
     /**
      * Get merged properties ValueMap for the current resource.
      */
     protected ValueMap getMergedProperties(String rootPagePath, Resource resource) {
-        Map<String, Object> mergedProperties = new HashMap<>();
-
-        mergedProperties.putAll(getGlobalProperties(rootPagePath, resource));
-        mergedProperties.putAll(getSharedProperties(rootPagePath, resource));
-        mergedProperties.putAll(resource.getValueMap());
-
-        return new ValueMapDecorator(mergedProperties);
+        return sharedComponentProperties.mergeProperties(
+                getGlobalProperties(rootPagePath, resource),
+                getSharedProperties(rootPagePath, resource),
+                resource);
     }
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/SharedComponentProperties.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/SharedComponentProperties.java
@@ -78,6 +78,7 @@ public interface SharedComponentProperties {
      * @return global properties or empty
      */
     ValueMap getGlobalProperties(Resource resource);
+
     /**
      * Construct an absolute resource path for retrieval of a shared component properties value map.
      *

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/SharedComponentProperties.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/SharedComponentProperties.java
@@ -19,11 +19,25 @@
  */
 package com.adobe.acs.commons.wcm.properties.shared;
 
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
 import org.osgi.annotation.versioning.ProviderType;
 
 @ProviderType
 @SuppressWarnings("squid:S1214")
 public interface SharedComponentProperties {
+    /**
+     * Bindings key for the root page path containing the shared and global properties resources
+     */
+    String SHARED_PROPERTIES_PAGE_PATH = "sharedPropertiesPagePath";
+    /**
+     * Bindings key for the resource path evaluated for shared properties
+     */
+    String SHARED_PROPERTIES_PATH = "sharedPropertiesPath";
+    /**
+     * Bindings key for the resource path evaluated for merged properties
+     */
+    String MERGED_PROPERTIES_PATH = "mergedPropertiesPath";
     String SHARED_PROPERTIES = "sharedProperties";
     String GLOBAL_PROPERTIES = "globalProperties";
     String MERGED_PROPERTIES = "mergedProperties";
@@ -39,4 +53,39 @@ public interface SharedComponentProperties {
         GLOBAL,
         MERGED
     }
+
+    /**
+     * Construct an absolute root page path containing the shared and global properties resources appropriate for the
+     * given component resource.
+     *
+     * @param resource the component resource to evaluate
+     * @return an absolute path to a parent resource for shared and global properties
+     */
+    String getSharedPropertiesPagePath(Resource resource);
+
+    /**
+     * Construct an absolute resource path for retrieval of a global component properties value map.
+     *
+     * @param resource the resource to evaluate
+     * @return an absolute path to a possible global component properties resource or null
+     */
+    String getGlobalPropertiesPath(Resource resource);
+
+    /**
+     * Construct an absolute resource path for retrieval of a shared component properties value map.
+     *
+     * @param resource the resource to evaluate
+     * @return an absolute path to a possible shared component properties resource or null
+     */
+    String getSharedPropertiesPath(Resource resource);
+
+    /**
+     * Merge global and shared properties into the valuemap retrieved from the provided resource.
+     *
+     * @param globalProperties global properties or null
+     * @param sharedProperties shared component properties or null
+     * @param resource         the component resource
+     * @return merged properties
+     */
+    ValueMap mergeProperties(ValueMap globalProperties, ValueMap sharedProperties, Resource resource);
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/SharedComponentProperties.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/SharedComponentProperties.java
@@ -72,12 +72,27 @@ public interface SharedComponentProperties {
     String getGlobalPropertiesPath(Resource resource);
 
     /**
+     * Get the global properties of the current resource, or an empty map.
+     *
+     * @param resource the current resource
+     * @return global properties or empty
+     */
+    ValueMap getGlobalProperties(Resource resource);
+    /**
      * Construct an absolute resource path for retrieval of a shared component properties value map.
      *
      * @param resource the resource to evaluate
      * @return an absolute path to a possible shared component properties resource or null
      */
     String getSharedPropertiesPath(Resource resource);
+
+    /**
+     * Get the shared component properties of the current resource, or an empty map.
+     *
+     * @param resource the current resource
+     * @return shared component properties or empty
+     */
+    ValueMap getSharedProperties(Resource resource);
 
     /**
      * Merge global and shared properties into the valuemap retrieved from the provided resource.

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/SharedValueMapResourceAdapter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/SharedValueMapResourceAdapter.java
@@ -1,0 +1,52 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.wcm.properties.shared;
+
+import org.apache.sling.api.resource.ValueMap;
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * Sling Resource Adapter providing access to Shared Component Properties evaluated for a particular resource, in a type
+ * that is friendly to the {@link org.apache.sling.api.adapter.SlingAdaptable} adapters cache.
+ */
+@ProviderType
+public interface SharedValueMapResourceAdapter {
+
+    /**
+     * Get the global properties value map or {@link ValueMap#EMPTY}.
+     *
+     * @return the global properties value map or {@link ValueMap#EMPTY}.
+     */
+    ValueMap getGlobalProperties();
+
+    /**
+     * Get the shared properties for this resource type or {@link ValueMap#EMPTY}.
+     *
+     * @return the shared properties for this resource type or {@link ValueMap#EMPTY}.
+     */
+    ValueMap getSharedProperties();
+
+    /**
+     * Get the merged properties for the adaptable resource.
+     *
+     * @return the merged properties for the adaptable resource.
+     */
+    ValueMap getMergedProperties();
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesBindingsValuesProvider.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesBindingsValuesProvider.java
@@ -70,7 +70,7 @@ public class SharedComponentPropertiesBindingsValuesProvider implements Bindings
             if (sharedComponentProperties != null) {
                 setSharedProperties(bindings, resource, cache);
             } else {
-                log.debug("Shared Component Properties must be configured enable this provider");
+                log.debug("Shared Component Properties must be configured to enable this provider");
             }
         }
         setDefaultBindings(bindings, resource);

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedComponentPropertiesImpl.java
@@ -19,13 +19,119 @@
  */
 package com.adobe.acs.commons.wcm.properties.shared.impl;
 
+import com.adobe.acs.commons.wcm.PageRootProvider;
 import com.adobe.acs.commons.wcm.properties.shared.SharedComponentProperties;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.felix.scr.annotations.Component;
 import org.apache.felix.scr.annotations.ConfigurationPolicy;
+import org.apache.felix.scr.annotations.Reference;
+import org.apache.felix.scr.annotations.ReferenceCardinality;
+import org.apache.felix.scr.annotations.ReferencePolicyOption;
 import org.apache.felix.scr.annotations.Service;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Component(policy = ConfigurationPolicy.REQUIRE)
 @Service
 public class SharedComponentPropertiesImpl implements SharedComponentProperties {
+    private static final Logger LOG = LoggerFactory.getLogger(SharedComponentPropertiesImpl.class);
+    private static final String INFIX_JCR_CONTENT = "/jcr:content/";
+    /**
+     * Bind if available, check for null when reading.
+     */
+    @Reference(policyOption = ReferencePolicyOption.GREEDY, cardinality = ReferenceCardinality.OPTIONAL_UNARY)
+    private PageRootProvider pageRootProvider;
 
+    /**
+     * Construct a canonical resource type relative path for the provided resource type,
+     * or null if the result is not acceptable.
+     * Step 1: discard empty and JCR node types / sling:nonexisting (contains ":")
+     * Step 2: return result if already relative (does not start with /)
+     * Step 3: relativize an absolute path using elements of {@code searchPaths} and return the first match found.
+     *
+     * @param resourceType the request resource resourceType
+     * @param searchPaths  {@link org.apache.sling.api.resource.ResourceResolver#getSearchPath()}
+     * @return the canonical resource type or null
+     */
+    static String getCanonicalResourceTypeRelativePath(final String resourceType, final String[] searchPaths) {
+        if (StringUtils.isEmpty(resourceType) || resourceType.contains(":")) {
+            return null;
+        }
+
+        if (resourceType.charAt(0) != '/') {
+            return resourceType;
+        } else if (searchPaths != null) {
+            for (final String searchPath : searchPaths) {
+                if (resourceType.startsWith(searchPath)) {
+                    return resourceType.substring(searchPath.length());
+                }
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String getSharedPropertiesPagePath(final Resource resource) {
+        if (pageRootProvider != null) {
+            if (resource != null) {
+                final String pagePath = pageRootProvider.getRootPagePath(resource.getPath());
+                if (StringUtils.isNotBlank(pagePath)) {
+                    return pagePath;
+                } else {
+                    LOG.debug("Could not determine shared properties page for resource {}", resource.getPath());
+                }
+            }
+        } else {
+            LOG.debug("Page Root Provider must be configured for shared component properties to be supported");
+        }
+        return null;
+    }
+
+    @Override
+    public String getGlobalPropertiesPath(final Resource resource) {
+        final String rootPagePath = getSharedPropertiesPagePath(resource);
+        if (StringUtils.isNotBlank(rootPagePath)) {
+            return rootPagePath + INFIX_JCR_CONTENT + NN_GLOBAL_COMPONENT_PROPERTIES;
+        }
+
+        return null;
+    }
+
+    @Override
+    public String getSharedPropertiesPath(final Resource resource) {
+        final String rootPagePath = getSharedPropertiesPagePath(resource);
+        if (StringUtils.isBlank(rootPagePath)) {
+            return null;
+        }
+
+        final String resourceTypeRelativePath = getCanonicalResourceTypeRelativePath(resource.getResourceType(),
+                resource.getResourceResolver().getSearchPath());
+        if (resourceTypeRelativePath != null) {
+            return rootPagePath + INFIX_JCR_CONTENT + NN_SHARED_COMPONENT_PROPERTIES + "/" + resourceTypeRelativePath;
+        }
+        return null;
+    }
+
+    @Override
+    public ValueMap mergeProperties(final ValueMap globalProperties,
+                                    final ValueMap sharedProperties,
+                                    final Resource resource) {
+        final Map<String, Object> mergedProperties = new HashMap<>();
+        if (globalProperties != null) {
+            mergedProperties.putAll(globalProperties);
+        }
+        if (sharedProperties != null) {
+            mergedProperties.putAll(sharedProperties);
+        }
+        if (resource != null) {
+            mergedProperties.putAll(resource.getValueMap());
+        }
+        return new ValueMapDecorator(mergedProperties);
+    }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedPropertiesRequestCache.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedPropertiesRequestCache.java
@@ -30,7 +30,7 @@ import java.util.function.Consumer;
 /**
  * Simple cache for global and shared properties bindings keyed by path and persisted in a request attribute.
  */
-final class SharedPropertiesRequestCache {
+public final class SharedPropertiesRequestCache {
     private static final String REQUEST_ATTRIBUTE_NAME = SharedPropertiesRequestCache.class.getName();
 
     private final Map<String, Bindings> cache = new HashMap<>();

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedPropertiesRequestCache.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedPropertiesRequestCache.java
@@ -1,3 +1,22 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2017 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package com.adobe.acs.commons.wcm.properties.shared.impl;
 
 

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedPropertiesRequestCache.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedPropertiesRequestCache.java
@@ -1,0 +1,49 @@
+package com.adobe.acs.commons.wcm.properties.shared.impl;
+
+
+import javax.script.Bindings;
+import javax.script.SimpleBindings;
+import javax.servlet.ServletRequest;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Simple cache for global and shared properties bindings keyed by path and persisted in a request attribute.
+ */
+final class SharedPropertiesRequestCache {
+    private static final String REQUEST_ATTRIBUTE_NAME = SharedPropertiesRequestCache.class.getName();
+
+    private final Map<String, Bindings> cache = new HashMap<>();
+
+    /**
+     * Constructor.
+     */
+    private SharedPropertiesRequestCache() {
+        /* only me */
+    }
+
+    public Bindings getBindings(final String propertiesPath,
+                                final Consumer<Bindings> computeIfNotFound) {
+        return cache.computeIfAbsent(propertiesPath, key -> {
+            final Bindings bindings = new SimpleBindings();
+            computeIfNotFound.accept(bindings);
+            return bindings;
+        });
+    }
+
+    public static SharedPropertiesRequestCache fromRequest(ServletRequest req) {
+        SharedPropertiesRequestCache cache = (SharedPropertiesRequestCache) req.getAttribute(REQUEST_ATTRIBUTE_NAME);
+        if (cache == null) {
+            cache = new SharedPropertiesRequestCache();
+            cache.toRequest(req);
+        }
+        return cache;
+    }
+
+    public SharedPropertiesRequestCache toRequest(ServletRequest req) {
+        SharedPropertiesRequestCache prev = (SharedPropertiesRequestCache) req.getAttribute(REQUEST_ATTRIBUTE_NAME);
+        req.setAttribute(REQUEST_ATTRIBUTE_NAME, this);
+        return prev;
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedValueMapResourceAdapterImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedValueMapResourceAdapterImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * ACS AEM Commons Bundle
  * %%
- * Copyright (C) 2016 Adobe
+ * Copyright (C) 2021 Adobe
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedValueMapResourceAdapterImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedValueMapResourceAdapterImpl.java
@@ -1,0 +1,58 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.wcm.properties.shared.impl;
+
+import com.adobe.acs.commons.wcm.properties.shared.SharedValueMapResourceAdapter;
+import org.apache.sling.api.resource.ValueMap;
+
+import java.util.Optional;
+
+/**
+ * Implementation of {@link SharedValueMapResourceAdapter}.
+ */
+public class SharedValueMapResourceAdapterImpl implements SharedValueMapResourceAdapter {
+
+    private final ValueMap globalProperties;
+    private final ValueMap sharedProperties;
+    private final ValueMap mergedProperties;
+
+    public SharedValueMapResourceAdapterImpl(final ValueMap globalProperties,
+                                             final ValueMap sharedProperties,
+                                             final ValueMap mergedProperties) {
+        this.globalProperties = Optional.ofNullable(globalProperties).orElse(ValueMap.EMPTY);
+        this.sharedProperties = Optional.ofNullable(sharedProperties).orElse(ValueMap.EMPTY);
+        this.mergedProperties = Optional.ofNullable(mergedProperties).orElse(ValueMap.EMPTY);
+    }
+
+    @Override
+    public ValueMap getGlobalProperties() {
+        return globalProperties;
+    }
+
+    @Override
+    public ValueMap getSharedProperties() {
+        return sharedProperties;
+    }
+
+    @Override
+    public ValueMap getMergedProperties() {
+        return mergedProperties;
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/properties/shared/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Shared Component Properties.
  */
-@org.osgi.annotation.versioning.Version("1.2.1")
+@org.osgi.annotation.versioning.Version("1.3.0")
 package com.adobe.acs.commons.wcm.properties.shared;

--- a/bundle/src/test/java/com/adobe/acs/commons/models/injectors/impl/SharedValueMapValueInjectorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/models/injectors/impl/SharedValueMapValueInjectorTest.java
@@ -25,6 +25,8 @@ import com.adobe.acs.commons.models.injectors.impl.model.impl.TestSharedValueMap
 import com.adobe.acs.commons.wcm.impl.PageRootProviderConfig;
 import com.adobe.acs.commons.wcm.impl.PageRootProviderMultiImpl;
 import com.adobe.acs.commons.wcm.properties.shared.SharedComponentProperties;
+import com.adobe.acs.commons.wcm.properties.shared.impl.SharedComponentPropertiesBindingsValuesProvider;
+import com.adobe.acs.commons.wcm.properties.shared.impl.SharedComponentPropertiesImpl;
 import com.day.cq.wcm.api.NameConstants;
 import io.wcm.testing.mock.aem.junit.AemContext;
 import org.apache.jackrabbit.vault.util.JcrConstants;
@@ -74,6 +76,7 @@ public class SharedValueMapValueInjectorTest {
     public void setup() throws RepositoryException {
         this.context.registerInjectActivateService(new PageRootProviderConfig(), "page.root.path", "/content/mysite/[a-z]{2}");
         this.context.registerInjectActivateService(new PageRootProviderMultiImpl());
+        this.context.registerInjectActivateService(new SharedComponentPropertiesImpl());
         this.context.registerInjectActivateService(new SharedValueMapValueAnnotationProcessorFactory());
         this.context.registerInjectActivateService(new SharedValueMapValueInjector());
         this.context.addModelsForClasses(TestSharedValueMapValueModelImpl.class);

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedValueMapResourceAdapterImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/properties/shared/impl/SharedValueMapResourceAdapterImplTest.java
@@ -1,0 +1,49 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.wcm.properties.shared.impl;
+
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertSame;
+
+public class SharedValueMapResourceAdapterImplTest {
+
+    @Test
+    public void testConstructor_nullToEmpty() {
+        final ValueMap otherEmpty = new ValueMapDecorator(new HashMap<>());
+        assertSame("expect empty for global", ValueMap.EMPTY,
+                new SharedValueMapResourceAdapterImpl(null, otherEmpty, otherEmpty).getGlobalProperties());
+        assertSame("expect empty for shared", ValueMap.EMPTY,
+                new SharedValueMapResourceAdapterImpl(otherEmpty, null, otherEmpty).getSharedProperties());
+        assertSame("expect empty for merged", ValueMap.EMPTY,
+                new SharedValueMapResourceAdapterImpl(otherEmpty, otherEmpty, null).getMergedProperties());
+
+        assertSame("expect otherEmpty for global", otherEmpty,
+                new SharedValueMapResourceAdapterImpl(otherEmpty, null, null).getGlobalProperties());
+        assertSame("expect otherEmpty for shared", otherEmpty,
+                new SharedValueMapResourceAdapterImpl(null, otherEmpty, null).getSharedProperties());
+        assertSame("expect otherEmpty for merged", otherEmpty,
+                new SharedValueMapResourceAdapterImpl(null, null, otherEmpty).getMergedProperties());
+    }
+}


### PR DESCRIPTION
This patch includes changes to leverage standard Sling object patterns to greatly improve performance of the SharedValueMapValueInjector and the SharedComponentPropertiesBindingsValuesProvider when rendering a complex page.

* SharedComponentPropertiesBindingsValuesProvider uses an internal request attribute cache type for collecting Bindings computed different levels of shared properties according to their resource paths. This optimizes the BVP behavior by keeping the SCP results around for reuse across sling includes.
* The SharedValueMapValueInjector will now attempt to retrieve results from the SlingBindings when the model adaptable is a request. This greatly optimizes requests for the simple case where a sling model used within an HTL script can access any SCP-provided properties from the SlingBindings, rather having to evaluate the adaptable request or resource again. 
* For more complicated scenarios where the injector is evaluating SCP for a resource adaptable, such as when it is referenced by another model using the @ChildResource annotation, and the bindings provided by BVP are not present or are not relevant for the child resource, the injector will adapt the resource to a SharedValueMapResourceAdapter, which implicitly leverages the SlingAdaptable adapters cache so that the SCP calculation for the injector is only evaluated once. This is similar to the traditional behavior of Resource.getValueMap() and originally Resource.adaptTo(ValueMap.class).