### PR TITLE
#3131 - Fix node type of /etc/acs-commons/redirect-maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@ in https://github.com/Adobe-Consulting-Services/acs-aem-commons/releases.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com)
 
+<!-- Keep this up to date! After a release, change the tag name to the latest release -->- 
+
 ## Unreleased ([details][unreleased changes details])
 
-<!-- Keep this up to date! After a release, change the tag name to the latest release -->- 
 ## Fixed
 - #3128 - Redirect Manager: import from xlsx not working due to apache-poi bundle upgrade in cloud SDK
-
+- #3131 - Fix node type of /etc/acs-commons/redirect-maps
 
 ## 6.0.10 - 2023-06-02
 

--- a/all/src/main/content/jcr_root/apps/acs-commons/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-acs-commons-all.config
+++ b/all/src/main/content/jcr_root/apps/acs-commons/config/org.apache.sling.jcr.repoinit.RepositoryInitializer-acs-commons-all.config
@@ -16,7 +16,8 @@ set ACL for everyone
 end
 
 create path /etc/acs-commons(sling:OrderedFolder)
-create path /etc/acs-commons/redirect-maps(nt:unstructured)
+create path /etc/acs-commons/redirect-maps(sling:OrderedFolder)
+create path /etc/acs-commons/redirect-maps/jcr:content(nt:unstructured)
 set ACL for everyone
     allow jcr:read on /etc/acs-commons/redirect-maps
 end


### PR DESCRIPTION
Set /etc/acs-commons/redirect-maps to be sling:OrderedFolder