### PR TITLE
Content Sync: add an option to disable recursion and sync a single page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ## Unreleased ([details][unreleased changes details])
 
 ## 6.6.4 - 2024-08-14
-- #3417 - Content Sync: Added 'Recursive' option 
+- #3417 - Configurable recursion in Content Sync
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ## Unreleased ([details][unreleased changes details])
 
 ## 6.6.4 - 2024-08-14
+- #3417 - Content Sync: Added 'Recursive' option 
 
 ### Fixed
 

--- a/bundle/src/main/java/com/adobe/acs/commons/contentsync/impl/LastModifiedStrategy.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/contentsync/impl/LastModifiedStrategy.java
@@ -60,17 +60,17 @@ public class LastModifiedStrategy implements UpdateStrategy {
         if (rootPath == null) {
             throw new IllegalArgumentException("root request parameter is required");
         }
+        boolean recursive = "true".equals(request.getParameter("recursive"));
 
         Resource root = request.getResourceResolver().getResource(rootPath);
         if (root == null) {
             return Collections.emptyList();
         }
-
         List<CatalogItem> items = new ArrayList<>();
         new AbstractResourceVisitor() {
             @Override
             public void visit(Resource res) {
-                if (!accepts(res)) {
+                if ((!recursive && !res.getPath().equals(root.getPath())) || !accepts(res)) {
                     return;
                 }
                 JsonObjectBuilder json = Json.createObjectBuilder();

--- a/bundle/src/test/java/com/adobe/acs/commons/contentsync/impl/TestLastModifiedStrategy.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/contentsync/impl/TestLastModifiedStrategy.java
@@ -199,4 +199,42 @@ public class TestLastModifiedStrategy {
         assertEquals(path + ".infinity.json", item.getContentUri());
         assertEquals(customExporter, item.getCustomExporter());
     }
+
+    @Test
+    public void testRecursive()  {
+        doAnswer(invocation -> {
+            GenericServlet servlet = mock(GenericServlet.class);
+            doReturn(REDIRECT_SERVLET).when(servlet).getServletName();
+            return servlet;
+        }).when(servletResolver).resolveServlet(any(SlingHttpServletRequest.class));
+
+        context.create().page("/content/wknd");
+        context.create().page("/content/wknd/en");
+        context.create().page("/content/wknd/en/home");
+        MockSlingHttpServletRequest request = context.request();
+
+        request.addRequestParameter("root", "/content/wknd");
+        request.addRequestParameter("recursive", "true");
+
+        List<CatalogItem> items = updateStrategy.getItems(request);
+        assertEquals(3, items.size());
+    }
+
+    @Test
+    public void testNonRecursive()  {
+        doAnswer(invocation -> {
+            GenericServlet servlet = mock(GenericServlet.class);
+            doReturn(REDIRECT_SERVLET).when(servlet).getServletName();
+            return servlet;
+        }).when(servletResolver).resolveServlet(any(SlingHttpServletRequest.class));
+
+        context.create().page("/content/wknd");
+        context.create().page("/content/wknd/en");
+        context.create().page("/content/wknd/en/home");
+        MockSlingHttpServletRequest request = context.request();
+        request.addRequestParameter("root", "/content/wknd");
+
+        List<CatalogItem> items = updateStrategy.getItems(request);
+        assertEquals(1, items.size());
+    }
 }

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/contentsync/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/contentsync/.content.xml
@@ -106,6 +106,13 @@
                                     name="delete"
                                     text="Delete resources that exist in the destination but not in the source"
                                     value="true"/>
+                                <recursive
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                        name="recursive"
+                                        text="Recursive"
+                                        checked="{Boolean}true"
+                                        value="true"/>
                             </items>
                         </checkboxes>
                         <submit


### PR DESCRIPTION
The feature was requested in https://github.com/Adobe-Consulting-Services/acs-aem-commons/discussions/3417

The PR adds a flag to disable recursion. If unchecked then the tool will sync only one page

![image](https://github.com/user-attachments/assets/c725d997-fc29-470c-8580-5aa04741d9c0)
