### PR TITLE
Bug 3040 - parameterized namespace include - 

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/granite/ui/components/impl/include/IncludeDecoratorFilterImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/granite/ui/components/impl/include/IncludeDecoratorFilterImpl.java
@@ -22,8 +22,12 @@ import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.engine.EngineConstants;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 import javax.annotation.CheckForNull;
 import javax.servlet.Filter;
@@ -35,6 +39,9 @@ import javax.servlet.ServletException;
 
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
 
 @Component(
         service = Filter.class,
@@ -43,6 +50,7 @@ import java.io.IOException;
                 EngineConstants.SLING_FILTER_SCOPE+"="+ EngineConstants.FILTER_SCOPE_INCLUDE
         }
 )
+@Designate(ocd = IncludeDecoratorFilterImpl.Config.class)
 public class IncludeDecoratorFilterImpl implements Filter {
 
     static final String RESOURCE_TYPE = "acs-commons/granite/ui/components/include";
@@ -65,7 +73,28 @@ public class IncludeDecoratorFilterImpl implements Filter {
      * Prefix value parameters passed downwards
      */
     static final String PREFIX = "ACS_AEM_COMMONS_INCLUDE_PREFIX_";
-    
+
+
+    static final String REQ_ATTR_IGNORE_CHILDREN_RESOURCE_TYPE = "ACS_AEM_COMMONS_EXCLUDE_CHILDREN_RESOURCE_TYPE";
+
+    private List<String> resourceTypesIgnoreChildren;
+
+    @ObjectClassDefinition(
+            name = "ACS AEM Commons - IncludeDecoratorFilterImpl",
+            description = "Used to perform the namespacing / parameterization in the include context")
+    public @interface Config {
+        String[] resourceTypesIgnoreChildren() default {
+                "granite/ui/components/coral/foundation/form/multifield"
+        };
+    }
+
+    @Activate
+    @Modified
+    public void init(Config config) {
+        this.resourceTypesIgnoreChildren = Arrays.asList(config.resourceTypesIgnoreChildren());
+    }
+
+
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
         // no-op
@@ -77,16 +106,28 @@ public class IncludeDecoratorFilterImpl implements Filter {
         ValueMap parameters = ValueMap.EMPTY;
 
         if(servletRequest instanceof SlingHttpServletRequest){
-            
+
             SlingHttpServletRequest request = (SlingHttpServletRequest) servletRequest;
 
-            if(request.getResourceResolver().isResourceType(request.getResource(), RESOURCE_TYPE)){
+            Predicate<String> typeCheckFn = (resourceType) -> request.getResourceResolver().isResourceType(request.getResource(), resourceType);
+
+            if(typeCheckFn.test(RESOURCE_TYPE)){
                 performFilter(request, servletResponse, chain, parameters);
                 return;
+            }else if(resourceTypesIgnoreChildren.stream().anyMatch(typeCheckFn)){
+                boolean ignoreChildren = resourceTypesIgnoreChildren.stream().anyMatch(typeCheckFn);
+                if(ignoreChildren){
+                    request.setAttribute(REQ_ATTR_IGNORE_CHILDREN_RESOURCE_TYPE, request.getResource().getResourceType());
+                }
+                chain.doFilter(servletRequest, servletResponse);
+                if(ignoreChildren){
+                    request.removeAttribute(REQ_ATTR_IGNORE_CHILDREN_RESOURCE_TYPE);
+                }
+                return;
             }
-            
+
         }
-    
+
         chain.doFilter(servletRequest, servletResponse);
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/granite/ui/components/impl/include/NamespaceDecoratedValueMapBuilder.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/granite/ui/components/impl/include/NamespaceDecoratedValueMapBuilder.java
@@ -25,16 +25,13 @@ import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.adobe.acs.commons.granite.ui.components.impl.include.IncludeDecoratorFilterImpl.REQ_ATTR_NAMESPACE;
-import static com.adobe.acs.commons.granite.ui.components.impl.include.IncludeDecoratorFilterImpl.PREFIX;
+import static com.adobe.acs.commons.granite.ui.components.impl.include.IncludeDecoratorFilterImpl.*;
 import static org.apache.commons.lang3.StringUtils.*;
 
 
@@ -47,7 +44,7 @@ public class NamespaceDecoratedValueMapBuilder {
 
     static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("(\\$\\{\\{([a-zA-Z0-9]+?)(:(.+?))??\\}\\})+?");
     static final Pattern PLACEHOLDER_TYPE_HINTED_PATTERN = Pattern.compile("(.*)\\$\\{\\{(\\(([a-zA-Z]+)\\)){1}([a-zA-Z0-9]+)(:(.+))?\\}\\}(.*)?");
-    
+
     public NamespaceDecoratedValueMapBuilder(SlingHttpServletRequest request, Resource resource, String[] namespacedProperties) {
         this.request = request;
         this.copyMap = new HashMap<>(resource.getValueMap());
@@ -61,7 +58,13 @@ public class NamespaceDecoratedValueMapBuilder {
 
     private void applyNameSpacing() {
 
-        if (request.getAttribute(REQ_ATTR_NAMESPACE) != null) {
+        Supplier<Boolean> shouldConsiderNamespacing = () ->
+                request.getAttribute(REQ_ATTR_NAMESPACE) != null && (
+                        request.getAttribute(REQ_ATTR_IGNORE_CHILDREN_RESOURCE_TYPE) == null ||
+                        request.getResourceResolver().isResourceType(request.getResource(), request.getAttribute(REQ_ATTR_IGNORE_CHILDREN_RESOURCE_TYPE).toString())
+                );
+
+        if (shouldConsiderNamespacing.get()) {
             for (String namespacedProp : namespacedProperties) {
                 if (copyMap.containsKey(namespacedProp)) {
 
@@ -86,85 +89,85 @@ public class NamespaceDecoratedValueMapBuilder {
         }
 
     }
-    
+
     public ValueMap build(){
         return new ValueMapDecorator(copyMap);
     }
-    
+
     private void applyDynamicVariables() {
         for(Iterator<Map.Entry<String,Object>> iterator = this.copyMap.entrySet().iterator(); iterator.hasNext();){
-    
+
             Map.Entry<String,Object> entry = iterator.next();
-            
+
             if(entry.getValue() instanceof String) {
                 final Object filtered = filter(entry.getValue().toString(), this.request);
                 copyMap.put(entry.getKey(), filtered);
             }
-            
+
         }
     }
-    
-    
+
+
     private Object filter(String value, SlingHttpServletRequest request) {
         Object filtered = applyTypeHintedPlaceHolders(value, request);
-        
+
         if(filtered != null){
             return filtered;
         }
-        
+
         return applyPlaceHolders(value, request);
     }
-    
+
     private Object applyTypeHintedPlaceHolders(String value, SlingHttpServletRequest request) {
         Matcher matcher = PLACEHOLDER_TYPE_HINTED_PATTERN.matcher(value);
-    
+
         if (matcher.find()) {
-        
+
             String prefix = matcher.group(1);
             String typeHint = matcher.group(3);
             String paramKey = matcher.group(4);
             String defaultValue = matcher.group(6);
             String suffix = matcher.group(7);
-    
+
             String requestParamValue = (request.getAttribute(PREFIX + paramKey) != null) ? request.getAttribute(PREFIX + paramKey).toString() : null;
             String chosenValue = defaultString(requestParamValue, defaultValue);
             String finalValue = defaultIfEmpty(prefix, EMPTY) + chosenValue + defaultIfEmpty(suffix, EMPTY);
-        
+
             return isNotEmpty(typeHint) ? castTypeHintedValue(typeHint, finalValue) : finalValue;
         }
-    
+
         return null;
     }
 
     private String applyPlaceHolders(String value, SlingHttpServletRequest request) {
         Matcher matcher = PLACEHOLDER_PATTERN.matcher(value);
         StringBuffer buffer = new StringBuffer();
-        
+
         while (matcher.find()) {
-            
+
             String paramKey = matcher.group(2);
             String defaultValue = matcher.group(4);
-            
+
             String requestParamValue = (request.getAttribute(PREFIX + paramKey) != null) ? request.getAttribute(PREFIX + paramKey).toString() : null;
             String chosenValue = defaultString(requestParamValue, defaultValue);
-            
+
             if(chosenValue == null){
                 chosenValue = StringUtils.EMPTY;
             }
-            
+
             matcher.appendReplacement(buffer, chosenValue);
-            
+
         }
-        
+
         matcher.appendTail(buffer);
-        
+
         return buffer.toString();
     }
-    
+
     private Object castTypeHintedValue(String typeHint, String chosenValue) {
-    
+
         final Class<?> clazz;
-    
+
         switch(typeHint.toLowerCase()){
             case "boolean":
                 clazz = Boolean.class;
@@ -179,7 +182,7 @@ public class NamespaceDecoratedValueMapBuilder {
                 clazz = String.class;
                 break;
         }
-        
+
         return TypeUtil.toObjectType(chosenValue, clazz);
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/granite/ui/components/impl/include/NamespaceResourceWrapper.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/granite/ui/components/impl/include/NamespaceResourceWrapper.java
@@ -23,6 +23,7 @@ import org.apache.commons.collections.iterators.FilterIterator;
 import org.apache.commons.collections.iterators.TransformIterator;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.resource.ValueMap;
 
 import javax.annotation.Nonnull;
@@ -37,10 +38,12 @@ public class NamespaceResourceWrapper extends FilteringResourceWrapper {
 
     private final SlingHttpServletRequest request;
     private final String[] namespacedProperties;
+
     private final ValueMap valueMap;
 
     public NamespaceResourceWrapper(@Nonnull Resource resource, @Nonnull ExpressionResolver expressionResolver,
-                                    @Nonnull SlingHttpServletRequest request, String[] namespacedProperties) {
+                                    @Nonnull SlingHttpServletRequest request,
+                                    String[] namespacedProperties) {
         super(resource, expressionResolver, request);
         this.expressionResolver = expressionResolver;
         this.request = request;
@@ -59,7 +62,7 @@ public class NamespaceResourceWrapper extends FilteringResourceWrapper {
             return null;
         }
 
-        NamespaceResourceWrapper wrapped =new  NamespaceResourceWrapper(child, expressionResolver, request,namespacedProperties);
+        NamespaceResourceWrapper wrapped =new NamespaceResourceWrapper(child, expressionResolver, request,namespacedProperties);
 
         if(!isVisible(wrapped)){
             return null;

--- a/bundle/src/main/java/com/adobe/acs/commons/granite/ui/components/impl/include/NamespacedTransformedResourceProviderImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/granite/ui/components/impl/include/NamespacedTransformedResourceProviderImpl.java
@@ -33,7 +33,7 @@ import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 @Component(service = NamespacedTransformedResourceProvider.class)
 @Designate(ocd = NamespacedTransformedResourceProviderImpl.Config.class)
 public class NamespacedTransformedResourceProviderImpl implements NamespacedTransformedResourceProvider {
-    
+
     @ObjectClassDefinition(
             name = "ACS AEM Commons - NamespacedTransformedResourceProvider",
             description = "Transforms a resource underlying children with a namespace. Used for granite dialog snippets to be included in a granular way.")
@@ -44,21 +44,25 @@ public class NamespacedTransformedResourceProviderImpl implements NamespacedTran
         )
         String[] properties() default {"name", "fileNameParameter", "fileReferenceParameter"};
     }
-    
+
     @Reference
     private ExpressionResolver expressionResolver;
-    
+
     private String[] namespacedProperties;
-    
+
     @Activate
     @Modified
     public void init(Config config) {
         this.namespacedProperties = config.properties();
     }
-    
+
     @Override
     public Resource transformResourceWithNameSpacing(SlingHttpServletRequest request, Resource targetResource) {
-        return new NamespaceResourceWrapper(targetResource, expressionResolver, request, namespacedProperties);
+        return new NamespaceResourceWrapper(
+                targetResource,
+                expressionResolver,
+                request,
+                namespacedProperties);
     }
-    
+
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/granite/ui/components/impl/include/IncludeDecoratorFilterImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/granite/ui/components/impl/include/IncludeDecoratorFilterImplTest.java
@@ -33,6 +33,7 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.annotation.Annotation;
 
 import static com.adobe.acs.commons.granite.ui.components.impl.include.IncludeDecoratorFilterImpl.REQ_ATTR_NAMESPACE;
 import static org.junit.Assert.assertEquals;
@@ -59,7 +60,17 @@ public class IncludeDecoratorFilterImplTest {
         context.currentResource("/apps/tab/items/column/items/include");
 
         systemUnderTest = new IncludeDecoratorFilterImpl();
+        systemUnderTest.init(new IncludeDecoratorFilterImpl.Config(){
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return null;
+            }
 
+            @Override
+            public String[] resourceTypesIgnoreChildren() {
+                return new String[]{"ignore/children/resource/type"};
+            }
+        });
 
     }
 
@@ -82,6 +93,25 @@ public class IncludeDecoratorFilterImplTest {
 
     @Test
     public void test_nested_include() throws IOException, ServletException {
+
+        Mockito.doAnswer(invocationOnMock -> {
+
+            SlingHttpServletRequest captured = invocationOnMock.getArgument(0, SlingHttpServletRequest.class);
+            assertEquals("nested/block1", captured.getAttribute(REQ_ATTR_NAMESPACE));
+            return null;
+
+        }).when(filterChain).doFilter(any(SlingHttpServletRequest.class), any(SlingHttpServletResponse.class));
+
+        context.request().setAttribute(REQ_ATTR_NAMESPACE, "nested");
+        systemUnderTest.doFilter(context.request(), context.response(), filterChain);
+
+        assertEquals("nested", context.request().getAttribute(REQ_ATTR_NAMESPACE));
+
+    }
+
+
+    @Test
+    public void test_ignore_children() throws IOException, ServletException {
 
         Mockito.doAnswer(invocationOnMock -> {
 

--- a/bundle/src/test/java/com/adobe/acs/commons/granite/ui/components/impl/include/NamespaceResourceWrapperTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/granite/ui/components/impl/include/NamespaceResourceWrapperTest.java
@@ -54,6 +54,7 @@ public class NamespaceResourceWrapperTest {
 
     private String[] properties = new String[]{"name"};
 
+    private String[] resourceTypesIgnoreChildren = new String[]{"ignore/resource/type"};
     @Before
     public void setUp() throws Exception {
 


### PR DESCRIPTION
add possibility to exclude children from certain resource types

Fixing [bug 3040](https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/3040) 