### PR TITLE
Fix/2830 - Dynamic Deck Dynamo rendering fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-5.0.14...HEAD
 
+### Fixed
+
+#2830 - Fixed issue with Dynamic Deck Dynamo breaking when the Dynamic Deck Dynamo has no items in its generic list page
+
 ## 5.3.0 - 2022-04-15
 
 ### Fixed

--- a/bundle/src/main/java/com/adobe/acs/commons/genericlists/impl/GenericListAdapterFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/genericlists/impl/GenericListAdapterFactory.java
@@ -52,8 +52,7 @@ public class GenericListAdapterFactory implements AdapterFactory {
         }
         final Page page = (Page) obj;
         if (page.getContentResource() != null
-                && page.getContentResource().isResourceType(GenericListImpl.RT_GENERIC_LIST)
-                && page.getContentResource().getChild("list") != null) {
+                && page.getContentResource().isResourceType(GenericListImpl.RT_GENERIC_LIST)) {
             return new GenericListImpl(page.getContentResource().getChild("list"));
         }
         return null;

--- a/bundle/src/main/java/com/adobe/acs/commons/genericlists/impl/GenericListImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/genericlists/impl/GenericListImpl.java
@@ -106,22 +106,27 @@ public final class GenericListImpl implements GenericList {
     private final Map<String, Item> valueMapping;
 
     public GenericListImpl(Resource listParsys) {
-        List<Item> tempItems = new ArrayList<>();
-        Map<String, Item> tempValueMapping = new HashMap<>();
-        Iterator<Resource> children = listParsys.listChildren();
-        while (children.hasNext()) {
-            Resource res = children.next();
-            ValueMap map = res.getValueMap();
-            String title = map.get(NameConstants.PN_TITLE, String.class);
-            String value = map.get(PN_VALUE, String.class);
-            if (title != null) {
-                ItemImpl item = new ItemImpl(title, value, map);
-                tempItems.add(item);
-                tempValueMapping.put(value, item);
+        if (listParsys == null) {
+            items = Collections.emptyList();
+            valueMapping = Collections.emptyMap();
+        } else {
+            List<Item> tempItems = new ArrayList<>();
+            Map<String, Item> tempValueMapping = new HashMap<>();
+            Iterator<Resource> children = listParsys.listChildren();
+            while (children.hasNext()) {
+                Resource res = children.next();
+                ValueMap map = res.getValueMap();
+                String title = map.get(NameConstants.PN_TITLE, String.class);
+                String value = map.get(PN_VALUE, String.class);
+                if (title != null) {
+                    ItemImpl item = new ItemImpl(title, value, map);
+                    tempItems.add(item);
+                    tempValueMapping.put(value, item);
+                }
             }
+            items = Collections.unmodifiableList(tempItems);
+            valueMapping = Collections.unmodifiableMap(tempValueMapping);
         }
-        items = Collections.unmodifiableList(tempItems);
-        valueMapping = Collections.unmodifiableMap(tempValueMapping);
     }
 
     @Override

--- a/bundle/src/test/java/com/adobe/acs/commons/genericlists/impl/GenericListAdapterFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/genericlists/impl/GenericListAdapterFactoryTest.java
@@ -114,6 +114,18 @@ public class GenericListAdapterFactoryTest {
         assertEquals("valueone", items.get(0).getValue());
     }
 
+
+    @Test
+    public void test_that_adapting_page_with_no_list_node_return_empty_generic_list() {
+        when(contentResource.getChild("list")).thenReturn(null);
+
+        GenericList list = adapterFactory.getAdapter(listPage, GenericList.class);
+        assertNotNull(list);
+        List<Item> items = list.getItems();
+        assertNotNull(items);
+        assertEquals(0, items.size());
+    }
+
     @Test
     public void test_that_adapting_page_with_wrong_resourceType_returns_null() {
         Page wrongPage = mock(Page.class);


### PR DESCRIPTION
Allows a generic list to have no `jcr:content/list` without throwing NPE's as this is the initial state. A GL with no `jcr:content/list` is considered empty.