### PR TITLE
use osgi-mock 3.2.2 to fix spurious test errors due to

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -433,6 +433,19 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.sling</groupId>
+                <artifactId>org.apache.sling.testing.osgi-mock.junit4</artifactId>
+                <version>3.2.2</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>org.apache.sling.testing.osgi-mock.core</artifactId>
+                <version>3.2.2</version>
+                <scope>test</scope>
+            </dependency>
+            <!-- sling-mock still uses an outdated osgi-mock, therefore explicitly manage its version to the latest 3.2.2 -->
+            <dependency>
+                <groupId>org.apache.sling</groupId>
                 <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
                 <version>3.2.2</version>
                 <scope>test</scope>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SLING-10973