### PR TITLE
Do not try to set a default for Collection fields in Sling Models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## Unreleased ([details][unreleased changes details])
 
+## Added 
+
+- #3209 - WARN org.apache.sling.models.impl.ModelAdapterFactory - Cannot provide default for java.util.List<java.lang.String>
 
 ## 6.3.0 - 2023-10-25
 

--- a/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlushModelImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/replication/dispatcher/impl/DispatcherFlushModelImpl.java
@@ -33,6 +33,7 @@ import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 @Model(
@@ -53,7 +54,6 @@ public class DispatcherFlushModelImpl implements DispatcherFlusherModel {
     private String replicationActionType;
 
     @ValueMapValue
-    @Default(values = {})
     private List<String> paths;
 
     @Override
@@ -63,7 +63,7 @@ public class DispatcherFlushModelImpl implements DispatcherFlusherModel {
 
     @Override
     public Collection<String> getPaths() {
-        return paths;
+        return paths != null ? paths : Collections.emptyList();
     }
 
     @Override

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/components/impl/TwitterFeedModelImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/components/impl/TwitterFeedModelImpl.java
@@ -46,7 +46,6 @@ public class TwitterFeedModelImpl implements TwitterFeedModel {
     private int limit;
 
     @ValueMapValue
-    @Default(values = {})
     private List<String> tweets;
 
     @PostConstruct


### PR DESCRIPTION
This prevents the error "WARN
org.apache.sling.models.impl.ModelAdapterFactory - Cannot provide default for java.util.List<java.lang.String>" being issued due to https://issues.apache.org/jira/browse/SLING-11812

This closes #3209