### PR TITLE
Fix Service-Component header in manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## Unreleased ([details][unreleased changes details])
 
-## Added
+### Added
 
 - #3323 - Add Provider Type Checker Plugin
+
+### Fixed
+
+- #3241 - Fix overlapping Service-Component header entries leading to double registration of components
 
 ## 6.6.0 - 2024-04-15
 

--- a/bundle/bnd.bnd
+++ b/bundle/bnd.bnd
@@ -20,4 +20,10 @@ Import-Package: \
   !org.bouncycastle.jce.*,\
   !org.checkerframework.checker.nullness.qual,\
   *
+# support processing of legacy Felix SCR annotations through the felix.scr.bnd plugin, look at https://github.com/apache/felix/blob/trunk/tools/org.apache.felix.scr.bnd/src/main/java/org/apache/felix/scrplugin/bnd/SCRDescriptorBndPlugin.java#L60
+# paths require special handling: https://bnd.bndtools.org/chapters/820-instructions.html#file
+-plugin.felixscr: org.apache.felix.scrplugin.bnd.SCRDescriptorBndPlugin;destdir="$(basedir)/target/classes";log=error
+# also detect scr descriptors from bundle fragments (https://docs.osgi.org/specification/osgi.cmpn/8.0.0/service.component.html#d0e30931)
+# this is not properly merged with entries from Felix SCR Bnd plugin, therefore later on patched with m-shade-p
+Service-Component: OSGI-INF/*.xml
 -classpath: $(basedir)/target/aem-sdk-api-info/

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -243,6 +243,14 @@
                                     </includes>
                                 </filter>
                             </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <!-- overwrite Service-Component again, as incorrectly merged by Felix SCR Bnd Plugin -->
+                                        <Service-Component>OSGI-INF/*.xml</Service-Component>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
                         </configuration>
                     </execution>
                 </executions>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -76,6 +76,15 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
+                <dependencies>
+                    <!-- https://github.com/apache/felix/tree/trunk/tools/org.apache.felix.scr.bnd, processes deprecated SCR annotations
+                        with the Bnd process -->
+                    <dependency>
+                        <groupId>org.apache.felix</groupId>
+                        <artifactId>org.apache.felix.scr.bnd</artifactId>
+                        <version>1.9.6</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -244,15 +244,10 @@ Bundle-DocURL: https://adobe-consulting-services.github.io/acs-aem-commons/
 # enable plugins (https://bnd.bndtools.org/instructions/plugin.html)
 -plugin.models: org.apache.sling.bnd.models.ModelsScannerPlugin
 -plugin.cac: org.apache.sling.caconfig.bndplugin.ConfigurationClassScannerPlugin
-# support processing of legacy Felix SCR annotations through the felix.scr.bnd plugin, look at https://github.com/apache/felix/blob/trunk/tools/org.apache.felix.scr.bnd/src/main/java/org/apache/felix/scrplugin/bnd/SCRDescriptorBndPlugin.java#L60
-# paths require special handling: https://bnd.bndtools.org/chapters/820-instructions.html#file
--plugin.felixscr: org.apache.felix.scrplugin.bnd.SCRDescriptorBndPlugin;destdir="$(basedir)/target/classes";log=error
 -plugin.providertype:org.apache.sling.providertype.bndplugin.ProviderTypeScanner
 # support only DS 1.4 (https://github.com/bndtools/bnd/pull/3121/files)
 -dsannotations-options: version;maximum=1.4.0,inherit
 -metatypeannotations-options: version;maximum=1.4.0
-# also detect scr descriptors from bundle fragments (https://docs.osgi.org/specification/osgi.cmpn/8.0.0/service.component.html#d0e30931)
-Service-Component: OSGI-INF/*.xml
                                 ]]></bnd>
                             </configuration>
                         </execution>
@@ -269,13 +264,6 @@ Service-Component: OSGI-INF/*.xml
                             <groupId>org.apache.sling</groupId>
                             <artifactId>org.apache.sling.caconfig.bnd-plugin</artifactId>
                             <version>1.0.2</version>
-                        </dependency>
-                        <!-- https://github.com/apache/felix/tree/trunk/tools/org.apache.felix.scr.bnd, processes deprecated SCR annotations
-                            with the Bnd process -->
-                        <dependency>
-                            <groupId>org.apache.felix</groupId>
-                            <artifactId>org.apache.felix.scr.bnd</artifactId>
-                            <version>1.9.6</version>
                         </dependency>
                         <!-- enforce that provider types are not implemented/extended, https://github.com/apache/sling-org-apache-sling-providertype-bnd-plugin --> 
                         <dependency>


### PR DESCRIPTION
The broken/incorrectly generated Service-Component header is caused by the Felix SCR Bnd Plugin.
Fix it afterwards with the help of a m-shade-p transformer

This closes #3241