### PR TITLE
Content Sync: add an option to disable ssl cert check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #3306 - Sling Model Page injector
 - #3306 - Sling Model Content Policy injector
 - #3306 - Sling Model Tag injector
+- #3320 - Content Sync: add an option to disable ssl cert check
 
 ### Fixed 
 

--- a/bundle/src/main/java/com/adobe/acs/commons/contentsync/ConfigurationUtils.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/contentsync/ConfigurationUtils.java
@@ -43,6 +43,7 @@ public class ConfigurationUtils {
     public static final String EVENT_USER_DATA_KEY = "event-user-data";
     public static final String SO_TIMEOUT_STRATEGY_KEY = "soTimeout";
     public static final String CONNECT_TIMEOUT_KEY = "connTimeout";
+    public static final String DISABLE_CERT_CHECK_KEY = "disableCertCheck";
 
     private ConfigurationUtils(){
 

--- a/bundle/src/main/java/com/adobe/acs/commons/contentsync/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/contentsync/package-info.java
@@ -17,5 +17,5 @@
  * limitations under the License.
  * #L%
  */
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("1.1.0")
 package com.adobe.acs.commons.contentsync;

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/contentsync/configure/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/contentsync/configure/.content.xml
@@ -256,6 +256,13 @@
                                             fieldLabel="Connect timeout in milliseconds"
                                             name="./connTimeout"
                                             value="5000"/>
+                                        <disable-cert-check
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                text="Disable SSL Certificate Check"
+                                                fieldDescription="If selected it will disable certificate check for the SSL connection."
+                                                name="./disableCertCheck"
+                                                value="true"/>
                                     </items>
                                 </fieldset>
                             </items>


### PR DESCRIPTION
Add an option to disable SSL certificate check in Content Sync

![image](https://github.com/Adobe-Consulting-Services/acs-aem-commons/assets/2543854/32943c93-faac-48ca-9589-b8a0561cd6d5)
