### PR TITLE
Use dependency-check-maven 10.0.2 due to changes on the NVD API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -472,7 +472,7 @@ Bundle-DocURL: https://adobe-consulting-services.github.io/acs-aem-commons/
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>9.0.10</version>
+                    <version>10.0.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>


### PR DESCRIPTION
https://github.com/jeremylong/DependencyCheck/issues/6817