### PR TITLE
Change organization to "AEM developer community"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     </licenses>
 
     <organization>
-        <name>Adobe</name>
+        <name>AEM developer community</name>
         <url>https://adobe-consulting-services.github.io/acs-aem-commons/</url>
     </organization>
 


### PR DESCRIPTION
Following https://github.com/Adobe-Consulting-Services/adobe-consulting-services.github.io/pull/217/files
also the organization in the pom.xml should change

It appears as vendor in the bundle header as well.