### PR TITLE
Fix #2749 and #2488: Manage Controlled Processes does not show any process

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/ControlledProcessManagerServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/ControlledProcessManagerServlet.java
@@ -121,7 +121,7 @@ public class ControlledProcessManagerServlet extends SlingAllMethodsServlet {
             LOG.error(ex.getMessage() + " -- End of line.", ex);
         }
         getGson().toJson(result, response.getWriter());
-        response.getWriter().flush(); // #2749
+        response.getWriter().close(); // #2749
     }
 
     Gson getGson() {

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/ControlledProcessManagerServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/ControlledProcessManagerServlet.java
@@ -120,8 +120,8 @@ public class ControlledProcessManagerServlet extends SlingAllMethodsServlet {
             result = "Exception occurred " + ex.getMessage();
             LOG.error(ex.getMessage() + " -- End of line.", ex);
         }
-        getGson().toJson(result, response.getWriter());
-        response.getWriter().close(); // #2749
+        String json = getGson().toJson(result); // #2749
+        response.getWriter().write(json);
     }
 
     Gson getGson() {

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/ControlledProcessManagerServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/ControlledProcessManagerServlet.java
@@ -28,6 +28,7 @@ import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -120,7 +121,9 @@ public class ControlledProcessManagerServlet extends SlingAllMethodsServlet {
             result = "Exception occurred " + ex.getMessage();
             LOG.error(ex.getMessage() + " -- End of line.", ex);
         }
-        getGson().toJson(result, response.getWriter());
+        PrintWriter writer = response.getWriter();
+        getGson().toJson(result, writer);
+        writer.flush(); // #2749
     }
 
     Gson getGson() {

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/ControlledProcessManagerServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/ControlledProcessManagerServlet.java
@@ -28,7 +28,6 @@ import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -121,9 +120,8 @@ public class ControlledProcessManagerServlet extends SlingAllMethodsServlet {
             result = "Exception occurred " + ex.getMessage();
             LOG.error(ex.getMessage() + " -- End of line.", ex);
         }
-        PrintWriter writer = response.getWriter();
-        getGson().toJson(result, writer);
-        writer.flush(); // #2749
+        getGson().toJson(result, response.getWriter());
+        response.getWriter().flush(); // #2749
     }
 
     Gson getGson() {

--- a/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlusherServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlusherServlet.java
@@ -143,6 +143,7 @@ public class DispatcherFlusherServlet extends SlingAllMethodsServlet {
                 resultMap.put(result.agentId, result.success);
             }
             gson.toJson(resultMap, response.getWriter());
+            response.getWriter().close(); // #2749
         } else {
             String suffix;
             if (caughtException) {

--- a/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlusherServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlusherServlet.java
@@ -142,8 +142,8 @@ public class DispatcherFlusherServlet extends SlingAllMethodsServlet {
             for (final FlushResult result : overallResults) {
                 resultMap.put(result.agentId, result.success);
             }
-            gson.toJson(resultMap, response.getWriter());
-            response.getWriter().close(); // #2749
+            String json = gson.toJson(resultMap); // #2749
+            response.getWriter().write(json);
         } else {
             String suffix;
             if (caughtException) {

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/VanityDuplicateCheckServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/VanityDuplicateCheckServlet.java
@@ -84,6 +84,7 @@ public final class VanityDuplicateCheckServlet extends SlingSafeMethodsServlet {
 
         Gson gson = new Gson();
         gson.toJson(paths, response.getWriter());
+        response.getWriter().close(); // #2749
     }
 
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/VanityDuplicateCheckServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/VanityDuplicateCheckServlet.java
@@ -83,8 +83,8 @@ public final class VanityDuplicateCheckServlet extends SlingSafeMethodsServlet {
         }
 
         Gson gson = new Gson();
-        gson.toJson(paths, response.getWriter());
-        response.getWriter().close(); // #2749
+        String json = gson.toJson(paths); // #2749
+        response.getWriter().write(json);
     }
 
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/ControlledProcessManagerServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/ControlledProcessManagerServletTest.java
@@ -19,19 +19,48 @@
  */
 package com.adobe.acs.commons.mcp.impl;
 
+import com.adobe.acs.commons.mcp.ControlledProcessManager;
+import com.adobe.acs.commons.mcp.ProcessDefinition;
+import com.adobe.acs.commons.mcp.ProcessInstance;
+import com.adobe.acs.commons.mcp.model.ManagedProcess;
+import com.adobe.acs.commons.mcp.model.impl.ArchivedProcessInstance;
+import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import io.wcm.testing.mock.aem.junit.AemContext;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestParameter;
 import org.apache.sling.api.request.RequestParameterMap;
+import org.apache.sling.api.request.RequestPathInfo;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.servlet.MockRequestPathInfo;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.reflect.Whitebox;
+
+import javax.servlet.ServletException;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -42,12 +71,28 @@ import static org.mockito.Mockito.when;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class ControlledProcessManagerServletTest {
+    @Rule
+    public AemContext ctx = new AemContext(ResourceResolverType.JCR_MOCK);
 
-    ControlledProcessManagerServlet servlet;
+    @Mock
+    ControlledProcessManager manager;
+
+    @InjectMocks
+    ControlledProcessManagerServlet servlet = new ControlledProcessManagerServlet();;
 
     @Before
     public void setUp() {
-        servlet = new ControlledProcessManagerServlet();
+        ctx.addModelsForClasses(ArchivedProcessInstance.class, ManagedProcess.class);
+
+        List<ProcessInstance> activeProcesses = new ArrayList<>();
+        ArchivedProcessInstance p1 = new ArchivedProcessInstance();
+        ManagedProcess infoBean = new ManagedProcess();
+        Whitebox.setInternalState(p1, "infoBean", infoBean);
+
+        List<ProcessInstance> inactiveProcesses = new ArrayList<>();
+        inactiveProcesses.add(p1);
+        when(manager.getActiveProcesses()).thenReturn(activeProcesses);
+        when(manager.getInactiveProcesses()).thenReturn(inactiveProcesses);
     }
 
     /**
@@ -103,5 +148,25 @@ public class ControlledProcessManagerServletTest {
         public InputStream noSerialize5 = mock(InputStream.class);
         public Resource noSerialize6 = mock(Resource.class);
         public int serialize7 = 1;
+    }
+
+    @Test // #2749: Manage Controlled Processes does not show any process
+    public void test2749() throws IOException, ServletException {
+        SlingHttpServletRequest request = mock(SlingHttpServletRequest.class);
+        RequestPathInfo pathInfo = mock(RequestPathInfo.class);
+        when(pathInfo.getSelectorString()).thenReturn("list");
+        when(request.getRequestPathInfo()).thenReturn(pathInfo);
+
+        SlingHttpServletResponse response = mock(SlingHttpServletResponse.class);
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        PrintWriter writer = new PrintWriter(bos);
+        when(response.getWriter()).thenReturn(writer);
+
+        servlet.doGet(request, response);
+
+        String json = bos.toString(); // the string returned in the response
+        Type list = new TypeToken<ArrayList<ArchivedProcessInstance>>() {}.getType();
+        List<ProcessInstance> instances = servlet.getGson().fromJson(json, list);
+        assertEquals(1, instances.size());
     }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/ControlledProcessManagerServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/ControlledProcessManagerServletTest.java
@@ -164,6 +164,7 @@ public class ControlledProcessManagerServletTest {
 
         servlet.doGet(request, response);
 
+        writer.close(); // the servlet engine closes the response stream
         String json = bos.toString(); // the string returned in the response
         Type list = new TypeToken<ArrayList<ArchivedProcessInstance>>() {}.getType();
         List<ProcessInstance> instances = servlet.getGson().fromJson(json, list);


### PR DESCRIPTION
Fix #2749 and #2488:

When serializing data using

```
gson.toJson(object, writer);
```
we need to ensure response.getWriter() is closed in the end, otherwise it might return an empty json. 

see the explanation in https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/2749#issuecomment-986244291
