### PR TITLE
Fix #2738: ignore exceptions when auto-sizing report columns

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/GenericReportExcelServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/GenericReportExcelServlet.java
@@ -150,7 +150,7 @@ public class GenericReportExcelServlet extends SlingSafeMethodsServlet {
         for(int i = 0; i <= lastColumnIndex; i++ ) {
             try {
                 sheet.autoSizeColumn(i);
-            } catch (Exception e){
+            } catch (Throwable e){
                 // autosize depends on AWT stuff and can fail, but it should not be fatal
                 LOG.warn("autoSizeColumn({}) failed: {}",i, e.getMessage());
             }

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/ProcessErrorReportExcelServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/ProcessErrorReportExcelServlet.java
@@ -159,7 +159,7 @@ public class ProcessErrorReportExcelServlet extends SlingSafeMethodsServlet {
         for (int i = 0; i <= lastColumnIndex; i++) {
             try {
                 sheet.autoSizeColumn(i);
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 // autosize depends on AWT stuff and can fail, but it should not be fatal
                 LOG.warn("autoSizeColumn({}) failed: {}",i, e.getMessage());
             }


### PR DESCRIPTION
ACS Commons uses the Apache POI library to generate Excel reports. On some platforms POI can throw `java.lang.reflect.InvocationTargetException` when auto-sizing spreadsheet  columns. The behavior depends whether  the default fonts are available on the underlying OS. This can only be reproduced in pure headless environments. Developers will never see it on their locals because they are running GUI.

We should silently ignore such auto-sizing errors as they are not fatal.  User will be able to download the report, only the spreadsheet columns will not auto-sized.

I contributed the auto-size code to POI in JDK 1.6 times and it never threw InvocationTargetException back then. Starting JDK 1.7 some vendors stopped shipping default fonts with their JDKs which resulted in InvocationTargetException when calling Java AWT classes. It's not a POI bug, e.g. similar problems were reported  on  https://bugs.openjdk.java.net/browse/JDK-8204688 