### PR TITLE
Fix Broken Styling when the notification is active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## Unreleased ([details][unreleased changes details])
 
+### Fixed
+- #3473 - Fix Broken Styling when the notification is active
+
 ## 6.9.4 - 2024-11-07
 
 ### Fixed

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/system-notifications/notification/clientlibs/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/system-notifications/notification/clientlibs/.content.xml
@@ -2,5 +2,4 @@
 <jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
     categories="acs-commons.system-notifications.notification"
-    dependencies="coralui3"
     jsProcessor="[default:none,min:gcc]"/>


### PR DESCRIPTION
**Summary**
Creating System-Notification using ACS-commons is breaking the content.

Issue 1 - OOTB Panels of AEM like Product Navigation, Insert components are broken. 
![image](https://github.com/user-attachments/assets/0657286d-01ae-44e8-bbf1-7012cada6067)

![image](https://github.com/user-attachments/assets/c55f24a1-4b24-41d6-80be-2281ef75e63e)


Issue 2 - The checkboxes within the components are broken disrupting the alignment with content
![image](https://github.com/user-attachments/assets/8bcb3516-8514-4340-86e2-41f81a39ec04)

**Steps to reproduce**
1. http://localhost:4502/sites.html/content  click on 
![image](https://github.com/user-attachments/assets/0708c73e-3c37-45c1-8878-4e3eb1596d74)
and then Tools 
![image](https://github.com/user-attachments/assets/065663fd-6ec1-4354-ad8c-3ae849fb42a9)
 Select ACS Commons-->System Notifications

2. Under Notifications Create a new notification once created edit the notification and turn on enabled and dismissible options with timeline set. Save your Notification.

![image](https://github.com/user-attachments/assets/36fd091d-c327-4574-8e9a-e2cf6f305f00)

3. Refresh your http://localhost:4502/sites.html/content observe the OOTB Product Navigation panel. Also try to author/configure any component to notice alignment issues with checkbox.

**Cause Of Issue:**
1. When Notification is enabled coralui3.css is overriding the selector .granite-shell-onboarding-controls from shell.css and customized css within components
![image](https://github.com/user-attachments/assets/19f03f80-3c79-4560-bb4c-207d2b73e481)

![image](https://github.com/user-attachments/assets/960ce67c-1b53-41f0-a15c-1bf67dfcef4c)
 
2. While the case is different when notification is disabled? the priority is for shell.css selector granite-shell-onboarding
![image](https://github.com/user-attachments/assets/6c429f56-e351-4b23-9e52-04516fb57290)

![image](https://github.com/user-attachments/assets/6291612c-9c08-4408-b2f1-5e9c82efbeba)

** Fix the issue while notification enabled :**
I Noticed that both system-notification (parent node ) and notification nodes (child node) has same clientlibs with same value added in dependencies property

![image](https://github.com/user-attachments/assets/c1b56326-2a73-4bd7-85e7-58961c8c65be)

![image](https://github.com/user-attachments/assets/6115af37-484d-45c9-a46d-2d02a4200e0f)
  
Its not necessary to add same dependencies on both parent and child node since the parent node properties are inherited from child node.

**Removing the dependencies property with value coralui3 in child node is fixing the issue while the notification is enabled**

Hope this is a sensible fix !!!





