### PR TITLE
Redirects Manager: rules are not orderable and not replicated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## Unreleased ([details][unreleased changes details])
 
+### Fixed
+- # - Redirect Manager: ensure redirect configurations are orderable
+
+## 6.10.0 - 2024-12-13
+
 - #3484 - Redirect Manager: A servlet to export redirects to a TXT file to use with pipeline-free redirects
 - #3480 - AEM Sites Copy Publish URLs
 

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/CreateRedirectConfigurationServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/CreateRedirectConfigurationServlet.java
@@ -98,7 +98,7 @@ public class CreateRedirectConfigurationServlet extends SlingAllMethodsServlet {
             if (config == null) {
                 String contextPrefix = StringUtils.defaultString(request.getParameter(REQ_PARAM_CTX_PREFIX));
                 config = resolver.create(bucket, configName,
-                        ImmutableMap.of(JcrConstants.JCR_PRIMARYTYPE, JcrResourceConstants.NT_SLING_FOLDER,
+                        ImmutableMap.of(JcrConstants.JCR_PRIMARYTYPE, JcrResourceConstants.NT_SLING_ORDERED_FOLDER,
                                 ResourceResolver.PROPERTY_RESOURCE_TYPE, REDIRECTS_RESOURCE_PATH,
                                 REQ_PARAM_CTX_PREFIX, contextPrefix));
                 log.info("created {} with context prefix '{}'", config.getPath(), contextPrefix);

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/replicate.POST.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/replicate.POST.jsp
@@ -21,6 +21,7 @@
           import="
     javax.jcr.Session,
     javax.jcr.Node,
+    javax.jcr.nodetype.NodeType,
 	java.util.*,
 	java.io.PrintWriter,
     com.day.cq.replication.Replicator,
@@ -28,11 +29,19 @@
     com.day.cq.replication.ReplicationActionType" %><pre><%
 
     String path = request.getParameter("path");
+    Resource configResource = resourceResolver.getResource(path);
 
     Replicator replicator = sling.getService(Replicator.class);
     ReplicationOptions opts = new ReplicationOptions();
     opts.setSuppressVersions(true);
-    replicator.replicate(resourceResolver.adaptTo(Session.class), ReplicationActionType.ACTIVATE, path, null);
+    Session session = resourceResolver.adaptTo(Session.class);
+    replicator.replicate(session, ReplicationActionType.ACTIVATE, path, null);
 	out.println("Replicating: " + path);
 
-%></pre>
+    if(!configResource.adaptTo(Node.class).isNodeType(NodeType.NT_HIERARCHY_NODE)){
+        for(Resource res : configResource.getChildren()){
+	        replicator.replicate(session, ReplicationActionType.ACTIVATE, res.getPath(), null);
+    	    out.println("Replicating: " + res.getPath());
+        }
+    }
+%>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/replicate.POST.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-redirects/replicate.POST.jsp
@@ -44,4 +44,4 @@
     	    out.println("Replicating: " + res.getPath());
         }
     }
-%>
+%></pre>


### PR DESCRIPTION
The PR fixes two regressions introduced by  https://github.com/Adobe-Consulting-Services/acs-aem-commons/pull/3399

1. The configuration node should be `sling:OrderedFolder` instead of `sling:Folder` to ensure the rules are orderable in the UI and the iterator over children follows the order.
2. The configuration node used to be `nt:unstructured` which is hierarchical and could be replicated as a whole. Now passing the configuration path, which is `sling:OrderedFolder|sling:Folder`, to `Replicator` only replicates that node and not the children.
