### PR TITLE
add additional options.

### DIFF
--- a/bundle/src/test/resources/com/adobe/acs/commons/workflow/process/impl/ReplicateWithOptionsWorkflowProcessTest.json
+++ b/bundle/src/test/resources/com/adobe/acs/commons/workflow/process/impl/ReplicateWithOptionsWorkflowProcessTest.json
@@ -15,6 +15,18 @@
       "jcr:content": {
         "jcr:primaryType": "nt:unstructured"
       }
+    },
+    "child3" : {
+      "jcr:primaryType": "cq:Page",
+      "jcr:content": {
+        "jcr:primaryType": "nt:unstructured",
+        "seo": {
+          "jcr:primaryType": "nt:unstructured",
+          "canonicalUrlOverride": "/content/xero/gb/en2",
+          "noindex": "true",
+          "priority": "1"
+        }
+      }
     }
   },
   "asset" : {


### PR DESCRIPTION
The idea behind these extensions is to allow replicating parts of a page without replicating the whole page to the publisher and invalidate the page path with the dispatcher. This allows updates of metadata on a page without updating whole page.

An example is if you have `jcr:content/seo` metadata that needs to be updated without replicating the whole page.

This extended version will test if the current payload has a valid child that needs to be replicated if the not current path will be replicated. If flush dispatcher has been enabled this will also replicate this or parent path as payload. Parent payload path is found by resource type that is specified.