### PR TITLE
Re-enable JUnit 4 and JUnit 3 unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## Unreleased ([details][unreleased changes details])
 
+### Fix
+
+- Re-enable accidentally disabled unit tests
+
 ## 6.4.0 - 2024-02-22
 
 ## Added 

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -504,6 +504,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -500,7 +500,12 @@
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -504,11 +504,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/bundle/src/test/java/com/adobe/acs/commons/packagegarbagecollector/PackageGarbageCollectionJobTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/packagegarbagecollector/PackageGarbageCollectionJobTest.java
@@ -48,6 +48,7 @@ import static com.adobe.acs.commons.packagegarbagecollector.PackageGarbageCollec
 import static com.adobe.acs.commons.testutil.LogTester.assertLogText;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -134,7 +135,7 @@ public class PackageGarbageCollectionJobTest {
         JcrPackageDefinition definition = mock(JcrPackageDefinition.class);
         when(definition.getLastUnpacked()).thenReturn(getDate(lastUnpackedDaysAgo));
         when(definition.getLastUnwrapped()).thenReturn(getDate(daysAgo));
-        when(definition.getCreated()).thenReturn(null);
+        lenient().when(definition.getCreated()).thenReturn(null);
         when(definition.getNode()).thenReturn(packageNode);
         PackageId pid = mock(PackageId.class);
         when(pid.getName()).thenReturn(name);

--- a/bundle/src/test/java/com/adobe/acs/commons/remoteassets/impl/RemoteAssetsConfigImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/remoteassets/impl/RemoteAssetsConfigImplTest.java
@@ -69,6 +69,7 @@ public class RemoteAssetsConfigImplTest {
           }
         };
         context.registerService(RequireAem.class, requireAem, "distribution","classic");
+        LogTester.reset();
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
         <aem.sdk.api.version>2023.1.10675.20230113T110236Z-220900</aem.sdk.api.version>
 
         <jacoco.version>0.8.7</jacoco.version>
+        <junit.jupiter.version>5.10.0</junit.jupiter.version> <!-- >= 5.x requires Java 11 -->
         <!-- affects both m-compiler-p and m-javadoc-p-->
         <maven.compiler.release>8</maven.compiler.release>
         <!-- for reproducible builds (https://maven.apache.org/guides/mini/guide-reproducible-builds.html), automatically adjusted during release -->
@@ -142,12 +143,12 @@
                         <dependency>
                             <groupId>org.junit.jupiter</groupId>
                             <artifactId>junit-jupiter-engine</artifactId>
-                            <version>5.10.0</version>
+                            <version>${junit.jupiter.version}</version>
                         </dependency>
                         <dependency>
                             <groupId>org.junit.vintage</groupId>
                             <artifactId>junit-vintage-engine</artifactId>
-                            <version>5.10.0</version>
+                            <version>${junit.jupiter.version}</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -619,7 +620,7 @@ Service-Component: OSGI-INF/*.xml
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.10.0</version>
+                <version>${junit.jupiter.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,18 @@
                     <configuration>
                         <trimStackTrace>false</trimStackTrace>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.junit.jupiter</groupId>
+                            <artifactId>junit-jupiter-engine</artifactId>
+                            <version>5.10.0</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.junit.vintage</groupId>
+                            <artifactId>junit-vintage-engine</artifactId>
+                            <version>5.10.0</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
@@ -605,16 +617,11 @@ Service-Component: OSGI-INF/*.xml
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter</artifactId>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
                 <version>5.10.0</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.junit.vintage</groupId>
-                <artifactId>junit-vintage-engine</artifactId>
-                <version>5.10.0</version>
-                <scope>test</scope>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -611,6 +611,12 @@ Service-Component: OSGI-INF/*.xml
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>5.10.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>4.13.2</version>


### PR DESCRIPTION
Looks like this was broken in #3233. With the addition of JUnit 5, the existing unit tests got ignored (note the sharp drop in overall coverage in the Codecov report). This PR should restore those old tests to full functionality.

Fixes #3270 