### PR TITLE
fix: syntax error in default errorpagehandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## Unreleased ([details][unreleased changes details])
 
+### Fixed
+- #3463 - Fixed syntax error in errorpagehandler default.jsp file
+
 ## 6.9.2 - 2024-11-04
 
 ### Fixed

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/errorpagehandler/default.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/errorpagehandler/default.jsp
@@ -25,7 +25,7 @@
 
     final ErrorPageHandlerService errorPageHandlerService = sling.getService(ErrorPageHandlerService.class);
 
-    if (errorPageHandlerService != null && errorPageHandlerService.isEnabled() && && errorPageHandlerService.shouldRequestUseErrorPageHandler(slingRequest)) {
+    if (errorPageHandlerService != null && errorPageHandlerService.isEnabled() && errorPageHandlerService.shouldRequestUseErrorPageHandler(slingRequest)) {
         final int status = errorPageHandlerService.getStatusCode(slingRequest);
 
         if (status >= SlingHttpServletResponse.SC_INTERNAL_SERVER_ERROR &&


### PR DESCRIPTION
Syntax error in default errorpagehandler causes a lot of AEM functionality to break. This was due to a syntax error where the `&&` in the JSP file was duplicated.