### PR TITLE
#2742 - Providing a way to localize list titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ### Fixed
 
+- #2742 - Provided a way to author localized titles for Generic Lists.
 - #2704 - Fixed issue with MCP report generation throwing an exception, and fixed some minor UI issues on AEM SDK (added BG color)
 - #2716 - Fixed issue with Shared Component Properties Bindings Values Provider facing lock contention
 - #2718 - Fixes CM Code Quality Pipeline failure caused by TestMarketoInterfaces and Jacoco instrumentation

--- a/bundle/src/main/java/com/adobe/acs/commons/genericlists/GenericList.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/genericlists/GenericList.java
@@ -84,7 +84,7 @@ public interface GenericList {
         @Nonnull
         @Inject
         @Named("jcr:title")
-        @FormField(name = "Title")
+        @FormField(name = "Title", localize = true)
         String getTitle();
 
         /**

--- a/bundle/src/main/java/com/adobe/acs/commons/genericlists/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/genericlists/package-info.java
@@ -20,5 +20,5 @@
 /**
  * Service for viewing generic list of key/value pairs.
  */
-@org.osgi.annotation.versioning.Version("1.1.0")
+@org.osgi.annotation.versioning.Version("1.1.1")
 package com.adobe.acs.commons.genericlists;

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/AbstractContainerComponent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/AbstractContainerComponent.java
@@ -107,7 +107,7 @@ public class AbstractContainerComponent extends FieldComponent {
     private void extractFieldComponents(Class clazz) {
         if (clazz == String.class || clazz.isPrimitive()) {
             FieldComponent comp = generateDefaultChildComponent();
-            FormField fieldDef = FormField.Factory.create(getName(), "", null, null, false, comp.getClass(), null);
+            FormField fieldDef = FormField.Factory.create(getName(), "", null, null, false, comp.getClass(), null, false, null);
             comp.setup(getName(), null, fieldDef, getHelper());
             comp.getComponentMetadata().put("title", getName());
             // TODO: Provide a proper mechanism for setting path when creating components

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FormField.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FormField.java
@@ -50,13 +50,17 @@ public @interface FormField {
 
     boolean showOnCreate() default true;
 
+    boolean localize() default false;
+
+    String[] languages() default { "en" };
+
     public static class Factory {
         private Factory() {
             // Factory cannot be instantiated
         }
 
         // Create FormField annotation, used to programatically generate forms when introspection isn't an option.
-        public static FormField create(String name, String hint, String description, String category, boolean required, Class<? extends FieldComponent> clazz, String[] options) {
+        public static FormField create(String name, String hint, String description, String category, boolean required, Class<? extends FieldComponent> clazz, String[] options, boolean localize, String[] languages) {
             return new FormField() {
                 @Override
                 public String name() {
@@ -101,6 +105,16 @@ public @interface FormField {
                 @Override
                 public boolean showOnCreate() {
                     return true;
+                }
+
+                @Override
+                public boolean localize() {
+                    return localize;
+                }
+
+                @Override
+                public String[] languages() {
+                    return languages;
                 }
             };
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/package-info.java
@@ -20,7 +20,7 @@
 /**
  * Form components for MCP
  */
-@Version("5.3.0")
+@Version("6.0.0")
 package com.adobe.acs.commons.mcp.form;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/form/FieldComponentTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/form/FieldComponentTest.java
@@ -183,6 +183,16 @@ public class FieldComponentTest {
                 public boolean showOnCreate() {
                     return true;
                 }
+
+                @Override
+                public boolean localize() {
+                    return false;
+                }
+
+                @Override
+                public String[] languages() {
+                    return null;
+                }
             };
             setup("test", null, field, null);
         }

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/form/SyntheticFormResourceTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/form/SyntheticFormResourceTest.java
@@ -26,6 +26,7 @@ import com.adobe.acs.commons.mcp.util.DeserializeException;
 import java.util.Map;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.scripting.SlingScriptHelper;
 import org.junit.Test;
 
@@ -116,7 +117,11 @@ public class SyntheticFormResourceTest {
     public void syntheticResourceTest() throws DeserializeException {
         SlingHttpServletRequest mockRequest = mock(SlingHttpServletRequest.class);
         SlingScriptHelper mockScriptHelper = mock(SlingScriptHelper.class);
+        ResourceResolver mockResourceResolver = mock(ResourceResolver.class);
         when(mockScriptHelper.getRequest()).thenReturn(mockRequest);
+        when(mockRequest.getResourceResolver()).thenReturn(mockResourceResolver);
+        when(mockResourceResolver.getResource(anyString())).thenReturn(null);
+
         Map<String, FieldComponent> form = AnnotatedFieldDeserializer.getFormFields(getClass(), mockScriptHelper);
         assertNotNull(form.get("textComponentTest"));
         Resource fieldResource = form.get("textComponentTest").buildComponentResource();


### PR DESCRIPTION
Available languages to use for localization are taken from `wcm/core/resources/languages`. Users can customize what languages are needed by overlaying `/libs/wcm/core/resources/languages` into `/apps/wcm/core/resources/languages' and only storing the languages they need.