### PR TITLE
Make dispatcher flush only call top path instead of all pages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ## Fixed
 
 - #3077 - errorpagehandler/default.jsp has a reference to a removed class
+- #3045  - Dispatcher Flush UI sends "Delete" Requests One Node at a Time 
 
 ## 6.0.6 - 2023-03-21
 

--- a/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/FlushAggregateHandler.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/FlushAggregateHandler.java
@@ -1,7 +1,20 @@
 /*
- * work-around for ACS AEM Commons issue 3045
+ * ACS AEM Commons
+ *
+ * Copyright (C) 2013 - 2023 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.adobe.acs.commons.replication.dispatcher;
 
 import com.day.cq.replication.AggregateHandler;
@@ -22,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Implements an aggregate handler that detects hierarchy nodes as aggregate root.
+ * Work-around for ACS AEM Commons issue #3045.
  */
 public class FlushAggregateHandler implements AggregateHandler 
 {
@@ -71,5 +85,4 @@ public class FlushAggregateHandler implements AggregateHandler
 		throws ReplicationException 
 	{
     }
-
-} // public class FlushAggregateHandler implements AggregateHandler 
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/FlushAggregateHandler.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/FlushAggregateHandler.java
@@ -1,0 +1,75 @@
+/*
+ * work-around for ACS AEM Commons issue 3045
+ */
+
+package com.adobe.acs.commons.replication.dispatcher;
+
+import com.day.cq.replication.AggregateHandler;
+import com.day.cq.replication.ReplicationAction;
+import com.day.cq.replication.ReplicationActionType;
+import com.day.cq.replication.ReplicationException;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.nodetype.NodeType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implements an aggregate handler that detects hierarchy nodes as aggregate root.
+ */
+public class FlushAggregateHandler implements AggregateHandler 
+{
+
+    /**
+     * default logger
+     */
+    private static final Logger log = LoggerFactory.getLogger(FlushAggregateHandler.class);
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return <code>true</code> if the node is a hierarchy node.
+     */
+    public boolean isAggregateRoot(Node node) 
+	{
+        try 
+		{
+            return node.isNodeType(NodeType.NT_HIERARCHY_NODE);
+        } 
+		catch (RepositoryException e) 
+		{
+            log.warn("Unable to determine aggregate root.", e);
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Returns the provided path.
+     */
+    public List<String> prepareForReplication(Session session, ReplicationActionType type, String path)
+        throws ReplicationException 
+	{
+        LinkedList<String> paths = new LinkedList<String>();
+        paths.add(path);
+        return paths;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * 
+     */
+    public void processForReplication(Session session, ReplicationAction action) 
+		throws ReplicationException 
+	{
+    }
+
+} // public class FlushAggregateHandler implements AggregateHandler 

--- a/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlusherImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlusherImpl.java
@@ -20,6 +20,7 @@ package com.adobe.acs.commons.replication.dispatcher.impl;
 
 import com.adobe.acs.commons.replication.dispatcher.DispatcherFlushFilter;
 import com.adobe.acs.commons.replication.dispatcher.DispatcherFlusher;
+import com.adobe.acs.commons.replication.dispatcher.FlushAggregateHandler;
 import com.day.cq.replication.Agent;
 import com.day.cq.replication.AgentFilter;
 import com.day.cq.replication.AgentManager;
@@ -95,6 +96,10 @@ public class DispatcherFlusherImpl implements DispatcherFlusher {
         options.setSuppressStatusUpdate(true);
         options.setSuppressVersions(true);
         options.setListener(listener);
+
+		// Issue 3045 - Add custom AggregateHandler.  
+		// Returns only the provided path instead of all the descendent nodes on that path.
+		options.setAggregateHandler(new FlushAggregateHandler());
 
         for (final String path : paths) {
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
This is an implementation of the fix provided by John Bunker for issue #3045.  Tested and verified to work in our environments. 