### PR TITLE
#2837: use  injector-specific annotations to prevent the wrong injector from kicking in

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/model/GenericBlobReport.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/model/GenericBlobReport.java
@@ -43,6 +43,7 @@ import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.ChildResource;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,7 +69,7 @@ public class GenericBlobReport extends AbstractReport {
     @Inject
     String name;
 
-    @Inject
+    @ValueMapValue
     List<String> columns;
 
     private static final Logger LOG = LoggerFactory.getLogger(GenericBlobReport.class);

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/model/GenericReport.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/model/GenericReport.java
@@ -38,6 +38,7 @@ import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.osgi.annotation.versioning.ProviderType;
 
 import com.adobe.acs.commons.mcp.ProcessInstance;
@@ -53,7 +54,7 @@ import com.day.cq.commons.jcr.JcrUtil;
 public class GenericReport extends AbstractReport {
     public static final String GENERIC_REPORT_RESOURCE_TYPE = ProcessInstance.RESOURCE_TYPE + "/process-generic-report";
 
-    @Inject
+    @ValueMapValue
     private List<String> columns;
 
     @Inject


### PR DESCRIPTION
Fix https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/2837