### PR TITLE
#2806 added new exception on in the accepts method to avoid rendering…

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/AemEnvironmentIndicatorFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/AemEnvironmentIndicatorFilter.java
@@ -226,8 +226,7 @@ public class AemEnvironmentIndicatorFilter implements Filter {
                                 : null;
 
                 if (contents != null) {
-                    final int bodyIndex = contents.indexOf("</body>");
-
+                    final int bodyIndex = StringUtils.lastIndexOf(contents, "</body>");
                     if (bodyIndex != -1) {
                         // prevent the captured response from being given out a 2nd time via the implicit close()
                         capturedResponse.setFlushBufferOnClose(false);
@@ -321,9 +320,14 @@ public class AemEnvironmentIndicatorFilter implements Filter {
 
     boolean hasAemEditorReferrer(final String headerValue, final String requestUri) {
         return StringUtils.endsWith(headerValue, "/editor.html" + requestUri)
-                || StringUtils.endsWith(headerValue, "/cf");
+                || StringUtils.endsWith(headerValue, "/cf")
+                || isEditExperienceFragmentVariation(headerValue, requestUri);
     }
-    
+
+    boolean isEditExperienceFragmentVariation(String headerValue, String requestUri) {
+        return StringUtils.contains(headerValue, "/editor.html/content/experience-fragments/") && StringUtils.startsWith(requestUri, "/content/experience-fragments/");
+    }
+
     @Activate
     @SuppressWarnings("squid:S1149")
     protected final void activate(ComponentContext ctx) {

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/AemEnvironmentIndicatorFilterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/AemEnvironmentIndicatorFilterTest.java
@@ -208,8 +208,15 @@ public class AemEnvironmentIndicatorFilterTest {
         context.request().setHeader("Referer", "/editor.html/content/we-retail.html");
         assertFalse(filter.accepts(context.request()));
     }
-    
-  
+
+    @Test
+    public void testIsEditExperienceFragmentVariation() {
+        context.registerInjectActivateService(filter, props);
+        context.request().setPathInfo("/content/experience-fragments/core-components-examples/library/simple-experience-fragment/simple-experience-fragment-livecopy.html");
+        context.request().setHeader("Referer", "/editor.html/content/experience-fragments/core-components-examples/library/simple-experience-fragment/master.html");
+        assertFalse(filter.accepts(context.request()));
+    }
+
     @Test
     public void testIsImproperlyConfigured() {
         assertFalse(filter.isImproperlyConfigured("not-blank", "not-blank"));


### PR DESCRIPTION
 - Added new exception on the accepts method to avoid rendering 2 times the AEM Environment indicator when editing an Experience Fragment variation
 - StringUtils.lastIndexOf(contents, "</body>") instead of contents.indexOf("</body>") to avoid possible issues with iframes.