### PR TITLE
#3105 Redirect Manager: support handling redirects when the request path does not start with /content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ## Unreleased ([details][unreleased changes details])
 
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->
+- #3105 - Redirect Manager: support handling redirects when the request path does not start with /content
 - #3095 - TagsExportServlet to return data in UTF-8 instead of iso-8859-1
 
 ## 6.0.8 - 2023-04-21

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
@@ -544,7 +544,7 @@ public class RedirectFilter extends AnnotatedStandardMBean
         }
 
         String resourcePath = request.getRequestPathInfo().getResourcePath();
-        boolean matches = getPaths().isEmpty() || getPaths().stream().anyMatch(p -> resourcePath.startsWith(p + "/"));
+        boolean matches = getPaths().isEmpty() || getPaths().stream().anyMatch(p -> p.equals("/") || resourcePath.startsWith(p + "/"));
         if (!matches) {
             log.trace("Request path [{}] not within any of {}.", resourcePath, paths);
             return false;


### PR DESCRIPTION
Addresses https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/3105