### PR TITLE
Only publish test results once

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -96,6 +96,7 @@ jobs:
           name: Test Results (${{ matrix.os }}, JDK ${{ matrix.jdk }}))
           path: |
             target/surefire-reports/TEST*.xml
+            target/failsafe-reports/TEST*.xml
             target/invoker-reports/TEST*.xml
             target/it/**/build.log
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -89,11 +89,15 @@ jobs:
       - name: ${{ matrix.namePrefix }} Build with Maven ${{ env.STEP_NAME_SUFFIX }}
         run: mvn -e -B -V ${{ env.MVN_GOAL }} ${{ env.MVN_ADDITIONAL_OPTS }}
 
-      - name: Publish Test Report
-        if: ${{ always() }} # make sure to run even if previous Maven execution failed (due to failed test)
-        uses: scacap/action-surefire-report@v1
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          check_name: Test report (${{ matrix.os }}, JDK ${{ matrix.jdk }})
+          name: Test Results (${{ matrix.os }}, JDK ${{ matrix.jdk }}))
+          path: |
+            target/surefire-reports/TEST*.xml
+            target/invoker-reports/TEST*.xml
+            target/it/**/build.log
 
       # https://about.codecov.io/blog/javascript-code-coverage-using-github-actions-and-codecov/
       - name: Upload code coverage to CodeCov (Main build)
@@ -107,3 +111,31 @@ jobs:
         with:
           changeLogPath: 'CHANGELOG.md'
           skipLabels: 'Skip-Changelog,skip-changelog'
+
+  publish-test-results:
+    name: "Publish Tests Results"
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+
+      # only needed unless run with comment_mode: off
+      pull-requests: write
+
+      # only needed for private repository
+      contents: read
+
+      # only needed for private repository
+      issues: read
+    if: always()
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: "artifacts/**/*.xml"


### PR DESCRIPTION
This aggregates the reports of all matrix builds.
The build test results can still be distinguished by their unique reort name