### PR TITLE
#3069 Managed Controlled Processes Dashboard not visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ## Unreleased ([details][unreleased changes details])
 
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
+- #3069 - Managed Controlled Processes Dashboard not visible
 
 ## 6.0.2 - 2023-03-08
 

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-controlled-processes/clientlibs/js/scriptRunner.js
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-controlled-processes/clientlibs/js/scriptRunner.js
@@ -144,7 +144,7 @@ var ScriptRunner = {
     },
     rebuildProcessList: function () {
         jQuery.ajax({
-            url: ScriptRunner.SERVLET_URL + ".list.json",
+            url: ScriptRunner.SERVLET_URL + ".list.json?_dc=" + Date.now(),
             dataType: "json",
             success: function (response) {
                 var processDom, process, i, noErrors = true, tableBody = jQuery(ScriptRunner.processTable).find("tbody");


### PR DESCRIPTION
Fix #3069 
The PR adds a query string parameter when calling` /apps/acs-commons/content/manage-controlled-processes/jcr:content.list.json`  to avoid caching  in Dispatcher Author.