### PR TITLE
Redirect Manager: support jcr:created and jcr:createdBy in Touch UI and Excel export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ## Unreleased ([details][unreleased changes details])
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
 [unreleased changes details]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-5.0.14...HEAD
+- #2936 - Redirect Manager: Expose the "Redirect Creator" property in Touch UI and Excel Export 
+- #2938 - Redirect Manager: Redirect rules imported from Excel file do not store jcr:created and jcr:createdBy properties
 
 ## 5.3.4 - 2022-08-22
 

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
@@ -356,7 +356,7 @@ public class RedirectFilter extends AnnotatedStandardMBean
         Collection<RedirectRule> rules = new ArrayList<>();
         for (Resource res : resource.getChildren()) {
             if(res.isResourceType(REDIRECT_RULE_RESOURCE_TYPE)){
-                rules.add(RedirectRule.from(res.getValueMap()));
+                rules.add(RedirectRule.from(res));
             }
         }
         return rules;

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilterMBean.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilterMBean.java
@@ -20,8 +20,6 @@
 package com.adobe.acs.commons.redirects.filter;
 
 import com.adobe.granite.jmx.annotation.Description;
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
 
 import javax.management.openmbean.OpenDataException;
 import javax.management.openmbean.TabularData;

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/models/RedirectRule.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/models/RedirectRule.java
@@ -71,10 +71,14 @@ public class RedirectRule {
     @Optional
     private boolean contextPrefixIgnored;
 
+    @ValueMapValue
+    @Optional
+    private Calendar untilDate;
+
     @Self
     private Resource resource;
 
-    private ZonedDateTime untilDate;
+    private ZonedDateTime zonedUntilDate;
 
     private Pattern ptrn;
 
@@ -105,14 +109,18 @@ public class RedirectRule {
         }
         ptrn = toRegex(regex);
         substitutions = SubstitutionElement.parse(this.target);
-        if (calendar != null) {
-            untilDate = ZonedDateTime.ofInstant( calendar.toInstant(), calendar.getTimeZone().toZoneId());
+        untilDate = calendar;
+        if (untilDate != null) {
+            zonedUntilDate = ZonedDateTime.ofInstant( untilDate.toInstant(), untilDate.getTimeZone().toZoneId());
         }
     }
 
     @PostConstruct
     protected void init() {
         createdBy = AuthorizableUtil.getFormattedName(resource.getResourceResolver(), createdBy);
+        if (untilDate != null) {
+            zonedUntilDate = ZonedDateTime.ofInstant( untilDate.toInstant(), untilDate.getTimeZone().toZoneId());
+        }
     }
 
     public static RedirectRule from(Resource resource) {
@@ -162,13 +170,13 @@ public class RedirectRule {
     }
 
     public ZonedDateTime getUntilDate() {
-        return untilDate;
+        return zonedUntilDate;
     }
 
     @Override
     public String toString() {
         return String.format("RedirectRule{source='%s', target='%s', statusCode=%s, untilDate=%s, note=%s, contextPrefixIgnored=%s}",
-                source, target, statusCode, untilDate, note, contextPrefixIgnored);
+                source, target, statusCode, zonedUntilDate, note, contextPrefixIgnored);
     }
 
     @Override

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/ExportRedirectMapServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/ExportRedirectMapServlet.java
@@ -96,6 +96,9 @@ public class ExportRedirectMapServlet extends SlingSafeMethodsServlet {
         dateStyle.setDataFormat(
                 wb.createDataFormat().getFormat("mmm d, yyyy"));
 
+        CellStyle lockedCellStyle = wb.createCellStyle();
+        lockedCellStyle.setLocked(true); // readonly cell
+
         Row headerRow;
         int rownum = 0;
         Sheet sheet = wb.createSheet("Redirects");
@@ -106,6 +109,7 @@ public class ExportRedirectMapServlet extends SlingSafeMethodsServlet {
         headerRow.createCell(3).setCellValue("Until Date");
         headerRow.createCell(4).setCellValue("Notes");
         headerRow.createCell(5).setCellValue("Ignore Context Prefix");
+        headerRow.createCell(6).setCellValue("Created By");
         for (Cell cell : headerRow) {
             cell.setCellStyle(headerStyle);
         }
@@ -122,6 +126,9 @@ public class ExportRedirectMapServlet extends SlingSafeMethodsServlet {
             }
             row.createCell(4).setCellValue(rule.getNote());
             row.createCell(5).setCellValue(rule.getContextPrefixIgnored());
+            Cell cell6 = row.createCell(6);
+            cell6.setCellValue(rule.getCreatedBy());
+            cell6.setCellStyle(lockedCellStyle);
         }
         sheet.setAutoFilter(new CellRangeAddress(0, rownum - 1, 0, 2));
         sheet.setColumnWidth(0, 256 * 50);
@@ -130,6 +137,7 @@ public class ExportRedirectMapServlet extends SlingSafeMethodsServlet {
         sheet.setColumnWidth(3, 256 * 12);
         sheet.setColumnWidth(4, 256 * 100);
         sheet.setColumnWidth(5, 256 * 20);
+        sheet.setColumnWidth(6, 256 * 25);
 
         return wb;
     }

--- a/bundle/src/test/java/com/adobe/acs/commons/redirects/models/RedirectRuleTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirects/models/RedirectRuleTest.java
@@ -48,7 +48,7 @@ public class RedirectRuleTest {
                 "note", "note-1",
                 "contextPrefixIgnored", true);
 
-        RedirectRule rule = RedirectRule.from(resource.getValueMap());
+        RedirectRule rule = RedirectRule.from(resource);
         assertEquals("/content/we-retail/en/one", rule.getSource());
         assertEquals("/content/we-retail/en/two", rule.getTarget());
         assertEquals(302, rule.getStatusCode());
@@ -71,7 +71,7 @@ public class RedirectRuleTest {
                 "statusCode", 302,
                 "untilDate", "11 January 2021");
 
-        RedirectRule rule = RedirectRule.from(resource.getValueMap());
+        RedirectRule rule = RedirectRule.from(resource);
         assertEquals("/content/we-retail/en/one", rule.getSource());
         assertEquals("/content/we-retail/en/two", rule.getTarget());
         assertEquals(302, rule.getStatusCode());
@@ -87,7 +87,7 @@ public class RedirectRuleTest {
                 "statusCode", 302,
                 "untilDate", "11 xxx 2021");
 
-        RedirectRule rule = RedirectRule.from(resource.getValueMap());
+        RedirectRule rule = RedirectRule.from(resource);
         assertEquals(null, rule.getUntilDate());
 
     }
@@ -103,8 +103,8 @@ public class RedirectRuleTest {
 
         Resource resource2 = context.create().resource("/var/acs-commons/redirects/rule2", props);
 
-        RedirectRule rule1 = RedirectRule.from(resource1.getValueMap());
-        RedirectRule rule2 = RedirectRule.from(resource2.getValueMap());
+        RedirectRule rule1 = RedirectRule.from(resource1);
+        RedirectRule rule2 = RedirectRule.from(resource2);
 
         assertTrue(rule1.equals(rule2));
         assertTrue(rule1.hashCode() == rule2.hashCode());

--- a/bundle/src/test/java/com/adobe/acs/commons/redirects/servlets/ImportRedirectMapServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirects/servlets/ImportRedirectMapServletTest.java
@@ -55,6 +55,7 @@ public class ImportRedirectMapServletTest {
         servlet = new ImportRedirectMapServlet();
         context.request().addRequestParameter("path", redirectStoragePath);
         context.addModelsForClasses(RedirectRule.class);
+        context.build().resource(redirectStoragePath);
     }
 
     @Test

--- a/bundle/src/test/java/com/adobe/acs/commons/redirects/servlets/ImportRedirectMapServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirects/servlets/ImportRedirectMapServletTest.java
@@ -37,14 +37,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.GregorianCalendar;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.adobe.acs.commons.redirects.Asserts.assertDateEquals;
@@ -78,7 +71,7 @@ public class ImportRedirectMapServletTest {
         ResourceBuilder rb = context.build().resource(redirectStoragePath).siblingsMode();
         int idx = 0;
         for (RedirectRule rule : savedRules) {
-            rb.resource("redirect-" + (++idx),
+            rb.resource("redirect-saved-" + (++idx),
                     "sling:resourceType", REDIRECT_RULE_RESOURCE_TYPE,
                     RedirectRule.SOURCE_PROPERTY_NAME, rule.getSource(),
                     RedirectRule.TARGET_PROPERTY_NAME, rule.getTarget(),
@@ -169,15 +162,16 @@ public class ImportRedirectMapServletTest {
         RedirectRule rule1 = new RedirectRule("/a1", "/b1", 301, null, null);
         RedirectRule rule2 = new RedirectRule("/a2", "/b2", 302, Calendar.getInstance(), "note");
         Collection<RedirectRule> rules = Arrays.asList(rule1, rule2);
-        servlet.update(root, rules);
+        servlet.update(root, rules, Collections.emptyMap());
 
-        ValueMap vm1 = root.getChild("redirect-rule-1").getValueMap();
+        Map<String, Resource> redirects = servlet.getRules(root);
+        ValueMap vm1 = redirects.get(rule1.getSource()).getValueMap();
         assertEquals(vm1.get(RedirectRule.SOURCE_PROPERTY_NAME), rule1.getSource());
         assertEquals(vm1.get(RedirectRule.TARGET_PROPERTY_NAME), rule1.getTarget());
         assertFalse(vm1.containsKey(RedirectRule.UNTIL_DATE_PROPERTY_NAME));
         assertFalse(vm1.containsKey(RedirectRule.NOTE_PROPERTY_NAME));
 
-        ValueMap vm2 = root.getChild("redirect-rule-2").getValueMap();
+        ValueMap vm2 = redirects.get(rule2.getSource()).getValueMap();
         assertEquals(vm2.get(RedirectRule.SOURCE_PROPERTY_NAME), rule2.getSource());
         assertEquals(vm2.get(RedirectRule.TARGET_PROPERTY_NAME), rule2.getTarget());
         assertEquals(vm2.get(RedirectRule.NOTE_PROPERTY_NAME), rule2.getNote());

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/manage-redirects.html
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/manage-redirects.html
@@ -103,6 +103,7 @@
                                 <col is="coral-table-column">
                                 <col is="coral-table-column">
                                 <col is="coral-table-column">
+                                <col is="coral-table-column">
                             </colgroup>
                             <thead is="coral-table-head" sticky>
                             <tr is="coral-table-row">
@@ -110,6 +111,7 @@
                                 <th is="coral-table-headercell">Redirect From</th>
                                 <th is="coral-table-headercell">Redirect To</th>
                                 <th is="coral-table-headercell">Status Code</th>
+                                <th is="coral-table-headercell">Created By</th>
                                 <th is="coral-table-headercell">Until Date</th>
                                 <th is="coral-table-headercell">Notes</th>
                                 <th is="coral-table-headercell">Ignore Context Prefix</th>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/redirect-row/redirect-row.html
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/redirect-row/redirect-row.html
@@ -9,13 +9,17 @@
       ${properties.target}
    </td>
    <td is="coral-table-cell" class="statusCode" data-value="${properties.statusCode}" style="width:50px;">${properties.statusCode}</td>
+   <td is="coral-table-cell" class="createdBy"
+       data-sly-use.redirect="com.adobe.acs.commons.redirects.models.RedirectRule">
+      ${redirect.createdBy}
+   </td>
    <td is="coral-table-cell" class="untilDate" data-value="${'yyyy-MM-dd\'T\'HH:mm:ss.SSSZ' @ format=properties.untilDate, locale='en'}"
        style="width:120px;">${'MMMM dd, yyyy hh:mm a' @ format=properties.untilDate, locale='en'}</td>
    <td is="coral-table-cell" class="note" data-value="${properties.note}" style="width:150px;">${properties.note}</td>
    <td is="coral-table-cell" class="contextPrefixIgnored" data-value="${properties.contextPrefixIgnored ? 'true' : 'false'}" style="text-align: center;width:50px;">
       <input data-sly-test="${properties.contextPrefixIgnored}" type="checkbox" checked disabled/>
    </td>
-   <td is="coral-table-cell">
+   <td is="coral-table-cell" style="width:30px;">
       <button is="coral-button" type="button" variant="minimal" icon="dragHandle" coral-table-roworder title="drag to re-arrange"></button>
    </td>
 </tr>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/redirect-manager/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/redirect-manager/.content.xml
@@ -116,10 +116,14 @@
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/hidden"
                                                 name="./jcr:createdBy"/>
-                                        <modified
+                                        <lastModified
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/hidden"
-                                                name="./jcr:modified"/>
+                                                name="./jcr:lastModified"/>
+                                        <lastModifiedBy
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/hidden"
+                                                name="./jcr:lastModifiedBy"/>
                                         <statusCode_x0040_TypeHint
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/hidden"


### PR DESCRIPTION
The PR addresses https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/2939, https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/2938 and https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/2936

Summary of changes: 

1. added a 'Created By' column in Touch UI and Excel Exports
2. Refactored Import From Excel to preserve existing nodes and custom properties. The old impl deleted and then re-created redirects and it could result in a loss of properties. 

