### PR TITLE
#3008 add State column in redirects UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ### Added 
 
+- #3008 - Redirect Manager: Add "State" column
+- #2980 - Add possibility to evaluate redirect rule on request URI instead of only resource path
 - #2977 - Redirect Manager: Add "Effective From" field
 
 ### Fixed 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ### Added 
 
 - #3008 - Redirect Manager: Add "State" column
-- #2980 - Add possibility to evaluate redirect rule on request URI instead of only resource path
 - #2977 - Redirect Manager: Add "Effective From" field
 
 ### Fixed 

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
@@ -20,10 +20,7 @@
 package com.adobe.acs.commons.redirects.filter;
 
 import com.adobe.acs.commons.redirects.LocationHeaderAdjuster;
-import com.adobe.acs.commons.redirects.models.RedirectConfiguration;
-import com.adobe.acs.commons.redirects.models.RedirectMatch;
-import com.adobe.acs.commons.redirects.models.RedirectRule;
-import com.adobe.acs.commons.redirects.models.Redirects;
+import com.adobe.acs.commons.redirects.models.*;
 import com.adobe.granite.jmx.annotation.AnnotatedStandardMBean;
 import com.day.cq.replication.ReplicationAction;
 import com.day.cq.replication.ReplicationEvent;
@@ -396,7 +393,7 @@ public class RedirectFilter extends AnnotatedStandardMBean
 
             RedirectRule redirectRule = match.getRule();
 
-            if (redirectRule.isExpired() || !redirectRule.isActive()) {
+            if (redirectRule.getState() != RedirectState.Active) {
                 log.debug("redirect rule matched, but didn't meet on/off time criteria: untilDate: {}, effectiveFrom: {}",
                         redirectRule.getUntilDate(), redirectRule.getEffectiveFrom());
             } else {

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
@@ -20,7 +20,11 @@
 package com.adobe.acs.commons.redirects.filter;
 
 import com.adobe.acs.commons.redirects.LocationHeaderAdjuster;
-import com.adobe.acs.commons.redirects.models.*;
+import com.adobe.acs.commons.redirects.models.RedirectConfiguration;
+import com.adobe.acs.commons.redirects.models.RedirectMatch;
+import com.adobe.acs.commons.redirects.models.RedirectRule;
+import com.adobe.acs.commons.redirects.models.RedirectState;
+import com.adobe.acs.commons.redirects.models.Redirects;
 import com.adobe.granite.jmx.annotation.AnnotatedStandardMBean;
 import com.day.cq.replication.ReplicationAction;
 import com.day.cq.replication.ReplicationEvent;
@@ -393,7 +397,7 @@ public class RedirectFilter extends AnnotatedStandardMBean
 
             RedirectRule redirectRule = match.getRule();
 
-            if (redirectRule.getState() != RedirectState.Active) {
+            if (redirectRule.getState() != RedirectState.ACTIVE) {
                 log.debug("redirect rule matched, but didn't meet on/off time criteria: untilDate: {}, effectiveFrom: {}",
                         redirectRule.getUntilDate(), redirectRule.getEffectiveFrom());
             } else {

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/models/RedirectRule.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/models/RedirectRule.java
@@ -248,13 +248,13 @@ public class RedirectRule {
         boolean invalid = effectiveFrom != null && untilDate != null && effectiveFrom.after(untilDate);
 
         if (invalid){
-            return RedirectState.Invalid;
+            return RedirectState.INVALID;
         } else if (expired){
-            return RedirectState.Expired;
+            return RedirectState.EXPIRED;
         } else if (pending){
-            return RedirectState.Pending;
+            return RedirectState.PENDING;
         } else {
-            return RedirectState.Active;
+            return RedirectState.ACTIVE;
         }
     }
 
@@ -264,8 +264,8 @@ public class RedirectRule {
     public boolean isPublished(){
         Calendar lastReplicated = resource.getParent().getValueMap().get("cq:lastReplicated", Calendar.class);
         boolean isPublished = lastReplicated != null;
-        boolean modifiedAfterPublication = isPublished &&
-                ((modified != null && modified.after(lastReplicated)) || (created != null && created.after(lastReplicated)));
+        boolean modifiedAfterPublication = isPublished
+                && ((modified != null && modified.after(lastReplicated)) || (created != null && created.after(lastReplicated)));
         return isPublished && !modifiedAfterPublication;
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/models/RedirectRule.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/models/RedirectRule.java
@@ -238,7 +238,8 @@ public class RedirectRule {
     }
 
     /**
-     * ----[effectiveFrom]---[now]---[intilDate]--->
+     * ----[effectiveFrom]---[now]---[untilDate]--->
+
      *
      * @return
      */

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/models/RedirectState.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/models/RedirectState.java
@@ -24,19 +24,19 @@ public enum RedirectState {
      * Active: redirect rule meets the on-time/off-time criteria, i.e.
      * activation date is previous or equal to current date and previous to the expiration date.
      */
-    Active("Redirect is active"),
+    ACTIVE("Redirect is active"),
     /**
      * Expired: expiration date is previous or equals to current date.
      */
-    Expired("Redirect has expired (off Time is less than current time)"),
+    EXPIRED("Redirect has expired (off Time is less than current time)"),
     /**
      * Pending: current date is previous to activation date
      */
-    Pending("Redirect is scheduled in the future"),
+    PENDING("Redirect is scheduled in the future"),
     /**
      * if there is an error with the configuration of a redirect (for instance, activation date is previous to expiration date)
      */
-    Invalid("Invalid On/Off time");
+    INVALID("Invalid On/Off time");
 
     String description;
 
@@ -46,5 +46,9 @@ public enum RedirectState {
 
     public String getDescription(){
         return description;
+    }
+
+    public String getName(){
+        return toString().toLowerCase();
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/models/RedirectState.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/models/RedirectState.java
@@ -1,0 +1,50 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.redirects.models;
+
+public enum RedirectState {
+    /**
+     * Active: redirect rule meets the on-time/off-time criteria, i.e.
+     * activation date is previous or equal to current date and previous to the expiration date.
+     */
+    Active("Redirect is active"),
+    /**
+     * Expired: expiration date is previous or equals to current date.
+     */
+    Expired("Redirect has expired (off Time is less than current time)"),
+    /**
+     * Pending: current date is previous to activation date
+     */
+    Pending("Redirect is scheduled in the future"),
+    /**
+     * if there is an error with the configuration of a redirect (for instance, activation date is previous to expiration date)
+     */
+    Invalid("Invalid On/Off time");
+
+    String description;
+
+    RedirectState(String description){
+        this.description = description;
+    }
+
+    public String getDescription(){
+        return description;
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/models/RedirectState.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/models/RedirectState.java
@@ -28,7 +28,7 @@ public enum RedirectState {
     /**
      * Expired: expiration date is previous or equals to current date.
      */
-    EXPIRED("Redirect has expired (off Time is less than current time)"),
+    EXPIRED("Redirect has expired (off time is less than current time)"),
     /**
      * Pending: current date is previous to activation date
      */

--- a/bundle/src/test/java/com/adobe/acs/commons/redirects/models/RedirectRuleTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirects/models/RedirectRuleTest.java
@@ -35,7 +35,6 @@ import java.util.GregorianCalendar;
 import java.util.Map;
 
 import static com.adobe.acs.commons.redirects.Asserts.assertDateEquals;
-import static com.adobe.acs.commons.redirects.models.RedirectRule.*;
 import static junit.framework.TestCase.assertTrue;
 import static junitx.framework.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
@@ -126,7 +125,7 @@ public class RedirectRuleTest {
                 .setStatusCode(302).build();
 
         RedirectRule rule1 = res1.adaptTo(RedirectRule.class);
-        assertEquals(RedirectState.Active, rule1.getState());
+        assertEquals(RedirectState.ACTIVE, rule1.getState());
 
         Calendar dateInFuture = GregorianCalendar.from(ZonedDateTime.now().plusDays(1));
         Resource res2 = new RedirectResourceBuilder(context)
@@ -137,7 +136,7 @@ public class RedirectRuleTest {
                 .build();
 
         RedirectRule rule2 = res2.adaptTo(RedirectRule.class);
-        assertEquals(RedirectState.Pending, rule2.getState());
+        assertEquals(RedirectState.PENDING, rule2.getState());
 
         Calendar dateInPast = GregorianCalendar.from(ZonedDateTime.now().minusDays(1));
         Resource res3 = new RedirectResourceBuilder(context)
@@ -148,7 +147,7 @@ public class RedirectRuleTest {
                 .build();
 
         RedirectRule rule3 = res3.adaptTo(RedirectRule.class);
-        assertEquals(RedirectState.Active, rule3.getState());
+        assertEquals(RedirectState.ACTIVE, rule3.getState());
 
         Resource res4 = new RedirectResourceBuilder(context)
                 .setSource("/content/geometrixx/en/contact-us")
@@ -158,7 +157,7 @@ public class RedirectRuleTest {
                 .build();
 
         RedirectRule rule4 = res4.adaptTo(RedirectRule.class);
-        assertEquals(RedirectState.Expired, rule4.getState());
+        assertEquals(RedirectState.EXPIRED, rule4.getState());
 
         Resource res5 = new RedirectResourceBuilder(context)
                 .setSource("/content/geometrixx/en/contact-us")
@@ -168,7 +167,7 @@ public class RedirectRuleTest {
                 .build();
 
         RedirectRule rule5 = res5.adaptTo(RedirectRule.class);
-        assertEquals(RedirectState.Active, rule5.getState());
+        assertEquals(RedirectState.ACTIVE, rule5.getState());
 
         Resource res6 = new RedirectResourceBuilder(context)
                 .setSource("/content/geometrixx/en/contact-us")
@@ -179,7 +178,7 @@ public class RedirectRuleTest {
                 .build();
 
         RedirectRule rule6 = res6.adaptTo(RedirectRule.class);
-        assertEquals(RedirectState.Active, rule6.getState());
+        assertEquals(RedirectState.ACTIVE, rule6.getState());
 
         Resource res7 = new RedirectResourceBuilder(context)
                 .setSource("/content/geometrixx/en/contact-us")
@@ -190,7 +189,7 @@ public class RedirectRuleTest {
                 .build();
 
         RedirectRule rule7 = res7.adaptTo(RedirectRule.class);
-        assertEquals(RedirectState.Invalid, rule7.getState());
+        assertEquals(RedirectState.INVALID, rule7.getState());
     }
 
     @Test

--- a/bundle/src/test/java/com/adobe/acs/commons/redirects/models/RedirectRuleTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirects/models/RedirectRuleTest.java
@@ -19,6 +19,9 @@
  */
 package com.adobe.acs.commons.redirects.models;
 
+import com.adobe.acs.commons.redirects.RedirectResourceBuilder;
+import org.apache.sling.api.resource.ModifiableValueMap;
+import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.testing.mock.osgi.MapUtil;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
@@ -26,11 +29,15 @@ import org.apache.sling.testing.mock.sling.junit.SlingContext;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.time.ZonedDateTime;
 import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.Map;
 
 import static com.adobe.acs.commons.redirects.Asserts.assertDateEquals;
+import static com.adobe.acs.commons.redirects.models.RedirectRule.*;
 import static junit.framework.TestCase.assertTrue;
+import static junitx.framework.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
 
 public class RedirectRuleTest {
@@ -109,5 +116,120 @@ public class RedirectRuleTest {
         assertTrue(rule1.equals(rule2));
         assertTrue(rule1.hashCode() == rule2.hashCode());
 
+    }
+
+    @Test
+    public void testState() throws PersistenceException {
+        Resource res1 = new RedirectResourceBuilder(context)
+                .setSource("/content/geometrixx/en/contact-us")
+                .setTarget("/content/geometrixx/en/contact-them")
+                .setStatusCode(302).build();
+
+        RedirectRule rule1 = res1.adaptTo(RedirectRule.class);
+        assertEquals(RedirectState.Active, rule1.getState());
+
+        Calendar dateInFuture = GregorianCalendar.from(ZonedDateTime.now().plusDays(1));
+        Resource res2 = new RedirectResourceBuilder(context)
+                .setSource("/content/geometrixx/en/contact-us")
+                .setTarget("/content/geometrixx/en/contact-them")
+                .setStatusCode(302)
+                .setEffectiveFrom(dateInFuture)
+                .build();
+
+        RedirectRule rule2 = res2.adaptTo(RedirectRule.class);
+        assertEquals(RedirectState.Pending, rule2.getState());
+
+        Calendar dateInPast = GregorianCalendar.from(ZonedDateTime.now().minusDays(1));
+        Resource res3 = new RedirectResourceBuilder(context)
+                .setSource("/content/geometrixx/en/contact-us")
+                .setTarget("/content/geometrixx/en/contact-them")
+                .setStatusCode(302)
+                .setEffectiveFrom(dateInPast)
+                .build();
+
+        RedirectRule rule3 = res3.adaptTo(RedirectRule.class);
+        assertEquals(RedirectState.Active, rule3.getState());
+
+        Resource res4 = new RedirectResourceBuilder(context)
+                .setSource("/content/geometrixx/en/contact-us")
+                .setTarget("/content/geometrixx/en/contact-them")
+                .setStatusCode(302)
+                .setUntilDate(dateInPast)
+                .build();
+
+        RedirectRule rule4 = res4.adaptTo(RedirectRule.class);
+        assertEquals(RedirectState.Expired, rule4.getState());
+
+        Resource res5 = new RedirectResourceBuilder(context)
+                .setSource("/content/geometrixx/en/contact-us")
+                .setTarget("/content/geometrixx/en/contact-them")
+                .setStatusCode(302)
+                .setUntilDate(dateInFuture)
+                .build();
+
+        RedirectRule rule5 = res5.adaptTo(RedirectRule.class);
+        assertEquals(RedirectState.Active, rule5.getState());
+
+        Resource res6 = new RedirectResourceBuilder(context)
+                .setSource("/content/geometrixx/en/contact-us")
+                .setTarget("/content/geometrixx/en/contact-them")
+                .setStatusCode(302)
+                .setEffectiveFrom(dateInPast)
+                .setUntilDate(dateInFuture)
+                .build();
+
+        RedirectRule rule6 = res6.adaptTo(RedirectRule.class);
+        assertEquals(RedirectState.Active, rule6.getState());
+
+        Resource res7 = new RedirectResourceBuilder(context)
+                .setSource("/content/geometrixx/en/contact-us")
+                .setTarget("/content/geometrixx/en/contact-them")
+                .setStatusCode(302)
+                .setEffectiveFrom(dateInFuture)
+                .setUntilDate(dateInPast)
+                .build();
+
+        RedirectRule rule7 = res7.adaptTo(RedirectRule.class);
+        assertEquals(RedirectState.Invalid, rule7.getState());
+    }
+
+    @Test
+    public void testIsPublished() throws PersistenceException {
+        Resource res1 = new RedirectResourceBuilder(context)
+                .setSource("/content/geometrixx/en/contact-us")
+                .setTarget("/content/geometrixx/en/contact-them")
+                .setStatusCode(302).build();
+
+        RedirectRule rule1 = res1.adaptTo(RedirectRule.class);
+        assertFalse(rule1.isPublished()); // never published
+
+        Calendar dateInPast = GregorianCalendar.from(ZonedDateTime.now().minusDays(1));
+        res1.getParent().adaptTo(ModifiableValueMap.class).put("cq:lastReplicated", dateInPast);
+        assertTrue(rule1.isPublished());
+
+        Resource res2 = new RedirectResourceBuilder(context)
+                .setSource("/content/geometrixx/en/1")
+                .setTarget("/content/geometrixx/en/2")
+                .setStatusCode(302)
+                .setCreated(GregorianCalendar.from(ZonedDateTime.now().minusMinutes(60)))
+                .build();
+        RedirectRule rule2 = res2.adaptTo(RedirectRule.class);
+        assertFalse(rule2.isPublished()); // jcr:created after lastReplicated
+
+        Resource res3 = new RedirectResourceBuilder(context)
+                .setSource("/content/geometrixx/en/1")
+                .setTarget("/content/geometrixx/en/2")
+                .setStatusCode(302)
+                .setCreated(GregorianCalendar.from(ZonedDateTime.now().minusMinutes(120)))
+                .setModified(GregorianCalendar.from(ZonedDateTime.now().minusMinutes(60)))
+                .build();
+        RedirectRule rule3 = res3.adaptTo(RedirectRule.class);
+        assertFalse(rule3.isPublished()); // jcr:lastModified after lastReplicated
+
+        // update cq:lastReplicated, all child redirects should become active
+        res1.getParent().adaptTo(ModifiableValueMap.class).put("cq:lastReplicated", Calendar.getInstance());
+        assertTrue(rule1.isPublished());
+        assertTrue(rule2.isPublished());
+        assertTrue(rule3.isPublished());
     }
 }

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/clientlibs/app.css
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/clientlibs/app.css
@@ -10,3 +10,18 @@
     font-family: 'Courier New', Courier, monospace
 }
 
+.Active {
+    color: #82c387;
+}
+
+.Expired {
+    color: #dcdcdc;
+}
+
+.Pending {
+    color: #f5b95a;
+}
+
+.Invalid {
+    color: #fa7369;
+}

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/clientlibs/app.css
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/clientlibs/app.css
@@ -10,18 +10,18 @@
     font-family: 'Courier New', Courier, monospace
 }
 
-.Active {
+.active {
     color: #82c387;
 }
 
-.Expired {
+.expired {
     color: #dcdcdc;
 }
 
-.Pending {
+.pending {
     color: #f5b95a;
 }
 
-.Invalid {
+.invalid {
     color: #fa7369;
 }

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/manage-redirects.html
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/manage-redirects.html
@@ -43,7 +43,7 @@
             </betty-titlebar-secondary>
         </betty-titlebar>
     </div>
-    <div class="content-container-inner" style="width:90%; margin:0 auto;">
+    <div class="content-container-inner" style="width:95%; margin:0 auto;">
         <coral-alert size="L" variant="warning" data-sly-test=${context.disabled}>
             <coral-alert-header>OSGi CONFIGURATION MISSING</coral-alert-header>
             <coral-alert-content>RedirectFilter is disabled and requires an OSGi configuration to start.
@@ -106,6 +106,7 @@
                                 <col is="coral-table-column">
                                 <col is="coral-table-column">
                                 <col is="coral-table-column">
+                                <col is="coral-table-column">
                             </colgroup>
                             <thead is="coral-table-head" sticky>
                             <tr is="coral-table-row">
@@ -114,6 +115,7 @@
                                 <th is="coral-table-headercell">Redirect To</th>
                                 <th is="coral-table-headercell">Status Code</th>
                                 <th is="coral-table-headercell">Created By</th>
+                                <th is="coral-table-headercell">State</th>
                                 <th is="coral-table-headercell">On Time</th>
                                 <th is="coral-table-headercell">Off Time</th>
                                 <th is="coral-table-headercell">Tags</th>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/redirect-row/redirect-row.html
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/redirect-row/redirect-row.html
@@ -13,7 +13,7 @@
    <td is="coral-table-cell" class="createdBy">${redirect.createdBy}</td>
    <td is="coral-table-cell" align="center" style="text-align: center;">
       <sly data-sly-test=${redirect.published}>
-         <coral-icon icon="circle" size="XS" id="s-${redirect.hashCode}" class="${redirect.state}">
+         <coral-icon icon="circle" size="XS" id="s-${redirect.hashCode}" class="${redirect.state.name}">
          </coral-icon>
          <coral-tooltip placement="right" target="#s-${redirect.hashCode}">${redirect.state.description}</coral-tooltip>
       </sly>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/redirect-row/redirect-row.html
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/redirect-row/redirect-row.html
@@ -1,6 +1,6 @@
 <tr is="coral-table-row" id="${resource.name}" data-path="${resource.path}"
     data-sly-use.redirect="com.adobe.acs.commons.redirects.models.RedirectRule">
-   <td is="coral-table-cell">
+   <td is="coral-table-cell" style="width:20px;">
       <a class="coral-Link edit-redirect-rule" href="#" target="_blank"><coral-icon icon="edit" size="XS"></coral-icon></a>
    </td>
    <td is="coral-table-cell" class="source" data-value="${redirect.source}" >
@@ -11,6 +11,13 @@
    </td>
    <td is="coral-table-cell" class="statusCode" data-value="${redirect.statusCode}" style="width:50px;">${redirect.statusCode}</td>
    <td is="coral-table-cell" class="createdBy">${redirect.createdBy}</td>
+   <td is="coral-table-cell" align="center" style="text-align: center;">
+      <sly data-sly-test=${redirect.published}>
+         <coral-icon icon="circle" size="XS" id="s-${redirect.hashCode}" class="${redirect.state}">
+         </coral-icon>
+         <coral-tooltip placement="right" target="#s-${redirect.hashCode}">${redirect.state.description}</coral-tooltip>
+      </sly>
+   </td>
    <td is="coral-table-cell" class="effectiveFrom" data-value="${'yyyy-MM-dd\'T\'HH:mm:ss.SSSZ' @ format=redirect.effectiveFrom, locale='en'}"
        style="width:120px;">${'MMMM dd, yyyy hh:mm a' @ format=redirect.effectiveFrom, locale='en'}</td>
    <td is="coral-table-cell" class="untilDate" data-value="${'yyyy-MM-dd\'T\'HH:mm:ss.SSSZ' @ format=redirect.untilDate, locale='en'}"


### PR DESCRIPTION
The PR introduces a new column in the Redirect Manager UI to show the state , e.g. Active, Expired, Pending, etc... 
See https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/3008