### PR TITLE
A servlet to export redirects to a TXT file to use with pipeline-free redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->- 
 
 ## Unreleased ([details][unreleased changes details])
+- # - Redirect Manager: A servlet to export redirects to a TXT file to use with pipeline-free redirects
 
 ## 6.9.6 - 2024-11-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->- 
 
 ## Unreleased ([details][unreleased changes details])
-- # - Redirect Manager: A servlet to export redirects to a TXT file to use with pipeline-free redirects
+- #3484 - Redirect Manager: A servlet to export redirects to a TXT file to use with pipeline-free redirects
 
 ## 6.9.6 - 2024-11-20
 

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.9.7-SNAPSHOT</version>
+        <version>6.10.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/bundle-cloud/pom.xml
+++ b/bundle-cloud/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.9.7-SNAPSHOT</version>
+        <version>6.10.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/bundle-onprem/pom.xml
+++ b/bundle-onprem/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.9.7-SNAPSHOT</version>
+        <version>6.10.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.9.7-SNAPSHOT</version>
+        <version>6.10.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/RewriteMapServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/RewriteMapServlet.java
@@ -1,8 +1,9 @@
-/*
+/*-
+ * #%L
  * ACS AEM Commons Bundle
- *
+ * %%
  * Copyright (C) 2013 - 2024 Adobe
- *
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.redirects.servlets;
 
@@ -51,6 +53,7 @@ public class RewriteMapServlet extends SlingSafeMethodsServlet {
     private static final long serialVersionUID = -3564475196678277711L;
 
     @Override
+    @SuppressWarnings("java:S3457")
     protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
             throws ServletException, IOException {
         response.setContentType(ContentType.TEXT_PLAIN.getMimeType());

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/RewriteMapServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/RewriteMapServlet.java
@@ -1,5 +1,5 @@
 /*
- * ACS AEM Commons
+ * ACS AEM Commons Bundle
  *
  * Copyright (C) 2013 - 2024 Adobe
  *
@@ -62,16 +62,16 @@ public class RewriteMapServlet extends SlingSafeMethodsServlet {
         }
         Collection<RedirectRule> rules = RedirectFilter.getRules(request.getResource());
         PrintWriter out = response.getWriter();
-        out.printf("# %s Redirects\n", statusCode == 0 ? "All" : "" + statusCode);
+        out.printf("# %s Redirects%n", statusCode == 0 ? "All" : "" + statusCode);
         for (RedirectRule rule : rules) {
             if(statusCode != 0 && rule.getStatusCode() != statusCode) {
                 continue;
             }
             String note = rule.getNote();
             if(note != null && !note.isEmpty()) {
-                out.printf("# %s\n", note);
+                out.printf("# %s%n", note);
             }
-            out.printf("%s %s\n", rule.getSource(), rule.getTarget());
+            out.printf("%s %s%n", rule.getSource(), rule.getTarget());
         }
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/RewriteMapServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/RewriteMapServlet.java
@@ -1,0 +1,70 @@
+/*
+ * ACS AEM Commons
+ *
+ * Copyright (C) 2013 - 2023 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adobe.acs.commons.redirects.servlets;
+
+import com.adobe.acs.commons.redirects.filter.RedirectFilter;
+import com.adobe.acs.commons.redirects.models.RedirectRule;
+import com.google.common.net.MediaType;
+import org.apache.http.entity.ContentType;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.osgi.service.component.annotations.Component;
+
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collection;
+
+import static com.adobe.acs.commons.redirects.servlets.CreateRedirectConfigurationServlet.REDIRECTS_RESOURCE_PATH;
+
+
+/**
+ * Servlet for generating an Apache RewriteMap text file to use with
+ * he Pipeline-free URL Redirects feature in AEM as a Cloud Service
+ *
+ * See https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/implementing/content-delivery/pipeline-free-url-redirects
+ *
+ */
+@Component(service = Servlet.class, property = {
+        "sling.servlet.methods=GET",
+        "sling.servlet.extensions=txt",
+        "sling.servlet.resourceTypes=" + REDIRECTS_RESOURCE_PATH
+})
+public class RewriteMapServlet extends SlingSafeMethodsServlet {
+
+    private static final long serialVersionUID = -3564475196678277711L;
+
+    @Override
+    protected void doGet(SlingHttpServletRequest request, SlingHttpServletResponse response)
+            throws ServletException, IOException {
+        response.setContentType(ContentType.TEXT_PLAIN.getMimeType());
+
+        Collection<RedirectRule> rules = RedirectFilter.getRules(request.getResource());
+        PrintWriter out = response.getWriter();
+        out.print("# Redirect Map File\n");
+        for (RedirectRule rule : rules) {
+            String note = rule.getNote();
+            if(note != null && !note.isEmpty()) {
+                out.printf("# %s\n", note);
+            }
+            out.printf("%s %s\n", rule.getSource(), rule.getTarget());
+        }
+    }
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/RewriteMapServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/RewriteMapServlet.java
@@ -40,6 +40,9 @@ import static com.adobe.acs.commons.redirects.servlets.CreateRedirectConfigurati
  * Servlet for generating an Apache RewriteMap text file to use with
  * he Pipeline-free URL Redirects feature in AEM as a Cloud Service
  *
+ * Usage: http://localhost:4502/conf/my-site/settings/redirects.txt
+ * To filter by status code: http://localhost:4502/conf/my-site/settings/redirects.301.txt
+ *
  * See https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/implementing/content-delivery/pipeline-free-url-redirects
  *
  */

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/RewriteMapServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/RewriteMapServlet.java
@@ -1,7 +1,7 @@
 /*
  * ACS AEM Commons
  *
- * Copyright (C) 2013 - 2023 Adobe
+ * Copyright (C) 2013 - 2024 Adobe
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package com.adobe.acs.commons.redirects.servlets;
 
 import com.adobe.acs.commons.redirects.filter.RedirectFilter;
 import com.adobe.acs.commons.redirects.models.RedirectRule;
-import com.google.common.net.MediaType;
 import org.apache.http.entity.ContentType;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
@@ -56,10 +55,18 @@ public class RewriteMapServlet extends SlingSafeMethodsServlet {
             throws ServletException, IOException {
         response.setContentType(ContentType.TEXT_PLAIN.getMimeType());
 
+        String[] selectors = request.getRequestPathInfo().getSelectors();
+        int statusCode = 0;
+        if(selectors != null && selectors.length > 0) {
+            statusCode = Integer.parseInt(selectors[0]);
+        }
         Collection<RedirectRule> rules = RedirectFilter.getRules(request.getResource());
         PrintWriter out = response.getWriter();
-        out.print("# Redirect Map File\n");
+        out.printf("# %s Redirects\n", statusCode == 0 ? "All" : "" + statusCode);
         for (RedirectRule rule : rules) {
+            if(statusCode != 0 && rule.getStatusCode() != statusCode) {
+                continue;
+            }
             String note = rule.getNote();
             if(note != null && !note.isEmpty()) {
                 out.printf("# %s\n", note);

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/RewriteMapServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/RewriteMapServlet.java
@@ -62,16 +62,16 @@ public class RewriteMapServlet extends SlingSafeMethodsServlet {
         }
         Collection<RedirectRule> rules = RedirectFilter.getRules(request.getResource());
         PrintWriter out = response.getWriter();
-        out.printf("# %s Redirects%n", statusCode == 0 ? "All" : "" + statusCode);
+        out.printf("# %s Redirects\n", statusCode == 0 ? "All" : "" + statusCode);
         for (RedirectRule rule : rules) {
             if(statusCode != 0 && rule.getStatusCode() != statusCode) {
                 continue;
             }
             String note = rule.getNote();
             if(note != null && !note.isEmpty()) {
-                out.printf("# %s%n", note);
+                out.printf("# %s\n", note);
             }
-            out.printf("%s %s%n", rule.getSource(), rule.getTarget());
+            out.printf("%s %s\n", rule.getSource(), rule.getTarget());
         }
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/package-info.java
@@ -15,5 +15,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@org.osgi.annotation.versioning.Version("1.1.0")
+@org.osgi.annotation.versioning.Version("1.2.0")
 package com.adobe.acs.commons.redirects.servlets;

--- a/bundle/src/test/java/com/adobe/acs/commons/redirects/servlets/RewriteMapServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirects/servlets/RewriteMapServletTest.java
@@ -1,8 +1,9 @@
-/*
+/*-
+ * #%L
  * ACS AEM Commons Bundle
- *
+ * %%
  * Copyright (C) 2013 - 2024 Adobe
- *
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.redirects.servlets;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/redirects/servlets/RewriteMapServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirects/servlets/RewriteMapServletTest.java
@@ -1,5 +1,5 @@
 /*
- * ACS AEM Commons
+ * ACS AEM Commons Bundle
  *
  * Copyright (C) 2013 - 2024 Adobe
  *

--- a/bundle/src/test/java/com/adobe/acs/commons/redirects/servlets/RewriteMapServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirects/servlets/RewriteMapServletTest.java
@@ -1,0 +1,111 @@
+/*
+ * ACS AEM Commons
+ *
+ * Copyright (C) 2013 - 2023 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adobe.acs.commons.redirects.servlets;
+
+import com.adobe.acs.commons.redirects.RedirectResourceBuilder;
+import com.adobe.acs.commons.redirects.filter.RedirectFilter;
+import com.adobe.acs.commons.redirects.models.RedirectRule;
+import org.apache.http.entity.ContentType;
+import org.apache.poi.xssf.usermodel.XSSFRow;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.apache.sling.api.resource.PersistenceException;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit.SlingContext;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
+import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.servlet.ServletException;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.Collection;
+
+import static com.adobe.acs.commons.redirects.Asserts.assertDateEquals;
+import static com.adobe.acs.commons.redirects.servlets.ExportRedirectMapServlet.SPREADSHEETML_SHEET;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Yegor Kozlov
+ */
+public class RewriteMapServletTest {
+    @Rule
+    public SlingContext context = new SlingContext(ResourceResolverType.RESOURCERESOLVER_MOCK);
+
+    private RewriteMapServlet servlet;
+    private final String redirectStoragePath = "/conf/acs-commons/redirects";
+
+    @Before
+    public void setUp() throws PersistenceException {
+        new RedirectResourceBuilder(context, redirectStoragePath)
+                .setSource("/content/one")
+                .setTarget("/content/two")
+                .setStatusCode(302)
+                .setUntilDate(new Calendar.Builder().setDate(2022, 9, 9).build())
+                .setEffectiveFrom(new Calendar.Builder().setDate(2025, 2, 2).build())
+                .setNotes("note-1")
+                .setEvaluateURI(true)
+                .setContextPrefixIgnored(true)
+                .setTagIds(new String[]{"redirects:tag1"})
+                .setCreatedBy("john.doe")
+                .setModifiedBy("jane.doe")
+                .setCreated(new Calendar.Builder().setDate(1974, 1, 16).build())
+                .setModified(new Calendar.Builder().setDate(1976, 10, 22).build())
+                .build();
+        new RedirectResourceBuilder(context, redirectStoragePath)
+                .setSource("/content/three")
+                .setTarget("/content/four")
+                .setStatusCode(301)
+                .setTagIds(new String[]{"redirects:tag2"})
+                .setModifiedBy("john.doe")
+                .build();
+
+        Resource redirects = context.resourceResolver().getResource(redirectStoragePath);
+        context.request().setResource(redirects);
+        servlet = new RewriteMapServlet();
+    }
+
+
+    @Test
+    public void testGet() throws ServletException, IOException {
+        MockSlingHttpServletRequest request = context.request();
+        MockSlingHttpServletResponse response = context.response();
+
+        servlet.doGet(request, response);
+
+        assertEquals(ContentType.TEXT_PLAIN.getMimeType(), response.getContentType());
+        String[] lines = response.getOutputAsString().split("\n");
+        assertEquals("# Redirect Map File", lines[0]);
+        assertEquals("# note-1", lines[1]);
+
+        String[] rule1 = lines[2].split(" ");
+        assertEquals("/content/one", rule1[0]);
+        assertEquals("/content/two", rule1[1]);
+
+        String[] rule2 = lines[3].split(" ");
+        assertEquals("/content/three", rule2[0]);
+        assertEquals("/content/four", rule2[1]);
+    }
+}

--- a/oakpal-checks/pom.xml
+++ b/oakpal-checks/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.9.7-SNAPSHOT</version>
+        <version>6.10.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>com.adobe.acs</groupId>
     <artifactId>acs-aem-commons</artifactId>
-    <version>6.9.7-SNAPSHOT</version>
+    <version>6.10.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>ACS AEM Commons - Reactor Project</name>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.9.7-SNAPSHOT</version>
+        <version>6.10.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/ui.config/pom.xml
+++ b/ui.config/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.9.7-SNAPSHOT</version>
+        <version>6.10.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.9.7-SNAPSHOT</version>
+        <version>6.10.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->


### PR DESCRIPTION
@krystiannowak @kwin @joerghoh 
the PR adds a servlet to export redirects into a text file, e.g. http://localhost:4502/conf/my-site/settings/redirects.txt 

```
# Redirect Map File
/abc2 /content/applications
/xyz /legacy-1
/content/applications1 /legacy-2
```

This way Redirect Manager  can serve redirects for [Pipeline-free URL Redirects](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/implementing/content-delivery/pipeline-free-url-redirects) 

`src/opt-in/managed-rewrite-maps.yaml` in the dispatcher configuration would look like
```yaml
maps:
- name: my-site.map
  path: /conf/my-site/settings/redirects.txt 
- name: another-site.map
  path: /conf/another-site/settings/redirects.txt 
```

and vhosts can reference redirects like
```
# RewriteMap from managed rewrite maps
RewriteMap my-site.foo dbm=sdbm:/tmp/rewrites/my-site.map
RewriteCond ${my-site.foo:$1} !=""
RewriteRule ^(.*)$ ${my-site.foo:$1|/} [L,R=301]
```

