### PR TITLE
AEM CS release version 18311+ required for Redirect Map Manager to work in AEM CS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ### Changed
 
-- #3420 - Redirect Map Manager - enable Redirect Map Manager in AEM CS (would require a specific - not public yet - AEM CS release version, TBA)
+- #3420 - Redirect Map Manager - enable Redirect Map Manager in AEM CS (requires AEM CS release version 18311 or higher)
 - #3429 - UI Widgets - add uniq function to embedded lodash library to resolve issue with composite multifield widget
 - #3423 - Redirect Manager - status code is not retaining its value in the dialog after authoring
 - #3417 - Configurable recursion in Content Sync


### PR DESCRIPTION
As in https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/implementing/content-delivery/pipeline-free-url-redirects it is announced that Redirect Map Manager works in AEM CS release versions from 18311 on, the CHANGELOG entry previously set in https://github.com/Adobe-Consulting-Services/acs-aem-commons/pull/3420 needs to be amended to point to finally known AEM CS release version

@davidjgonzalez @SachinMali @joerghoh 