### PR TITLE
Support for selector-based redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ## Unreleased ([details][unreleased changes details])
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-5.0.14...HEAD
+- #2877 - Support for selector-based redirects
 
 ## 5.3.2 - 2022-06-22
 

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
@@ -153,7 +153,8 @@ public class RedirectFilter extends AnnotatedStandardMBean
         @AttributeDefinition(name = "Preserve Query String", description = "Preserve query string in redirects", type = AttributeType.BOOLEAN)
         boolean preserveQueryString() default true;
 
-        @AttributeDefinition(name = "Evaluate Selectors", description = "Take into account selectors when evaluating redirects", type = AttributeType.BOOLEAN)
+        @AttributeDefinition(name = "Evaluate Selectors", description = "Take into account selectors when evaluating redirects. " +
+                "When this flag is unchecked (default), selectors are ignored and don't participate in rule matching", type = AttributeType.BOOLEAN)
         boolean evaluateSelectors() default false;
 
         @AttributeDefinition(name = "Additional Response Headers", description = "Optional response headers in the name:value format to apply on delivery,"
@@ -567,7 +568,7 @@ public class RedirectFilter extends AnnotatedStandardMBean
             });
             RequestPathInfo requestPathInfo = slingRequest.getRequestPathInfo();
             String resourcePath = requestPathInfo.getResourcePath(); // /content/mysite/en/page.html
-            if(evaluateSelectors && requestPathInfo.getSelectorString() != null){
+            if(evaluateSelectors && requestPathInfo.getSelectorString() != null) {
                 resourcePath += "." + requestPathInfo.getSelectorString();
             }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/models/RedirectConfiguration.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/models/RedirectConfiguration.java
@@ -74,8 +74,8 @@ public class RedirectConfiguration {
     public static String normalizePath(String resourcePath) {
         int sep = resourcePath.lastIndexOf('.');
         if (sep != -1 && !resourcePath.startsWith("/content/dam/")) {
-            // strip off extension if present
-            resourcePath = resourcePath.substring(0, sep);
+            // strip off .html extension and query string if present
+            resourcePath = resourcePath.replaceAll("\\.html(\\?.*)?$", "");
         }
         return resourcePath;
     }

--- a/bundle/src/test/java/com/adobe/acs/commons/redirects/filter/RedirectFilterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirects/filter/RedirectFilterTest.java
@@ -815,6 +815,8 @@ public class RedirectFilterTest {
 
         withRules(
                 new RedirectRule("/content/geometrixx/en/one\\.(mobile|desktop)", "/content/geometrixx/en/two",
+                        302, null, null),
+                new RedirectRule("/content/we-retail/en/home.product1/*", "/content/we-retail/en/home.product2",
                         302, null, null)
         );
 
@@ -824,6 +826,10 @@ public class RedirectFilterTest {
                 navigate("/content/geometrixx/en/one.desktop.html").getHeader("Location"));
         // unknown selector, does not match the regex
         assertEquals(null, navigate("/content/geometrixx/en/one.unknown.html").getHeader("Location"));
+
+        assertEquals("/content/we-retail/en/home.product2.html",
+                navigate("/content/we-retail/en/home.product1/feature.html").getHeader("Location"));
+        assertEquals(null, navigate("/content/we-retail/en/home.unknown/feature.html").getHeader("Location"));
     }
 
 

--- a/bundle/src/test/java/com/adobe/acs/commons/redirects/filter/RedirectFilterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirects/filter/RedirectFilterTest.java
@@ -64,17 +64,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class RedirectFilterTest {
 
@@ -140,7 +130,7 @@ public class RedirectFilterTest {
         context.requestPathInfo().setResourcePath(resourcePath);
         request.setResource(context.create().resource(resourcePath));
 
-        MockSlingHttpServletResponse response = context.response();
+        MockSlingHttpServletResponse response = new MockSlingHttpServletResponse();
         filter.doFilter(request, response, filterChain);
 
         return response;
@@ -795,4 +785,65 @@ public class RedirectFilterTest {
                 .doFilter(any(SlingHttpServletRequest.class), any(SlingHttpServletResponse.class));
     }
 
+
+    @Test
+    public void testMatchSelectors() throws Exception {
+        RedirectFilter.Configuration configuration = filter.getConfiguration();
+        when(configuration.evaluateSelectors()).thenReturn(true);
+        filter.activate(configuration, context.bundleContext());
+
+        withRules(
+                new RedirectRule("/content/geometrixx/en/one.mobile", "/content/geometrixx/en/two",
+                        302, null, null)
+        );
+
+        // happy path: selector matched
+        assertEquals("/content/geometrixx/en/two.html",
+                navigate("/content/geometrixx/en/one.mobile.html").getHeader("Location"));
+
+        // no selectors
+        assertEquals(null, navigate("/content/geometrixx/en/one.html").getHeader("Location"));
+        // selector does not match the rule
+        assertEquals(null, navigate("/content/geometrixx/en/one.desktop.html").getHeader("Location"));
+    }
+
+    @Test
+    public void testMatchSelectorsRegex() throws Exception {
+        RedirectFilter.Configuration configuration = filter.getConfiguration();
+        when(configuration.evaluateSelectors()).thenReturn(true);
+        filter.activate(configuration, context.bundleContext());
+
+        withRules(
+                new RedirectRule("/content/geometrixx/en/one\\.(mobile|desktop)", "/content/geometrixx/en/two",
+                        302, null, null)
+        );
+
+        assertEquals("/content/geometrixx/en/two.html",
+                navigate("/content/geometrixx/en/one.mobile.html").getHeader("Location"));
+        assertEquals("/content/geometrixx/en/two.html",
+                navigate("/content/geometrixx/en/one.desktop.html").getHeader("Location"));
+        // unknown selector, does not match the regex
+        assertEquals(null, navigate("/content/geometrixx/en/one.unknown.html").getHeader("Location"));
+    }
+
+
+    @Test
+    public void testSelectorsDisabled() throws Exception {
+        RedirectFilter.Configuration configuration = filter.getConfiguration();
+        when(configuration.evaluateSelectors()).thenReturn(false);
+        filter.activate(configuration, context.bundleContext());
+
+        withRules(
+                new RedirectRule("/content/geometrixx/en/one", "/content/geometrixx/en/page1",
+                        302, null, null),
+                new RedirectRule("/content/geometrixx/en/one.desktop", "/content/geometrixx/en/page1",
+                        302, null, null),
+                new RedirectRule("/content/geometrixx/en/one.mobile", "/content/geometrixx/en/page1",
+                        302, null, null)
+        );
+
+        assertEquals("/content/geometrixx/en/page1.html", navigate("/content/geometrixx/en/one.html").getHeader("Location"));
+        assertEquals("/content/geometrixx/en/page1.html", navigate("/content/geometrixx/en/one.mobile.html").getHeader("Location"));
+        assertEquals("/content/geometrixx/en/page1.html", navigate("/content/geometrixx/en/one.desktop.html").getHeader("Location"));
+    }
 }


### PR DESCRIPTION
The PR introduces support for selector-based redirects

```
/content/geometrixx/en/one.mobile =>  /content/geometrixx/en/two
/content/geometrixx/en/one\\.(mobile|desktop) => /content/geometrixx/en/two

# change selector on the same resource path
/content/geometrixx/en/one.mobile =>  /content/geometrixx/en/one.desktop 

```
See https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/2855

The new feature is enabled by flag in the OSGi configuration. The default is `false` which means selectors are not taken into account. This is to stay compatible with the old, selector-agnostic implementation. 

Documentation update is in https://github.com/Adobe-Consulting-Services/adobe-consulting-services.github.io/pull/231