### PR TITLE
Fix bnd-maven-plugin configuration merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 - #3494 - Remove offline instrumentation with Jacoco
 
+### Fixed
+
+- #3471 - EmailService not working due to unsatisfied reference to MailTemplateManager in AEM on prem
+
 ## 6.9.10 - 2024-12-13
 
 ### Added 

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -48,6 +48,7 @@
                 <configuration>
                     <packageType>container</packageType>
                     <excludes>**/META-INF/*,**/thumbnail.png</excludes>
+                    <embeddedTarget>/apps/acs-commons/install</embeddedTarget>
                 </configuration>
                 <executions>
                     <execution>
@@ -59,40 +60,14 @@
                             <name>acs-aem-commons-all</name>
                             <embeddeds>
                                 <embedded>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>acs-aem-commons-bundle</artifactId>
-                                    <target>/apps/acs-commons/install</target>
-                                    <filter>true</filter>
-                                    <isAllVersionsFilter>true</isAllVersionsFilter>
-                                </embedded>
-                                <embedded>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>acs-aem-commons-bundle-onprem</artifactId>
-                                    <target>/apps/acs-commons/install</target>
-                                    <filter>true</filter>
-                                    <isAllVersionsFilter>true</isAllVersionsFilter>
-                                </embedded>
-                                <embedded>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>acs-aem-commons-ui.apps</artifactId>
+                                    <!-- exclude cloud specific dependencies -->
+                                    <artifactId>~acs-aem-commons-bundle-cloud</artifactId>
                                     <classifier>~cloud</classifier>
-                                    <target>/apps/acs-commons/install</target>
+                                    <type>jar,zip</type>
                                     <filter>true</filter>
                                     <isAllVersionsFilter>true</isAllVersionsFilter>
-                                </embedded>
-                                <embedded>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>acs-aem-commons-ui.content</artifactId>
-                                    <target>/apps/acs-commons/install</target>
-                                    <filter>true</filter>
-                                    <isAllVersionsFilter>true</isAllVersionsFilter>
-                                </embedded>
-                                <embedded>
-                                    <groupId>${project.groupId}</groupId>
-                                    <artifactId>acs-aem-commons-ui.config</artifactId>
-                                    <target>/apps/acs-commons/install</target>
-                                    <filter>true</filter>
-                                    <isAllVersionsFilter>true</isAllVersionsFilter>
+                                    <!-- only consider direct dependencies -->
+                                    <excludeTransitive>true</excludeTransitive>
                                 </embedded>
                             </embeddeds>
                         </configuration>
@@ -206,10 +181,29 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>acs-aem-commons-bundle-onprem</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.acs</groupId>
+            <artifactId>acs-aem-commons-bundle-cloud</artifactId>
+            <version>${project.version}</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>acs-aem-commons-ui.apps</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.acs</groupId>
+            <artifactId>acs-aem-commons-ui.apps</artifactId>
+            <classifier>cloud</classifier>
+            <version>${project.version}</version>
+            <type>zip</type>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -278,39 +272,17 @@
                                         <cloudManagerTarget>all</cloudManagerTarget>
                                     </properties>
                                     <embeddeds>
+                                        <!-- exclude onprem/classic specific artifacts-->
                                         <embedded>
-                                            <groupId>${project.groupId}</groupId>
-                                            <artifactId>acs-aem-commons-bundle</artifactId>
-                                            <target>/apps/acs-commons/install</target>
+                                            <artifactId>~acs-aem-commons-bundle-onprem,~acs-aem-commons-ui.apps</artifactId>
                                             <filter>true</filter>
                                             <isAllVersionsFilter>true</isAllVersionsFilter>
+                                            <!-- only consider direct dependencies -->
+                                            <excludeTransitive>true</excludeTransitive>
                                         </embedded>
                                         <embedded>
-                                            <groupId>${project.groupId}</groupId>
-                                            <artifactId>acs-aem-commons-bundle-cloud</artifactId>
-                                            <target>/apps/acs-commons/install</target>
-                                            <filter>true</filter>
-                                            <isAllVersionsFilter>true</isAllVersionsFilter>
-                                        </embedded>
-                                        <embedded>
-                                            <groupId>${project.groupId}</groupId>
                                             <artifactId>acs-aem-commons-ui.apps</artifactId>
                                             <classifier>cloud</classifier>
-                                            <target>/apps/acs-commons/install</target>
-                                            <filter>true</filter>
-                                            <isAllVersionsFilter>true</isAllVersionsFilter>
-                                        </embedded>
-                                        <embedded>
-                                            <groupId>${project.groupId}</groupId>
-                                            <artifactId>acs-aem-commons-ui.content</artifactId>
-                                            <target>/apps/acs-commons/install</target>
-                                            <filter>true</filter>
-                                            <isAllVersionsFilter>true</isAllVersionsFilter>
-                                        </embedded>
-                                        <embedded>
-                                            <groupId>${project.groupId}</groupId>
-                                            <artifactId>acs-aem-commons-ui.config</artifactId>
-                                            <target>/apps/acs-commons/install</target>
                                             <filter>true</filter>
                                             <isAllVersionsFilter>true</isAllVersionsFilter>
                                         </embedded>
@@ -348,26 +320,14 @@
                                 <goals>
                                     <goal>project-analyse</goal>
                                 </goals>
+                                <configuration>
+                                    <classifier>cloud</classifier>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
                 </plugins>
             </build>
-            <dependencies>
-                <dependency>
-                    <groupId>com.adobe.acs</groupId>
-                    <artifactId>acs-aem-commons-bundle-cloud</artifactId>
-                    <version>${project.version}</version>
-                    <type>jar</type>
-                </dependency>
-                <dependency>
-                    <groupId>com.adobe.acs</groupId>
-                    <artifactId>acs-aem-commons-ui.apps</artifactId>
-                    <classifier>cloud</classifier>
-                    <version>${project.version}</version>
-                    <type>zip</type>
-                </dependency>
-            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -219,14 +219,8 @@
                     <groupId>biz.aQute.bnd</groupId>
                     <artifactId>bnd-maven-plugin</artifactId>
                     <version>${bnd.version}</version>
-                    <executions>
-                        <execution>
-                            <id>bnd-process</id>
-                            <goals>
-                                <goal>bnd-process</goal>
-                            </goals>
-                            <configuration>
-                                <bnd><![CDATA[
+                    <configuration>
+                        <bnd><![CDATA[
 # a lot of bundle header are generated from pom elements by default: https://github.com/bndtools/bnd/tree/master/maven/bnd-maven-plugin#default-bundle-headers
 Bundle-Category: acs-aem-commons
 # export all versioned packages except for conditional ones (https://github.com/bndtools/bnd/issues/3721#issuecomment-579026778)
@@ -248,8 +242,14 @@ Bundle-DocURL: https://adobe-consulting-services.github.io/acs-aem-commons/
 # support only DS 1.4 (https://github.com/bndtools/bnd/pull/3121/files)
 -dsannotations-options: version;maximum=1.4.0,inherit
 -metatypeannotations-options: version;maximum=1.4.0
-                                ]]></bnd>
-                            </configuration>
+                        ]]></bnd>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>bnd-process</id>
+                            <goals>
+                                <goal>bnd-process</goal>
+                            </goals>
                         </execution>
                     </executions>
                     <dependencies>


### PR DESCRIPTION
Previously the configuration from the parent (per execution id) was overriding the local config (per plugin). Now the parent configuration is no longer per execution id, i.e. both local plugin configurations (i.e. on plugin level and on execution id level) take precedence.

This closes #3471