### PR TITLE
#2867 the versioned clientlibs transformers picks up link tags 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ## Unreleased ([details][unreleased changes details])
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-5.0.14...HEAD
-
+- #2867 - Make the Versioned Clientlibs transformer pick up css link tags without a type attribute if  the attribute rel="stylesheet" is set
 ### Fixed
 
 - #2837 - Fixed blank MCP reports when running on AEM as a Cloud Service with Forms SDK

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/SaxElementUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/SaxElementUtils.java
@@ -32,13 +32,15 @@ public class SaxElementUtils {
     public static final String CSS_TYPE = "text/css";
     public static final String JS_TYPE = "text/javascript";
     public static final String JS_MODULE_TYPE = "module";
+    public static final String STYLESHEET_REL="stylesheet";
 
     public static boolean isCss(final String elementName, final Attributes attrs) {
         final String type = attrs.getValue("", "type");
         final String href = attrs.getValue("", "href");
+        final String rel = attrs.getValue("","rel");
 
         return StringUtils.equals("link", elementName)
-                && StringUtils.equals(type, CSS_TYPE)
+                && (StringUtils.equals(type, CSS_TYPE) || StringUtils.equals(rel,STYLESHEET_REL))
                 && StringUtils.startsWith(href, "/")
                 && !StringUtils.startsWith(href, "//")
                 && StringUtils.endsWith(href, LibraryType.CSS.extension);

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/SaxElementUtilsTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/SaxElementUtilsTest.java
@@ -39,6 +39,12 @@ public class SaxElementUtilsTest {
                                 "href", "/css.css",
                                 "type", "text/css")));
 
+        assertTrue("CSS with Rel attribute ",
+                SaxElementUtils.isCss("link",
+                        makeAtts(
+                                "href", "/css.css",
+                                "rel", "stylesheet")));
+
         assertFalse("CSS - not a link",
                 SaxElementUtils.isCss("notlink",
                         makeAtts(
@@ -70,6 +76,7 @@ public class SaxElementUtilsTest {
                                 "href", "/css.css",
                                 "type", "text/notcss")));
     }
+
 
     @Test
     public void testIsJavascript() throws Exception {


### PR DESCRIPTION
 the versioned clientlibs transformers picks up link tags with rel=stylesheet even if the type attribute is missing