### PR TITLE
#3537 Content Sync: preserve mix:referenceable mixin on Assets and Content Fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->-
 
 ## Unreleased ([details][unreleased changes details])
+- #3537 Content Sync: preserve mix:referenceable mixin on Assets and Content Fragments
 
  ## 6.11.0 - 2025-03-14
 

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.12.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/bundle-cloud/pom.xml
+++ b/bundle-cloud/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.12.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/bundle-onprem/pom.xml
+++ b/bundle-onprem/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.12.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.12.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/bundle/src/main/java/com/adobe/acs/commons/contentsync/CatalogItem.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/contentsync/CatalogItem.java
@@ -20,9 +20,11 @@
 package com.adobe.acs.commons.contentsync;
 
 
+import javax.json.JsonArray;
 import javax.json.JsonObject;
 
 import static org.apache.jackrabbit.JcrConstants.JCR_CONTENT;
+import static org.apache.jackrabbit.JcrConstants.JCR_MIXINTYPES;
 
 /**
  * A Json object describing a resource to sync.
@@ -71,4 +73,17 @@ public class CatalogItem {
     public JsonObject getJsonObject(){
         return object;
     }
+
+    public String[] getMixins(){
+        JsonArray mixins = object.getJsonArray(JCR_MIXINTYPES);
+        if(mixins == null){
+            return new String[0];
+        }
+        String[] mixinArray = new String[mixins.size()];
+        for(int i = 0; i < mixins.size(); i++){
+            mixinArray[i] = mixins.getString(i);
+        }
+        return mixinArray;
+    }
+
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/contentsync/ContentSync.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/contentsync/ContentSync.java
@@ -256,7 +256,7 @@ public class ContentSync {
                 contentNode = parentNode.getNode(nodeName);
             } else {
                 contentNode = parentNode.addNode(nodeName, primaryType);
-                String mixins[] = catalogItem.getMixins();
+                String[] mixins = catalogItem.getMixins();
                 for (String mx : mixins) {
                     contentNode.addMixin(mx);
                 }

--- a/bundle/src/main/java/com/adobe/acs/commons/contentsync/ContentSync.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/contentsync/ContentSync.java
@@ -256,6 +256,10 @@ public class ContentSync {
                 contentNode = parentNode.getNode(nodeName);
             } else {
                 contentNode = parentNode.addNode(nodeName, primaryType);
+                String mixins[] = catalogItem.getMixins();
+                for (String mx : mixins) {
+                    contentNode.addMixin(mx);
+                }
             }
         } else {
             contentNode = parentNode;

--- a/bundle/src/main/java/com/adobe/acs/commons/contentsync/impl/LastModifiedStrategy.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/contentsync/impl/LastModifiedStrategy.java
@@ -34,6 +34,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 import javax.json.Json;
+import javax.json.JsonArrayBuilder;
 import javax.json.JsonObjectBuilder;
 import javax.servlet.GenericServlet;
 import javax.servlet.Servlet;
@@ -45,6 +46,7 @@ import java.util.List;
 
 import static org.apache.jackrabbit.JcrConstants.JCR_CONTENT;
 import static org.apache.jackrabbit.JcrConstants.JCR_PRIMARYTYPE;
+import static org.apache.jackrabbit.JcrConstants.JCR_MIXINTYPES;
 
 @Component
 public class LastModifiedStrategy implements UpdateStrategy {
@@ -198,6 +200,15 @@ public class LastModifiedStrategy implements UpdateStrategy {
     void writeMetadata(JsonObjectBuilder jw, Resource res, SlingHttpServletRequest request) {
         jw.add("path", res.getPath());
         jw.add(JCR_PRIMARYTYPE, res.getValueMap().get(JCR_PRIMARYTYPE, String.class));
+
+        String[] mixins = res.getValueMap().get(JCR_MIXINTYPES, String[].class);
+        if(mixins != null){
+            JsonArrayBuilder mx = Json.createArrayBuilder();
+            for(String mixin : mixins){
+                mx.add(mixin);
+            }
+            jw.add(JCR_MIXINTYPES, mx.build());
+        }
 
         Resource jcrContent = res.getChild(JCR_CONTENT);
         String exportUri;

--- a/bundle/src/main/java/com/adobe/acs/commons/contentsync/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/contentsync/package-info.java
@@ -17,5 +17,5 @@
  * limitations under the License.
  * #L%
  */
-@org.osgi.annotation.versioning.Version("1.3.0")
+@org.osgi.annotation.versioning.Version("6.12.0")
 package com.adobe.acs.commons.contentsync;

--- a/bundle/src/test/java/com/adobe/acs/commons/contentsync/TestContentSync.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/contentsync/TestContentSync.java
@@ -63,6 +63,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mockConstructionWithAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -280,6 +281,7 @@ public class TestContentSync {
         JsonObject catalogItem = Json.createObjectBuilder()
                 .add("path", "/content/dam/asset")
                 .add("exportUri", "/content/dam/asset/jcr:content.infinity.json")
+                .add("jcr:mixinTypes", Json.createArrayBuilder().add("mix:referenceable").build() )
                 .add("jcr:primaryType", "dam:Asset")
                 .build();
 
@@ -288,6 +290,7 @@ public class TestContentSync {
         contentSync.importData(new CatalogItem(catalogItem), sanitizedJson);
 
         Asset asset = context.resourceResolver().getResource("/content/dam/asset").adaptTo(Asset.class);
+        assertArrayEquals(new String[]{"mix:referenceable"}, asset.adaptTo(Resource.class).getValueMap().get("jcr:mixinTypes", String[].class));
 
         byte[] data = IOUtils.toByteArray(
                 asset.getOriginal().getStream()
@@ -299,6 +302,7 @@ public class TestContentSync {
         assertEquals("Adobe PDF library 15.00", asset.getMetadata("pdf:Producer"));
         assertEquals((long) 657, asset.getMetadata("tiff:ImageWidth"));
     }
+
 
     @Test
     public void testUpdateExistingAsset() throws Exception {

--- a/oakpal-checks/pom.xml
+++ b/oakpal-checks/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.12.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>com.adobe.acs</groupId>
     <artifactId>acs-aem-commons</artifactId>
-    <version>6.11.1-SNAPSHOT</version>
+    <version>6.12.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>ACS AEM Commons - Reactor Project</name>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.12.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/ui.config/pom.xml
+++ b/ui.config/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.12.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.11.1-SNAPSHOT</version>
+        <version>6.12.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->


### PR DESCRIPTION
Fixes #3537

The old impl didn't preserve JCR mixins on the parent resource nodes, e.g. if the asset being sync-ed is `mix:referenceable` and has a UUID created by that mixin

```
+ /content/dam/my-asset
  - jcr:primaryType = dam:Asset
  - jcr:mixinTypes = [mix:referenceable] 
  - jcr:uuid = 4beeea0b-7e6e-429f-992e-6de775282044
```

then the synced node would be

```
+ /content/dam/my-asset
  - jcr:primaryType = dam:Asset
```

The PR ensures that `jcr:mixinTypes` are preserved.