### PR TITLE
Removed deprecated

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/models/injectors/annotation/ChildResourceFromRequest.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/models/injectors/annotation/ChildResourceFromRequest.java
@@ -46,10 +46,6 @@ import java.lang.annotation.Target;
 public @interface ChildResourceFromRequest {
     String name() default "";
 
-    /** @deprecated */
-    @Deprecated
-    boolean optional() default false;
-
     InjectionStrategy injectionStrategy() default InjectionStrategy.DEFAULT;
 
     String via() default "";

--- a/bundle/src/main/java/com/adobe/acs/commons/models/injectors/annotation/impl/ChildResourceFromRequestAnnotationProcessorFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/models/injectors/annotation/impl/ChildResourceFromRequestAnnotationProcessorFactory.java
@@ -62,11 +62,6 @@ public class ChildResourceFromRequestAnnotationProcessorFactory implements Stati
         public InjectionStrategy getInjectionStrategy() {
             return this.annotation.injectionStrategy();
         }
-
-        @SuppressWarnings("deprecation")
-        public Boolean isOptional() {
-            return this.annotation.optional();
-        }
     }
 
 }


### PR DESCRIPTION
For the issue, https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/2955 - Removed Deprecated Java classes/methods.


There are multiple (approximately 6 classes) with Deprecated annotations, however, most of them extend from some API/JAR files that either have to be upgraded or deferred for now.

<img width="850" alt="Screen Shot 2022-11-27 at 12 49 01 PM" src="https://user-images.githubusercontent.com/2335734/204151496-d6b1228a-b939-4998-ab26-a4204710fd13.png">
