### PR TITLE
Bugfix: Fixed Configuration Model for Redirect Manager after change in "redirect" resource as "sling:Folder"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## Unreleased ([details][unreleased changes details])
 
+### Fixed
+- #3479 - Fixed Configurations Model for Redirect Manager after change in "redirect" resource as "sling:Folder"
+
 ## 6.9.6 - 2024-11-20
 
 ### Fixed


### PR DESCRIPTION
### **Issue**: Regression

### **Cause**:  
The resource type for redirects has been changed to `"sling:Folder"`. However, the JCR query used to display the list of configurations has not been updated and currently only retrieves nodes of type `"nt:unstructured"`.

### **Fix**:  
Refactor Configurations Model to read the configs directly without query. 


Regression via https://github.com/Adobe-Consulting-Services/acs-aem-commons/pull/3399