### PR TITLE
Expiration time in Adobe I/O JWT token needs to be a long value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 - #2837 - Fixed blank MCP reports when running on AEM as a Cloud Service with Forms SDK
 - #2826 - 5.3.1-SNAPSHOT build failing validation locally
+- #2860 - Changed expiration time from Date object to long value. Expiration time in Adobe I/O JWT token needs to be a long value. 
+
 
 ## 5.3.0 - 2022-04-15
 

--- a/bundle/src/main/java/com/adobe/acs/commons/adobeio/service/impl/IntegrationServiceImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/adobeio/service/impl/IntegrationServiceImpl.java
@@ -207,11 +207,11 @@ public class IntegrationServiceImpl implements IntegrationService, Runnable {
         return jwtClaims;
     }
 
-    private Date getExpirationDate() {
+    private long getExpirationDate() {
         Calendar cal = Calendar.getInstance();
         cal.setTime(new Date());
         cal.add(Calendar.SECOND, jwtServiceConfig.expirationTimeInSeconds());
-        return cal.getTime();
+        return cal.getTime().getTime();
     }
 
 }


### PR DESCRIPTION
If the "exp" JSON attribute does not have a long value of time, the access_token generation request will throw below error:
```
{
    "error_description": "JWT token is incorrectly formatted, and can not be decoded.",
    "error": "invalid_token"
}
```
Error JWT Payload:

```
{
     exp: 'Thu Jun 09 16:58:09 EDT 2022', // Note the value of timestamp, this has to be long e.g., 123497778
     sub: 'XXXXX@techacct.adobe.com', 
     aud:'https://ims-na1.adobelogin.com/c/abc',
     iss:'XXX@AdobeOrg',
     'https://ims-na1.adobelogin.com/s/ent_campaign_sdk':true,
 }
```
