### PR TITLE
Prevent URL modification on dismiss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ## Added
 
 - #3323 - Add Provider Type Checker Plugin
+- #3338 - Prevent URL modification on dismiss
 
 ## 6.6.0 - 2024-04-15
 

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/system-notifications/notification/clientlibs/notification.js
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/system-notifications/notification/clientlibs/notification.js
@@ -23,7 +23,9 @@ $(function() {
         $('body').append(data);
     });
     
-    $('body').on('click', '.acsCommons-System-Notification-dismiss', function() {
+    $('body').on('click', '.acsCommons-System-Notification-dismiss', function(e) {
+        e.preventDefault();
+        
         var $notification = $(this).closest('.acsCommons-System-Notification'),
             uid = $notification.data('uid'),
             dismissible = $notification.data('dismissible'),


### PR DESCRIPTION
When users dismiss notifications today, the href value of # is added to the current page. Although this does not cause compatibility issues, it's a pseudo-navigation that adds no value. Preventing this with preventDefault() will not negatively impact the system notifications at all and it will prevent conflicts with SPAs and other interactions while there is a non-default URI fragment in place. 