### PR TITLE
Defect/mcp forms/npe on multifield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## Unreleased ([details][unreleased changes details])
 
+### Fix
+
+- #3264 - NullPointerException while displaying MCP forms
+
 ## 6.3.8 - 2024-02-02
 
 ### Fix

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -514,6 +514,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit-addons</groupId>
             <artifactId>junit-addons</artifactId>
             <scope>test</scope>
@@ -649,6 +654,20 @@
         <dependency>
             <groupId>io.wcm</groupId>
             <artifactId>io.wcm.testing.aem-mock.junit4</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.jackrabbit</groupId>
+                    <artifactId>oak-jcr</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.wcm</groupId>
+            <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/AbstractResourceImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/AbstractResourceImpl.java
@@ -76,8 +76,12 @@ public class AbstractResourceImpl extends AbstractResource {
             properties = new HashMap<>();
         }
 
-        properties.put(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, resourceType);
-        properties.put(JcrResourceConstants.SLING_RESOURCE_SUPER_TYPE_PROPERTY, resourceSuperType);
+        if (resourceType != null) {
+            properties.put(JcrResourceConstants.SLING_RESOURCE_TYPE_PROPERTY, resourceType);
+        }
+        if (resourceSuperType != null) {
+            properties.put(JcrResourceConstants.SLING_RESOURCE_SUPER_TYPE_PROPERTY, resourceSuperType);
+        }
 
         this.properties = new ValueMapDecorator(properties);
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FieldsetComponent.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/form/FieldsetComponent.java
@@ -41,7 +41,9 @@ public final class FieldsetComponent extends ContainerComponent {
 
     @Override
     public Resource buildComponentResource() {
-        getProperties().put(CLASS, getCssClass());
+        if (getCssClass() != null) {
+            getProperties().put(CLASS, getCssClass());
+        }
         return super.buildComponentResource();
     }
 

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/form/AbstractResourceImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/form/AbstractResourceImplTest.java
@@ -1,0 +1,37 @@
+/*-
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 - 2024 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.mcp.form;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.apache.sling.api.resource.ResourceResolver;
+import org.junit.jupiter.api.Test;
+
+class AbstractResourceImplTest {
+
+  @Test
+  void doesNotAddNullValues() {
+    AbstractResourceImpl nullResourceType = new AbstractResourceImpl("/fake", null, "some/fake/type", null);
+    assertFalse(nullResourceType.getValueMap().containsKey(ResourceResolver.PROPERTY_RESOURCE_TYPE));
+
+    AbstractResourceImpl nullSuperType = new AbstractResourceImpl("/fake", "some/fake/type", null, null);
+    assertFalse(nullSuperType.getValueMap().containsKey("sling:resourceSuperType"));
+  }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/form/FieldsetTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/form/FieldsetTest.java
@@ -1,0 +1,66 @@
+/*-
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 - 2024 Adobe
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package com.adobe.acs.commons.mcp.form;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.api.scripting.SlingScriptHelper;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith({MockitoExtension.class, AemContextExtension.class})
+class FieldsetTest {
+
+  private final AemContext ctx = new AemContext(ResourceResolverType.JCR_MOCK);
+
+  @Mock
+  private FormField formField;
+
+  @Mock
+  private SlingScriptHelper slingScriptHelper;
+
+  @BeforeEach
+  public void setup() {
+    ctx.currentResource(ctx.create().resource("/dummy/resource"));
+    when(slingScriptHelper.getRequest()).thenReturn(ctx.request());
+  }
+
+  @Test
+  public void classNotSpecified() {
+    final FieldsetComponent fieldsetComponent = new FieldsetComponent();
+    fieldsetComponent.setup("dummy", null, formField, slingScriptHelper);
+
+    Resource resource = fieldsetComponent.buildComponentResource();
+    ValueMap map = resource.getValueMap();
+
+    assertFalse(map.containsKey("class"));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -639,6 +639,12 @@ Service-Component: OSGI-INF/*.xml
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>4.11.0</version><!-- >= 5.x requires Java 11 -->
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.jacoco</groupId>
                 <artifactId>org.jacoco.agent</artifactId>
                 <classifier>runtime</classifier>
@@ -673,6 +679,18 @@ Service-Component: OSGI-INF/*.xml
             <dependency>
                 <groupId>io.wcm</groupId>
                 <artifactId>io.wcm.testing.aem-mock.junit4</artifactId>
+                <version>5.1.2</version><!-- newer versions require Java 11, https://github.com/wcm-io/io.wcm.testing.aem-mock/issues/13 -->
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-simple</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.wcm</groupId>
+                <artifactId>io.wcm.testing.aem-mock.junit5</artifactId>
                 <version>5.1.2</version><!-- newer versions require Java 11, https://github.com/wcm-io/io.wcm.testing.aem-mock/issues/13 -->
                 <scope>test</scope>
                 <exclusions>


### PR DESCRIPTION
#3264 Make sure no null values are added to ValueMaps.

I had to add some new dependencies because JUnit 4 tests are not currently picked up by JUnit 5, but the JUnit 5 versions of some testing utilities were missing. You probably want to include the "junit-vintage" artifact to have the JUnit 5 engine run older tests.