### PR TITLE
replaced underscore with acs-commons.lodash based on 2821

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/touchui-widgets/composite-multifield/.content.xml
@@ -4,7 +4,7 @@
           jsProcessor="[default:none,min:gcc]"
           allowProxy="{Boolean}true"
           categories="[acs-commons.authoring.composite-multifield,acs-commons.granite.ui.coral2.foundation]"
-          dependencies="[underscore]"/>
+          dependencies="[acs-commons.lodash]"/>
 <!--
 
 Wrapper Client Library definition:


### PR DESCRIPTION
As suggested in  ACS Commons 5.1.2 | Composite Multifield and Loadash behaviour #2821 (https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/2821) a change of the dependency of multifield has been raised.
This has been through a local build and partially tested on a local 6.5.12 + Asset search HF.
I had no time to add a multifield component to my local thus tests are partial
@wrandall22 would be a good reviewer