### PR TITLE
enable Redirect Map Manager in AEM CS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ### Changed
 
-- #3420 - Redirect Map Manager - enable Redirect Map Manager in AEM CS
+- #3420 - Redirect Map Manager - enable Redirect Map Manager in AEM CS (would require a specific - not public yet - AEM CS release version, TBA)
 
 ## 6.6.4 - 2024-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## Unreleased ([details][unreleased changes details])
 
+### Changed
+
+- #3420 - Redirect Map Manager - enable Redirect Map Manager in AEM CS
+
 ## 6.6.4 - 2024-08-14
 
 ### Fixed

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/AddEntryServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/AddEntryServlet.java
@@ -22,15 +22,12 @@ import java.util.List;
 
 import javax.servlet.ServletException;
 
-import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.adobe.acs.commons.util.RequireAem;
 
 /**
  * Servlet for adding a line into the redirect map text file
@@ -43,10 +40,6 @@ public class AddEntryServlet extends SlingAllMethodsServlet {
     private static final long serialVersionUID = -1704915461516132101L;
     private static final Logger log = LoggerFactory.getLogger(AddEntryServlet.class);
     
-    // Disable this feature on AEM as a Cloud Service
-    @Reference(target="(distribution=classic)")
-    transient RequireAem requireAem;
-
     @Override
     protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RedirectEntriesServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RedirectEntriesServlet.java
@@ -21,15 +21,12 @@ import java.io.IOException;
 
 import javax.servlet.ServletException;
 
-import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.adobe.acs.commons.util.RequireAem;
 
 /**
  * Servlet rendering the redirect map to a JSON Array
@@ -38,10 +35,6 @@ import com.adobe.acs.commons.util.RequireAem;
         "redirectentries" }, extensions = { "json" }, metatype = false)
 public class RedirectEntriesServlet extends SlingSafeMethodsServlet {
   
-  // Disable this feature on AEM as a Cloud Service
-  @Reference(target="(distribution=classic)")
-  transient RequireAem requireAem;
-
     private static final long serialVersionUID = -2825679173210628699L;
     private static final Logger log = LoggerFactory.getLogger(RedirectEntriesServlet.class);
 

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RedirectMapServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RedirectMapServlet.java
@@ -22,7 +22,6 @@ import java.nio.charset.StandardCharsets;
 
 import javax.servlet.ServletException;
 
-import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
@@ -31,7 +30,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.adobe.acs.commons.redirectmaps.models.RedirectMapModel;
-import com.adobe.acs.commons.util.RequireAem;
 import com.google.common.net.MediaType;
 
 /**
@@ -45,10 +43,6 @@ public class RedirectMapServlet extends SlingSafeMethodsServlet {
     private static final Logger log = LoggerFactory.getLogger(RedirectMapServlet.class);
     private static final long serialVersionUID = -3564475196678277711L;
     
-    // Disable this feature on AEM as a Cloud Service
-    @Reference(target="(distribution=classic)")
-    transient RequireAem requireAem;
-
     @Override
     protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RemoveEntryServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/RemoveEntryServlet.java
@@ -22,15 +22,12 @@ import java.util.List;
 
 import javax.servlet.ServletException;
 
-import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.adobe.acs.commons.util.RequireAem;
 
 /**
  * Servlet for removing a line from the redirect map text file
@@ -43,10 +40,6 @@ public class RemoveEntryServlet extends SlingAllMethodsServlet {
     private static final long serialVersionUID = -5963945855717054678L;
     private static final Logger log = LoggerFactory.getLogger(RemoveEntryServlet.class);
     
-    // Disable this feature on AEM as a Cloud Service
-    @Reference(target="(distribution=classic)")
-    transient RequireAem requireAem;
-
     @Override
     protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {

--- a/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/UpdateEntryServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirectmaps/impl/UpdateEntryServlet.java
@@ -22,15 +22,12 @@ import java.util.List;
 
 import javax.servlet.ServletException;
 
-import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.sling.SlingServlet;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.adobe.acs.commons.util.RequireAem;
 
 /**
  * Servlet for updating a line in the redirect map text file
@@ -43,10 +40,6 @@ public class UpdateEntryServlet extends SlingAllMethodsServlet {
     private static final long serialVersionUID = -1704915461516132101L;
     private static final Logger log = LoggerFactory.getLogger(UpdateEntryServlet.class);
     
-    // Disable this feature on AEM as a Cloud Service
-    @Reference(target="(distribution=classic)")
-    transient RequireAem requireAem;
-
     @Override
     protected void doPost(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/content.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/redirectmappage/content.jsp
@@ -1,26 +1,7 @@
-<%@ page session="false" contentType="text/html" pageEncoding="utf-8"
-    import="com.adobe.acs.commons.util.RequireAem" %>
+<%@ page session="false" contentType="text/html" pageEncoding="utf-8" %>
 <%@include file="/libs/foundation/global.jsp" %>
 <%@taglib prefix="sling2" uri="http://sling.apache.org/taglibs/sling" %>
-<cq:setContentBundle /><%
-
-RequireAem requireAem = sling.getService(RequireAem.class);
-
-if (RequireAem.Distribution.CLOUD_READY.equals(requireAem.getDistribution())) { %>
-<link rel="stylesheet" href="https://unpkg.com/@adobe/spectrum-css@2.15.1/dist/standalone/spectrum-light.css"/>
-
-<div class="spectrum-Toast spectrum-Toast--negative" style="display: block; margin: 0 auto; width: 100%;">
-    <div class="spectrum-Toast-body">
-        <div class="spectrum-Toast-content">
-            Redirect Maps are not compatible with your version of Adobe Experience Manager.
-            <br/>
-            Please checkout ACS AEM Commons' Redirect Manager instead.
-        </div>
-    </div>
-</div>
-
-<%  return;
-} %>
+<cq:setContentBundle />
 
 
 

--- a/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/acs-commons/redirect-maps/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/cq/core/content/nav/tools/acs-commons/redirect-maps/.content.xml
@@ -26,8 +26,4 @@
           href="/acs-commons.html/etc/acs-commons/redirect-maps"
           id="acs-commons__redirect-maps"
           target="_blank">
-    <granite:rendercondition
-            jcr:primaryType="nt:unstructured"
-            sling:resourceType="acs-commons/console/renderconditions/require-aem"
-            distribution="classic"/>
 </jcr:root>


### PR DESCRIPTION
This PR enables [Redirect Map Manager](https://adobe-consulting-services.github.io/acs-aem-commons/features/redirect-map-manager/index.html) functionality in AEM CS (making it AEM as a Cloud Service compatible) as per https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/release-notes/release-notes/2024/release-notes-2024-5-0#apache-rewritemaps-early-adopter in its _Business users can declare redirects outside of Git (Early Adopter Program)_ paragraph:
> Similar to AEM 6.5, Apache/dispatcher will ingest rewrite maps placed in a specific location in the publish repository, and load them, without requiring a web tier pipeline execution. This opens up opportunities for a business user to declare redirects using either a spreadsheet or a UI, such as that offered by ACS Commons Redirect Map Manager or created as part of a customer application.

**Please note** that for now - as this functionality would require a specific (not public yet) AEM CS release version - it effectively won't bring any functionality (unless customer being in early adopter program mentioned above). The version of AEM CS release that would have this functionality enable is still TBA. Having it installed on not-yet-compatible AEM CS version would just make the endpoint exposed not being queried, hence not-yet-effective.
The release notes of AEM CS will mention when this feature will be supported.

cc: @davidjgonzalez @SachinMali @chaik @froesef