### PR TITLE
Redirect Manager - Misc Improvements in Bulk Import from Spreadsheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ## Unreleased ([details][unreleased changes details])
 
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
+- #3046 - Redirect Manager Import Spreadsheet Issue
+- #3009 - Redirect Manager: Add informative error message during import
 
 ## 5.6.0 - 2023-02-02
 

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
@@ -360,7 +360,10 @@ public class RedirectFilter extends AnnotatedStandardMBean
         Collection<RedirectRule> rules = new ArrayList<>();
         for (Resource res : resource.getChildren()) {
             if(res.isResourceType(REDIRECT_RULE_RESOURCE_TYPE)){
-                rules.add(res.adaptTo(RedirectRule.class));
+                RedirectRule rule = res.adaptTo(RedirectRule.class);
+                if(rule != null) {
+                    rules.add(rule);
+                }
             }
         }
         return rules;

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/models/ExportColumn.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/models/ExportColumn.java
@@ -35,15 +35,14 @@ public enum ExportColumn {
     CREATED("Created", RedirectRule.CREATED_PROPERTY_NAME, Calendar.class, false),
     CREATED_BY("Created By", RedirectRule.CREATED_BY_PROPERTY_NAME, String.class, false),
     MODIFIED("Modified", RedirectRule.MODIFIED_PROPERTY_NAME, Calendar.class, false),
-    MODIFIED_BY("Modified By", RedirectRule.MODIFIED_BY_PROPERTY_NAME, String.class, false)
-    ;
+    MODIFIED_BY("Modified By", RedirectRule.MODIFIED_BY_PROPERTY_NAME, String.class, false);
 
     private final String title;
     private final String propertyName;
     private final Class<?> type;
     private final boolean importable;
 
-    ExportColumn(String title, String propertyName, Class type, boolean importable){
+    ExportColumn(String title, String propertyName, Class<?> type, boolean importable){
         this.title = title;
         this.propertyName = propertyName;
         this.type = type;

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/models/ExportColumn.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/models/ExportColumn.java
@@ -42,6 +42,7 @@ public enum ExportColumn {
     private final Class<?> type;
     private final boolean importable;
 
+    @SuppressWarnings("squid:UnusedPrivateMethod") // false positive
     ExportColumn(String title, String propertyName, Class<?> type, boolean importable){
         this.title = title;
         this.propertyName = propertyName;

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/models/ExportColumn.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/models/ExportColumn.java
@@ -1,0 +1,48 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.redirects.models;
+
+public enum ExportColumn {
+
+    SOURCE("Source Url"),
+    TARGET("Target Url"),
+    STATUS_CODE("Status Code"),
+    OFF_TIME("Off Time"),
+    ON_TIME("On Time"),
+    NOTES("Notes"),
+    EVALUATE_URI("Evaluate URI"),
+    IGNORE_CONTEXT_PREFIX("Ignore Context Prefix"),
+    TAGS("Tags"),
+    CREATED("Created"),
+    CREATED_BY("Created By"),
+    MODIFIED("Modified"),
+    MODIFIED_BY("Modified By")
+    ;
+
+    private String title;
+
+    ExportColumn(String title){
+        this.title = title;
+    }
+
+    public String getTitle(){
+        return title;
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/models/ExportColumn.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/models/ExportColumn.java
@@ -19,30 +19,50 @@
  */
 package com.adobe.acs.commons.redirects.models;
 
+import java.util.Calendar;
+
 public enum ExportColumn {
 
-    SOURCE("Source Url"),
-    TARGET("Target Url"),
-    STATUS_CODE("Status Code"),
-    OFF_TIME("Off Time"),
-    ON_TIME("On Time"),
-    NOTES("Notes"),
-    EVALUATE_URI("Evaluate URI"),
-    IGNORE_CONTEXT_PREFIX("Ignore Context Prefix"),
-    TAGS("Tags"),
-    CREATED("Created"),
-    CREATED_BY("Created By"),
-    MODIFIED("Modified"),
-    MODIFIED_BY("Modified By")
+    SOURCE("Source Url", RedirectRule.SOURCE_PROPERTY_NAME, Boolean.class, true),
+    TARGET("Target Url", RedirectRule.TARGET_PROPERTY_NAME, Boolean.class, true),
+    STATUS_CODE("Status Code", RedirectRule.STATUS_CODE_PROPERTY_NAME, Integer.class, true),
+    OFF_TIME("Off Time", RedirectRule.UNTIL_DATE_PROPERTY_NAME, Calendar.class, true),
+    ON_TIME("On Time", RedirectRule.EFFECTIVE_FROM_PROPERTY_NAME, Calendar.class, true),
+    NOTES("Notes", RedirectRule.NOTE_PROPERTY_NAME, String.class, true),
+    EVALUATE_URI("Evaluate URI", RedirectRule.EVALUATE_URI_PROPERTY_NAME, Boolean.class, true),
+    IGNORE_CONTEXT_PREFIX("Ignore Context Prefix", RedirectRule.CONTEXT_PREFIX_IGNORED_PROPERTY_NAME, Boolean.class, true),
+    TAGS("Tags", RedirectRule.TAGS_PROPERTY_NAME, String[].class, true),
+    CREATED("Created", RedirectRule.CREATED_PROPERTY_NAME, Calendar.class, false),
+    CREATED_BY("Created By", RedirectRule.CREATED_BY_PROPERTY_NAME, String.class, false),
+    MODIFIED("Modified", RedirectRule.MODIFIED_PROPERTY_NAME, Calendar.class, false),
+    MODIFIED_BY("Modified By", RedirectRule.MODIFIED_BY_PROPERTY_NAME, String.class, false)
     ;
 
-    private String title;
+    private final String title;
+    private final String propertyName;
+    private final Class<?> type;
+    private final boolean importable;
 
-    ExportColumn(String title){
+    ExportColumn(String title, String propertyName, Class type, boolean importable){
         this.title = title;
+        this.propertyName = propertyName;
+        this.type = type;
+        this.importable = importable;
     }
 
     public String getTitle(){
         return title;
+    }
+
+    public String getPropertyName(){
+        return propertyName;
+    }
+
+    public Class<?> getPropertyType(){
+        return type;
+    }
+
+    public boolean isImportable(){
+        return importable;
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/models/ImportLog.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/models/ImportLog.java
@@ -23,8 +23,11 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
+/**
+ * A class to collect messages when importing redirect rules from a spreadsheet.
+ */
 public class ImportLog {
-    private List<Entry> log = new ArrayList<>();
+    private final List<Entry> log = new ArrayList<>();
     private String path;
 
     public void setPath(String path){
@@ -49,10 +52,14 @@ public class ImportLog {
         log.add(new Entry(Level.INFO, cell , msg));
     }
 
-    static class Entry {
-        final Level level;
-        final String cell;
-        final String msg;
+    public static class Entry {
+        Level level;
+        String cell;
+        String msg;
+
+        Entry(){
+            // default constructor needed to de-serialize from json
+        }
 
         Entry(Level level, String cell, String msg) {
             this.level = level;

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/models/ImportLog.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/models/ImportLog.java
@@ -1,0 +1,80 @@
+/*
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2016 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.redirects.models;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public class ImportLog {
+    private List<Entry> log = new ArrayList<>();
+    private String path;
+
+    public void setPath(String path){
+        this.path = path;
+    }
+
+    public String getPath(){
+        return path;
+    }
+
+    public List<Entry> getLog(){
+        // WARNs first, followed by INFOs, then by cell ascending
+        log.sort(Comparator.comparing(Entry::getLevel).thenComparing(Entry::getCell));
+        return log;
+    }
+
+    public void warn(String cell, String msg){
+        log.add(new Entry(Level.WARN, cell , msg));
+    }
+
+    public void info(String cell, String msg){
+        log.add(new Entry(Level.INFO, cell , msg));
+    }
+
+    static class Entry {
+        final Level level;
+        final String cell;
+        final String msg;
+
+        Entry(Level level, String cell, String msg) {
+            this.level = level;
+            this.cell = cell;
+            this.msg = msg;
+        }
+
+        public Level getLevel() {
+            return level;
+        }
+
+        public String getCell() {
+            return cell;
+        }
+
+        public String getMsg() {
+            return msg;
+        }
+    }
+
+    enum Level {
+        WARN,
+        INFO
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/ExportRedirectMapServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/ExportRedirectMapServlet.java
@@ -20,6 +20,7 @@
 package com.adobe.acs.commons.redirects.servlets;
 
 import com.adobe.acs.commons.redirects.filter.RedirectFilter;
+import com.adobe.acs.commons.redirects.models.ExportColumn;
 import com.adobe.acs.commons.redirects.models.RedirectRule;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
@@ -103,19 +104,36 @@ public class ExportRedirectMapServlet extends SlingSafeMethodsServlet {
         int rownum = 0;
         Sheet sheet = wb.createSheet("Redirects");
         headerRow = sheet.createRow(rownum++);
-        headerRow.createCell(0).setCellValue("Source Url");
-        headerRow.createCell(1).setCellValue("Target Url");
-        headerRow.createCell(2).setCellValue("Status Code");
-        headerRow.createCell(3).setCellValue("Off Time");
-        headerRow.createCell(4).setCellValue("Notes");
-        headerRow.createCell(5).setCellValue("Evaluate URI");
-        headerRow.createCell(6).setCellValue("Ignore Context Prefix");
-        headerRow.createCell(7).setCellValue("Tags");
-        headerRow.createCell(8).setCellValue("Created");
-        headerRow.createCell(9).setCellValue("Created By");
-        headerRow.createCell(10).setCellValue("Modified");
-        headerRow.createCell(11).setCellValue("Modified By");
-        headerRow.createCell(12).setCellValue("On Time");
+
+        headerRow.createCell(0).setCellValue(ExportColumn.SOURCE.getTitle());
+        headerRow.createCell(1).setCellValue(ExportColumn.TARGET.getTitle());
+        headerRow.createCell(2).setCellValue(ExportColumn.STATUS_CODE.getTitle());
+        headerRow.createCell(3).setCellValue(ExportColumn.OFF_TIME.getTitle());
+        headerRow.createCell(4).setCellValue(ExportColumn.ON_TIME.getTitle());
+        headerRow.createCell(5).setCellValue(ExportColumn.NOTES.getTitle());
+        headerRow.createCell(6).setCellValue(ExportColumn.EVALUATE_URI.getTitle());
+        headerRow.createCell(7).setCellValue(ExportColumn.IGNORE_CONTEXT_PREFIX.getTitle());
+        headerRow.createCell(8).setCellValue(ExportColumn.TAGS.getTitle());
+        headerRow.createCell(9).setCellValue(ExportColumn.CREATED.getTitle());
+        headerRow.createCell(10).setCellValue(ExportColumn.CREATED_BY.getTitle());
+        headerRow.createCell(11).setCellValue(ExportColumn.MODIFIED.getTitle());
+        headerRow.createCell(12).setCellValue(ExportColumn.MODIFIED_BY.getTitle());
+
+        // column width in POI is measured in 1/256th of the default character width
+        sheet.setColumnWidth(0, 256 * 50);
+        sheet.setColumnWidth(1, 256 * 50);
+        sheet.setColumnWidth(2, 256 * 15);
+        sheet.setColumnWidth(3, 256 * 12);
+        sheet.setColumnWidth(4, 256 * 12);
+        sheet.setColumnWidth(5, 256 * 100);
+        sheet.setColumnWidth(6, 256 * 20);
+        sheet.setColumnWidth(7, 256 * 20);
+        sheet.setColumnWidth(8, 256 * 25);
+        sheet.setColumnWidth(9, 256 * 12);
+        sheet.setColumnWidth(10, 256 * 30);
+        sheet.setColumnWidth(11, 256 * 12);
+        sheet.setColumnWidth(12, 256 * 30);
+
         for (Cell cell : headerRow) {
             cell.setCellStyle(headerStyle);
         }
@@ -130,54 +148,43 @@ public class ExportRedirectMapServlet extends SlingSafeMethodsServlet {
                 cell.setCellValue(untilDateTime);
                 cell.setCellStyle(dateStyle);
             }
-            row.createCell(4).setCellValue(rule.getNote());
-            row.createCell(5).setCellValue(rule.getEvaluateURI());
-            row.createCell(6).setCellValue(rule.getContextPrefixIgnored());
 
-            Cell cell6 = row.createCell(7);
+            Calendar effectiveFrom = rule.getEffectiveFrom();
+            if (effectiveFrom != null) {
+                Cell cell = row.createCell(4);
+                cell.setCellValue(effectiveFrom);
+                cell.setCellStyle(dateStyle);
+            }
+
+            row.createCell(5).setCellValue(rule.getNote());
+            row.createCell(6).setCellValue(rule.getEvaluateURI());
+            row.createCell(7).setCellValue(rule.getContextPrefixIgnored());
+
+            Cell cell6 = row.createCell(8);
             String[] tagIds = rule.getTagIds();
             if(tagIds != null) {
                 cell6.setCellValue(String.join("\n", tagIds));
             }
             cell6.setCellStyle(cellWrapStyle);
 
-            Cell cell7 = row.createCell(8);
+            Cell cell7 = row.createCell(9);
             cell7.setCellValue(rule.getCreated());
             cell7.setCellStyle(dateStyle);
 
-            Cell cell8 = row.createCell(9);
+            Cell cell8 = row.createCell(10);
             cell8.setCellValue(rule.getCreatedBy());
             cell8.setCellStyle(lockedCellStyle);
 
-            Cell cell9 = row.createCell(10);
+            Cell cell9 = row.createCell(11);
             cell9.setCellValue(rule.getModified());
             cell9.setCellStyle(dateStyle);
 
-            Cell cell10 = row.createCell(11);
+            Cell cell10 = row.createCell(12);
             cell10.setCellValue(rule.getModifiedBy());
             cell10.setCellStyle(lockedCellStyle);
 
-            Calendar effectiveFrom = rule.getEffectiveFrom();
-            if (effectiveFrom != null) {
-                Cell cell = row.createCell(12);
-                cell.setCellValue(effectiveFrom);
-                cell.setCellStyle(dateStyle);
-            }
         }
         sheet.setAutoFilter(new CellRangeAddress(0, rownum - 1, 0, 10));
-        sheet.setColumnWidth(0, 256 * 50);
-        sheet.setColumnWidth(1, 256 * 50);
-        sheet.setColumnWidth(2, 256 * 15);
-        sheet.setColumnWidth(3, 256 * 12);
-        sheet.setColumnWidth(4, 256 * 100);
-        sheet.setColumnWidth(5, 256 * 20);
-        sheet.setColumnWidth(6, 256 * 20);
-        sheet.setColumnWidth(7, 256 * 25);
-        sheet.setColumnWidth(8, 256 * 12);
-        sheet.setColumnWidth(9, 256 * 30);
-        sheet.setColumnWidth(10, 256 * 12);
-        sheet.setColumnWidth(11, 256 * 30);
-        sheet.setColumnWidth(12, 256 * 12);
 
         return wb;
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/ImportRedirectMapServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/ImportRedirectMapServlet.java
@@ -257,6 +257,7 @@ public class ImportRedirectMapServlet extends SlingAllMethodsServlet {
         return props;
     }
 
+    @SuppressWarnings("squid:S3776")
     private Map<String, Object> readOptionalProperties(Row row, Map<ExportColumn, Integer> cols, ImportLog auditLog) {
         Map<String, Object> props = new HashMap<>();
         for (ExportColumn column : ExportColumn.values()) {

--- a/bundle/src/test/java/com/adobe/acs/commons/redirects/filter/RedirectFilterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirects/filter/RedirectFilterTest.java
@@ -200,7 +200,8 @@ public class RedirectFilterTest {
                     .setSource("/content/we-retail/en/events/*")
                     .setTarget("/content/we-retail/en/four")
                     .setEvaluateURI(true)
-                    .setStatusCode(301).build()
+                    .setStatusCode(301).build(),
+            new RedirectResourceBuilder(context).build() // invalid rule wo source|target|statusCode should be ignored
         );
 
         ResourceBuilder rb = context.build().resource(redirectStoragePath).siblingsMode();

--- a/bundle/src/test/java/com/adobe/acs/commons/redirects/servlets/ExportRedirectMapServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirects/servlets/ExportRedirectMapServletTest.java
@@ -115,24 +115,24 @@ public class ExportRedirectMapServletTest {
         assertEquals("/content/two", row1.getCell(1).getStringCellValue());
         assertEquals(302, (int) row1.getCell(2).getNumericCellValue());
         assertDateEquals("09 October 2022", new Calendar.Builder().setInstant(row1.getCell(3).getDateCellValue()).build());
-        assertEquals("note-1", row1.getCell(4).getStringCellValue());
-        assertTrue(row1.getCell(5).getBooleanCellValue());
+        assertDateEquals("02 March 2025", new Calendar.Builder().setInstant(row1.getCell(4).getDateCellValue()).build());
+        assertEquals("note-1", row1.getCell(5).getStringCellValue());
         assertTrue(row1.getCell(6).getBooleanCellValue());
-        assertEquals("redirects:tag1", row1.getCell(7).getStringCellValue());
-        assertDateEquals("16 February 1974", new Calendar.Builder().setInstant(row1.getCell(8).getDateCellValue()).build());
-        assertEquals("john.doe", row1.getCell(9).getStringCellValue());
-        assertDateEquals("22 November 1976", new Calendar.Builder().setInstant(row1.getCell(10).getDateCellValue()).build());
-        assertEquals("jane.doe", row1.getCell(11).getStringCellValue());
-        assertDateEquals("02 March 2025", new Calendar.Builder().setInstant(row1.getCell(12).getDateCellValue()).build());
+        assertTrue(row1.getCell(7).getBooleanCellValue());
+        assertEquals("redirects:tag1", row1.getCell(8).getStringCellValue());
+        assertDateEquals("16 February 1974", new Calendar.Builder().setInstant(row1.getCell(9).getDateCellValue()).build());
+        assertEquals("john.doe", row1.getCell(10).getStringCellValue());
+        assertDateEquals("22 November 1976", new Calendar.Builder().setInstant(row1.getCell(11).getDateCellValue()).build());
+        assertEquals("jane.doe", row1.getCell(12).getStringCellValue());
 
         XSSFRow row2 = sheet.getRow(2);
         assertEquals("/content/three", row2.getCell(0).getStringCellValue());
         assertEquals("/content/four", row2.getCell(1).getStringCellValue());
         assertEquals(301, (int) row2.getCell(2).getNumericCellValue());
-        assertFalse(row2.getCell(5).getBooleanCellValue());
         assertFalse(row2.getCell(6).getBooleanCellValue());
-        assertEquals("redirects:tag2", row2.getCell(7).getStringCellValue());
-        assertEquals("", row2.getCell(9).getStringCellValue());
-        assertEquals("john.doe", row2.getCell(11).getStringCellValue());
+        assertFalse(row2.getCell(7).getBooleanCellValue());
+        assertEquals("redirects:tag2", row2.getCell(8).getStringCellValue());
+        assertEquals("", row2.getCell(10).getStringCellValue());
+        assertEquals("john.doe", row2.getCell(12).getStringCellValue());
     }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/redirects/servlets/ImportRedirectMapServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirects/servlets/ImportRedirectMapServletTest.java
@@ -22,6 +22,7 @@ package com.adobe.acs.commons.redirects.servlets;
 import com.adobe.acs.commons.redirects.RedirectResourceBuilder;
 import com.adobe.acs.commons.redirects.models.ExportColumn;
 import com.adobe.acs.commons.redirects.models.RedirectRule;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
@@ -39,6 +40,7 @@ import org.junit.Test;
 import javax.servlet.ServletException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Calendar;
@@ -377,7 +379,6 @@ public class ImportRedirectMapServletTest {
         RedirectRule rule4 = rules.get("/content/2").adaptTo(RedirectRule.class);
         assertEquals("/en/we-retail", rule4.getTarget());
         assertEquals(null, rule4.getUntilDate());
-    }
 
     @Test
     public void testUpdate() throws IOException {

--- a/bundle/src/test/java/com/adobe/acs/commons/redirects/servlets/ImportRedirectMapServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirects/servlets/ImportRedirectMapServletTest.java
@@ -20,6 +20,7 @@
 package com.adobe.acs.commons.redirects.servlets;
 
 import com.adobe.acs.commons.redirects.RedirectResourceBuilder;
+import com.adobe.acs.commons.redirects.models.ExportColumn;
 import com.adobe.acs.commons.redirects.models.RedirectRule;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Row;
@@ -65,8 +66,200 @@ public class ImportRedirectMapServletTest {
         context.build().resource(redirectStoragePath);
     }
 
+    /**
+     * Import a spreadsheet with ony 3 required columns:
+     *   - Cell A - source
+     *   - Cell B - target
+     *   - Cell C - statusCode
+     */
     @Test
-    public void testImport() throws ServletException, IOException {
+    public void testImportOnlyRequiredColumns() throws ServletException, IOException {
+
+        // new rules in a spreadsheet. will be merged with the existing rules
+        XSSFWorkbook wb = new XSSFWorkbook();
+        CellStyle dateStyle = wb.createCellStyle();
+        dateStyle.setDataFormat(
+                wb.createDataFormat().getFormat("mmm d, yyyy"));
+        Sheet sheet = wb.createSheet();
+        Row headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue(ExportColumn.SOURCE.getTitle());
+        headerRow.createCell(1).setCellValue(ExportColumn.TARGET.getTitle());
+        headerRow.createCell(2).setCellValue(ExportColumn.STATUS_CODE.getTitle());
+
+        Row row1 = sheet.createRow(1);
+        row1.createCell(0).setCellValue("/content/1");
+        row1.createCell(1).setCellValue("/en/we-retail");
+        row1.createCell(2).setCellValue(301);
+
+        Row row2 = sheet.createRow(2);
+        row2.createCell(0).setCellValue("/content/2");
+        row2.createCell(1).setCellValue("/en/we-retail");
+        row2.createCell(2).setCellValue(302);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        wb.write(out);
+        out.close();
+        byte[] excelBytes = out.toByteArray();
+
+        MockSlingHttpServletRequest request = context.request();
+        MockSlingHttpServletResponse response = context.response();
+
+        request.addRequestParameter("file", excelBytes, "binary/data");
+
+        servlet.doPost(request, response);
+
+        Resource storageRoot = context.resourceResolver().getResource(redirectStoragePath);
+        Map<String, Resource> rules = servlet.getRules(storageRoot); // rules keyed by source
+        assertEquals("number of redirects after import ", 2, rules.size());
+
+        RedirectRule rule1 = rules.get("/content/1").adaptTo(RedirectRule.class);
+        assertEquals("/content/1", rule1.getSource());
+        assertEquals("/en/we-retail", rule1.getTarget());
+        assertEquals(301, rule1.getStatusCode());
+
+        RedirectRule rule2 = rules.get("/content/2").adaptTo(RedirectRule.class);
+        assertEquals("/content/2", rule2.getSource());
+        assertEquals("/en/we-retail", rule2.getTarget());
+        assertEquals(302, rule2.getStatusCode());
+    }
+
+    /**
+     * Row that don't have valid source/target/statusCode shoudl be skipped
+     */
+    @Test
+    public void testIgnoreInvalidRows() throws ServletException, IOException {
+
+        // new rules in a spreadsheet. will be merged with the existing rules
+        XSSFWorkbook wb = new XSSFWorkbook();
+        CellStyle dateStyle = wb.createCellStyle();
+        dateStyle.setDataFormat(
+                wb.createDataFormat().getFormat("mmm d, yyyy"));
+        Sheet sheet = wb.createSheet();
+        Row headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue(ExportColumn.SOURCE.getTitle());
+        headerRow.createCell(1).setCellValue(ExportColumn.TARGET.getTitle());
+        headerRow.createCell(2).setCellValue(ExportColumn.STATUS_CODE.getTitle());
+
+        Row row1 = sheet.createRow(1);
+        //row1.createCell(0).setCellValue("/content/1");
+        row1.createCell(1).setCellValue("/en/we-retail");
+        row1.createCell(2).setCellValue(301);
+
+        Row row2 = sheet.createRow(2);
+        row2.createCell(0).setCellValue("/content/1");
+        //row2.createCell(1).setCellValue("/en/we-retail");
+        row2.createCell(2).setCellValue(301);
+
+        Row row3 = sheet.createRow(3);
+        row3.createCell(0).setCellValue("/content/1");
+        row3.createCell(1).setCellValue("/en/we-retail");
+        //row3.createCell(2).setCellValue(301);
+
+        Row row4 = sheet.createRow(4);
+        row4.createCell(0).setCellValue(true);
+        row4.createCell(1).setCellValue("/en/we-retail");
+        row4.createCell(2).setCellValue(301);
+
+        Row row5 = sheet.createRow(5);
+        row5.createCell(0).setCellValue("/content/1");
+        row5.createCell(1).setCellValue(true);
+        row5.createCell(2).setCellValue(301);
+
+        Row row6 = sheet.createRow(6);
+        row6.createCell(0).setCellValue("/content/1");
+        row6.createCell(1).setCellValue("/en/we-retail");
+        row6.createCell(2).setCellValue(true);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        wb.write(out);
+        out.close();
+        byte[] excelBytes = out.toByteArray();
+
+        MockSlingHttpServletRequest request = context.request();
+        MockSlingHttpServletResponse response = context.response();
+
+        request.addRequestParameter("file", excelBytes, "binary/data");
+
+        servlet.doPost(request, response);
+
+        Resource storageRoot = context.resourceResolver().getResource(redirectStoragePath);
+        Map<String, Resource> rules = servlet.getRules(storageRoot); // rules keyed by source
+        assertEquals("number of redirects after import ", 0, rules.size());
+
+        System.out.println(response.getOutputAsString());
+    }
+
+    /**
+     * User can change the order of optional columns (starting with D), e.g.
+     *   - Cell D - Evaluate URI
+     *   - Cell E - Notes
+     *   ...
+     */
+    @Test
+    public void testImportMixedColumns() throws ServletException, IOException {
+
+        // new rules in a spreadsheet. will be merged with the existing rules
+        XSSFWorkbook wb = new XSSFWorkbook();
+        CellStyle dateStyle = wb.createCellStyle();
+        dateStyle.setDataFormat(
+                wb.createDataFormat().getFormat("mmm d, yyyy"));
+        Sheet sheet = wb.createSheet();
+        Row headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue(ExportColumn.SOURCE.getTitle());
+        headerRow.createCell(1).setCellValue(ExportColumn.TARGET.getTitle());
+        headerRow.createCell(2).setCellValue(ExportColumn.STATUS_CODE.getTitle());
+        headerRow.createCell(3).setCellValue(ExportColumn.EVALUATE_URI.getTitle());
+        headerRow.createCell(4).setCellValue(ExportColumn.OFF_TIME.getTitle());
+        headerRow.createCell(5).setCellValue(ExportColumn.ON_TIME.getTitle());
+        headerRow.createCell(6).setCellValue(ExportColumn.NOTES.getTitle());
+        headerRow.createCell(7).setCellValue(ExportColumn.IGNORE_CONTEXT_PREFIX.getTitle());
+        headerRow.createCell(8).setCellValue(ExportColumn.TAGS.getTitle());
+
+        Row row1 = sheet.createRow(1);
+        row1.createCell(0).setCellValue("/content/1");
+        row1.createCell(1).setCellValue("/en/we-retail");
+        row1.createCell(2).setCellValue(301);
+        row1.createCell(3).setCellValue(true);
+        row1.createCell(4).setCellValue(new Calendar.Builder().setDate(1974, 01, 16).build());
+        row1.getCell(4).setCellStyle(dateStyle);
+        row1.createCell(5).setCellValue(new Calendar.Builder().setDate(2025, 02, 02).build());
+        row1.getCell(5).setCellStyle(dateStyle);
+        row1.createCell(6).setCellValue("note-abc");
+        row1.createCell(7).setCellValue(true);
+        row1.createCell(8).setCellValue("redirects:tag1\nredirects:tag2");
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        wb.write(out);
+        out.close();
+        byte[] excelBytes = out.toByteArray();
+
+        MockSlingHttpServletRequest request = context.request();
+        MockSlingHttpServletResponse response = context.response();
+
+        request.addRequestParameter("file", excelBytes, "binary/data");
+
+        servlet.doPost(request, response);
+
+        Resource storageRoot = context.resourceResolver().getResource(redirectStoragePath);
+        Map<String, Resource> rules = servlet.getRules(storageRoot); // rules keyed by source
+        assertEquals("number of redirects after import ", 1, rules.size());
+
+        RedirectRule rule = rules.get("/content/1").adaptTo(RedirectRule.class);
+        assertEquals("/en/we-retail", rule.getTarget());
+        assertEquals(301, rule.getStatusCode());
+        assertDateEquals("16 February 1974", rule.getUntilDate());
+        assertDateEquals("02 March 2025", rule.getEffectiveFrom());
+        assertEquals("note-abc", rule.getNote());
+        assertTrue(rule.getEvaluateURI());
+        assertTrue(rule.getContextPrefixIgnored());
+        assertArrayEquals(new String[]{"redirects:tag1", "redirects:tag2"}, rule.getTagIds());
+    }
+
+    /**
+     * Merge redirects from spreadsheet with existing redirects in the repository
+     */
+    @Test
+    public void testImportMixedExistingAndSpreadsheet() throws ServletException, IOException {
         // existing rules
         new RedirectResourceBuilder(context, redirectStoragePath)
                 .setSource("/content/one")
@@ -98,7 +291,21 @@ public class ImportRedirectMapServletTest {
         dateStyle.setDataFormat(
                 wb.createDataFormat().getFormat("mmm d, yyyy"));
         Sheet sheet = wb.createSheet();
-        sheet.createRow(0); //header.not used in import, can be all blank
+        Row headerRow = sheet.createRow(0);
+        headerRow.createCell(0).setCellValue(ExportColumn.SOURCE.getTitle());
+        headerRow.createCell(1).setCellValue(ExportColumn.TARGET.getTitle());
+        headerRow.createCell(2).setCellValue(ExportColumn.STATUS_CODE.getTitle());
+        headerRow.createCell(3).setCellValue(ExportColumn.OFF_TIME.getTitle());
+        headerRow.createCell(4).setCellValue(ExportColumn.NOTES.getTitle());
+        headerRow.createCell(5).setCellValue(ExportColumn.EVALUATE_URI.getTitle());
+        headerRow.createCell(6).setCellValue(ExportColumn.IGNORE_CONTEXT_PREFIX.getTitle());
+        headerRow.createCell(7).setCellValue(ExportColumn.TAGS.getTitle());
+        headerRow.createCell(8).setCellValue(ExportColumn.CREATED.getTitle());
+        headerRow.createCell(9).setCellValue(ExportColumn.CREATED_BY.getTitle());
+        headerRow.createCell(10).setCellValue(ExportColumn.MODIFIED.getTitle());
+        headerRow.createCell(11).setCellValue(ExportColumn.MODIFIED_BY.getTitle());
+        headerRow.createCell(12).setCellValue(ExportColumn.ON_TIME.getTitle());
+
         Row row1 = sheet.createRow(1);
         row1.createCell(0).setCellValue("/content/1");
         row1.createCell(1).setCellValue("/en/we-retail");
@@ -171,7 +378,6 @@ public class ImportRedirectMapServletTest {
         assertEquals("/en/we-retail", rule4.getTarget());
         assertEquals(null, rule4.getUntilDate());
     }
-
 
     @Test
     public void testUpdate() throws IOException {

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/clientlibs/app.css
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/clientlibs/app.css
@@ -25,3 +25,8 @@
 .invalid {
     color: #fa7369;
 }
+
+.dlg-import-cell {
+    padding: 4px 8px;
+    height: 36px;
+}

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/clientlibs/app.js
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/clientlibs/app.js
@@ -267,21 +267,21 @@
             var isErr= response.log.length;
             if(response.log.length){
                 var maxItems = 10;
-				var html = "<section>";
+				var html = "";
                 if(response.log.length > maxItems){
 					html += "<p>Showing " + maxItems + " of " + response.log.length + "</p>";
                 }
-                html += "<table width='500' is='coral-table'>";
+                html += "<table is='coral-table'>";
 
                 var arr = response.log.slice(0, maxItems);
                 for(var i = 0; i < arr.length; i++ ){
                     var row = arr[i];
-                    html += "<tr is='coral-table-row'><td is='coral-table-cell'>" + row.level + "</td><td is='coral-table-cell'>" + row.cell + "</td><td is='coral-table-cell'>" + row.msg + "</td></tr>";
+                    html += "<tr is='coral-table-row' class='dlg-import-cell'><td is='coral-table-cell' class='dlg-import-cell'>" +
+                    row.level + "</td><td is='coral-table-cell' class='dlg-import-cell'>" + row.cell + "</td><td is='coral-table-cell'>" + row.msg + "</td></tr>";
                 }
                 html += "</table>";
-                html += "<p><a href='"+response.path+"' target=_blank>Click to open the full log in a separate tab</a></p>";
-                html += "</section>";
-                var dialog = new Coral.Dialog().set({
+                html += "<p><a href='"+response.path+"' target=_blank>Click to download the full log</a></p>";
+                 var dialog = new Coral.Dialog().set({
                     header: {
                       innerHTML: "Issues Importing Redirects"
                     },

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/clientlibs/app.js
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/clientlibs/app.js
@@ -132,24 +132,6 @@
         }
     });
 
-    $(document).on("click", ".cq-dialog-upload", function (e) {
-        var $form = $(this).closest('form');
-        var data = new FormData($form[0]);
-
-        var message = $(this).attr('alert');
-        $.ajax({
-            url: $form.attr('action'),
-            type: "POST",
-            data: data,
-            cache: false,
-            contentType: false,
-            processData: false,
-            async: false
-        }).done(function(response){
-            location.reload(true);
-        });
-        return false;
-    });
 
     $(document).on("click", ".cq-dialog-download", function (e) {
         var $form = $(this).closest('form');
@@ -268,6 +250,61 @@
         updatePrefixFormData($(this));
         showPrefixDialog();
 
+    });
+
+    $(document).on("click", ".acs-redirects-form-import", function (e) {
+        e.preventDefault();
+
+        var $form = $(this).closest('form');
+        var data = new FormData($form[0]);
+        $.ajax( {
+            url: $form.attr('action'),
+            type: 'POST',
+            data: new FormData( $form[0] ),
+            processData: false,
+            contentType: false
+        }).done(function( response ) {
+            var isErr= response.log.length;
+            if(response.log.length){
+                var maxItems = 10;
+				var html = "<section>";
+                if(response.log.length > maxItems){
+					html += "<p>Showing " + maxItems + " of " + response.log.length + "</p>";
+                }
+                html += "<table width='500' is='coral-table'>";
+
+                var arr = response.log.slice(0, maxItems);
+                for(var i = 0; i < arr.length; i++ ){
+                    var row = arr[i];
+                    html += "<tr is='coral-table-row'><td is='coral-table-cell'>" + row.level + "</td><td is='coral-table-cell'>" + row.cell + "</td><td is='coral-table-cell'>" + row.msg + "</td></tr>";
+                }
+                html += "</table>";
+                html += "<p><a href='"+response.path+"' target=_blank>Click to open the full log in a separate tab</a></p>";
+                html += "</section>";
+                var dialog = new Coral.Dialog().set({
+                    header: {
+                      innerHTML: "Issues Importing Redirects"
+                    },
+                    content: {
+                      innerHTML: html
+                    },
+                    footer: {
+                      innerHTML: "<button class='ok-button' is='coral-button' variant='primary' icon='check' coral-close>OK</button>"
+                    },
+                    closable: "on",
+                    variant: "warning"
+                  });
+                  document.body.appendChild(dialog);
+
+                $(dialog).find(".ok-button").click(function() { location.reload(); });
+                dialog.show().center();
+
+            } else {
+				location.reload(true);
+            }
+        });
+
+        return false;
     });
 
 

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/manage-redirects.html
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/manage-redirects.html
@@ -160,16 +160,16 @@
                     <section>
                         <h2 class="coral-Heading coral-Heading--2">Import Redirect Map</h2>
                         <p>The redirect map file will be combined with the redirects configured in AEM to create the final set of redirects. This file should be a spreadsheet file with the first column containing the source path, the second column containing the redirect destination and the third column containing the redirect status code.</p>
-                        <form action="${resource.path}.import.html" method="post" class="coral-Form--aligned" enctype="multipart/form-data">
+                        <form action="${resource.path}.import.html" method="post" class="coral-Form--aligned" enctype="multipart/form-data" >
                             <input type="hidden" name="path" value="${context.redirectResource.path}" />
                             <div class="coral-Form-fieldwrapper">
-                                <label class="coral-Form-fieldlabel" id="label-vertical-inputgroup-2"> Redirect Map File * </label>
+                                <label class="coral-Form-fieldlabel" id="label-vertical-inputgroup-2"> Excel Spreadsheet With Redirects * </label>
                                 <div class="coral-InputGroup coral-Form-field">
                                     <input is="coral-Textfield" class="coral-InputGroup-input coral3-Textfield" id="acs-redirect-import-ctrl" type="file" name="./redirects.redirectmap.xlsx" accept=".xlsx" />
                                 </div>
                             </div>
                             <div class="coral-Form-fieldwrapper">
-                                <button class="coral-Button coral-Button--primary  cq-dialog-upload" icon="fileExcel" is="coral-button" variant="primary">Import Redirect Map</button>
+                                <button class="coral-Button  acs-redirects-form-import" icon="fileExcel" is="coral-button" variant="primary">Import Redirect Map</button>
                             </div>
                         </form>
                     </section>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/redirect-row/redirect-row.html
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/redirect-row/redirect-row.html
@@ -1,4 +1,5 @@
 <tr is="coral-table-row" id="${resource.name}" data-path="${resource.path}"
+    data-sly-test="${resource.source && resource.target && resource.statusCode}"
     data-sly-use.redirect="com.adobe.acs.commons.redirects.models.RedirectRule">
    <td is="coral-table-cell" style="width:20px;">
       <a class="coral-Link edit-redirect-rule" href="#" target="_blank"><coral-icon icon="edit" size="XS"></coral-icon></a>


### PR DESCRIPTION
The PR addresses #3046 and #3009

The code was refactored to avoid creating invalid rules when user submits an invalid spreadsheet, and also to avoid failing with  an exception if the input cells are invalid, e.g. unparsable date,etc. 

Instead of silent page reload user now gets a feedback dialog with the information which cell had what problem, e.g. 

<img width="432" alt="image" src="https://user-images.githubusercontent.com/2543854/218261646-d1b95f31-4010-471c-afab-51a4ad3ee270.png">


The dialog shows top 10 issues. The full log is saved under /var/acs-commons/redirects/$uuid and can be downloaded from the link on the bottom. 