### PR TITLE
#3096 warn when the NamedTransformImageServlet is used

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/images/impl/NamedTransformImageServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/images/impl/NamedTransformImageServlet.java
@@ -126,7 +126,7 @@ public class NamedTransformImageServlet extends SlingSafeMethodsServlet implemen
     private static final Logger log = LoggerFactory.getLogger(NamedTransformImageServlet.class);
     
     private static final Logger AVOID_USAGE_LOGGER = 
-    		LoggerFactory.getLogger(NamedTransformImageServlet.class.getName() + ".avoidUsage");
+    		LoggerFactory.getLogger(NamedTransformImageServlet.class.getName() + ".AvoidUsage");
     
 
     public static final String NAME_IMAGE = "image";
@@ -544,6 +544,10 @@ public class NamedTransformImageServlet extends SlingSafeMethodsServlet implemen
             renditionPatternPicker = new RenditionPatternPicker(DEFAULT_ASSET_RENDITION_PICKER_REGEX);
         }
         
+        /**
+         * We want to be able to determine if the absence of the messages of the AVOID_USAGE_LOGGER
+         * is caused by not using this feature or by disabling the WARN messages.
+         */
         if (!AVOID_USAGE_LOGGER.isWarnEnabled()) {
         	log.info("Warnings for the use of the NamedTransfomringImageServlet disabled");
         }

--- a/bundle/src/main/java/com/adobe/acs/commons/images/impl/NamedTransformImageServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/images/impl/NamedTransformImageServlet.java
@@ -124,6 +124,10 @@ import java.util.regex.Pattern;
 public class NamedTransformImageServlet extends SlingSafeMethodsServlet implements OptingServlet {
 
     private static final Logger log = LoggerFactory.getLogger(NamedTransformImageServlet.class);
+    
+    private static final Logger AVOID_USAGE_LOGGER = 
+    		LoggerFactory.getLogger(NamedTransformImageServlet.class.getName() + ".avoidUsage");
+    
 
     public static final String NAME_IMAGE = "image";
 
@@ -165,7 +169,7 @@ public class NamedTransformImageServlet extends SlingSafeMethodsServlet implemen
 
     private transient RenditionPatternPicker renditionPatternPicker =
             new RenditionPatternPicker(Pattern.compile(DEFAULT_ASSET_RENDITION_PICKER_REGEX));
-
+    
     /**
      * Only accept requests that.
      * - Are not null
@@ -204,6 +208,14 @@ public class NamedTransformImageServlet extends SlingSafeMethodsServlet implemen
     @Override
     protected final void doGet(final SlingHttpServletRequest request, final SlingHttpServletResponse response) throws
             ServletException, IOException {
+    	
+    	
+    	// Warn when this servlet is used
+    	AVOID_USAGE_LOGGER.warn("An image is transformed on-the-fly, which can be a very resource intensive operation. "
+    			+ "If done frequently, you should consider to create such a rendition upfront using processing profiles. "
+    			+ "See https://adobe-consulting-services.github.io/acs-aem-commons/features/named-image-transform/index.html for more details.");
+    	
+    	
         // Get the transform names from the suffix
         final List<NamedImageTransformer> selectedNamedImageTransformers = getNamedImageTransformers(request);
 
@@ -530,6 +542,10 @@ public class NamedTransformImageServlet extends SlingSafeMethodsServlet implemen
             log.error("Error creating RenditionPatternPicker with regex [ {} ], defaulting to [ {} ]", regex,
                     DEFAULT_ASSET_RENDITION_PICKER_REGEX);
             renditionPatternPicker = new RenditionPatternPicker(DEFAULT_ASSET_RENDITION_PICKER_REGEX);
+        }
+        
+        if (!AVOID_USAGE_LOGGER.isWarnEnabled()) {
+        	log.info("Warnings for the use of the NamedTransfomringImageServlet disabled");
         }
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/images/impl/NamedTransformImageServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/images/impl/NamedTransformImageServlet.java
@@ -212,7 +212,7 @@ public class NamedTransformImageServlet extends SlingSafeMethodsServlet implemen
     	
     	// Warn when this servlet is used
     	AVOID_USAGE_LOGGER.warn("An image is transformed on-the-fly, which can be a very resource intensive operation. "
-    			+ "If done frequently, you should consider to create such a rendition upfront using processing profiles. "
+    			+ "If done frequently, you should consider switching to dynamic AEM web-optimized images or creating such a rendition upfront using processing profiles. "
     			+ "See https://adobe-consulting-services.github.io/acs-aem-commons/features/named-image-transform/index.html for more details.");
     	
     	


### PR DESCRIPTION
This servlet can be quite resource demanding, and in most cases you should create the required renditions upfront using processing profiles. See https://adobe-consulting-services.github.io/acs-aem-commons/features/named-image-transform/index.html