### PR TITLE
Remove JaCoCo offline instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## Unreleased ([details][unreleased changes details])
 
+### Changed
+
+- #3494 - Remove offline instrumentation with Jacoco
+
+## 6.9.10 - 2024-12-13
+
+### Added 
 - #3484 - Redirect Manager: A servlet to export redirects to a TXT file to use with pipeline-free redirects
 - #3480 - AEM Sites Copy Publish URLs
 
 ### Fixed
 - #3479 - Fixed Configurations Model for Redirect Manager after change in "redirect" resource as "sling:Folder"
-
-### Fixed
-
 - #3483 - Fixed issue with genericlist/body.jsp importing a class from an impl package.
 
 ## 6.9.6 - 2024-11-20

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <!-- the minimum AEMaaCS version being supported -->
         <aem.sdk.api.version>2024.8.17569.20240822T203847Z-240700</aem.sdk.api.version>
 
-        <jacoco.version>0.8.11</jacoco.version>
+        <jacoco.version>0.8.12</jacoco.version>
         <junit.jupiter.version>5.10.2</junit.jupiter.version> <!-- >= 5.x requires Java 11 -->
         <!-- affects both m-compiler-p and m-javadoc-p-->
         <maven.compiler.release>8</maven.compiler.release>
@@ -794,38 +794,48 @@ Bundle-DocURL: https://adobe-consulting-services.github.io/acs-aem-commons/
         <profile>
             <id>coverage</id>
             <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <argLine>@{jacoco.command}</argLine>
+                            </configuration>
+                        </plugin>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-failsafe-plugin</artifactId>
+                            <configuration>
+                                <!-- 
+                                for IT where you need a forked JVM to run the tests you can use this system property to make sure that
+                                the JaCoCo agent correctly instruments your code
+                                set system property also via argLine as only that allows late evaluation -->
+                                <argLine>@{jacoco.command} -Djacoco.command=@{jacoco.command}</argLine>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
                 <plugins>
                     <plugin>
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
                         <version>${jacoco.version}</version>
+                        
                         <executions>
                             <execution>
-                                <id>default-prepare-agent</id>
+                                <id>prepare-agent</id>
                                 <goals>
                                     <goal>prepare-agent</goal>
                                 </goals>
+                                <!-- the same execution data file is used for both IT and UT-->
                                 <configuration>
-                                    <excludes>
-                                        <exclude>*</exclude>
-                                    </excludes>
+                                    <propertyName>jacoco.command</propertyName>
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>jacoco-instrument</id>
-                                <goals>
-                                    <goal>instrument</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>jacoco-restore-instrumented-classes</id>
-                                <goals>
-                                    <goal>restore-instrumented-classes</goal>
-                                </goals>
-                            </execution>
-                            <execution>
                                 <id>report</id>
-                                <phase>prepare-package</phase>
+                                <phase>verify</phase>
                                 <goals>
                                     <goal>report</goal>
                                 </goals>


### PR DESCRIPTION
It incorrectly affects manifest calculation which leads to follow-up issues with aemanalyser-m-p and is generally not recommended (https://www.eclemma.org/jacoco/trunk/doc/instrument-mojo.html)

It was originally introduced for compatibility with PowerMock but that is no longer used.

This closes #3494