### PR TITLE
Reverts the default resource type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## Unreleased ([details][unreleased changes details])
 - #3537 Content Sync: preserve mix:referenceable mixin on Assets and Content Fragments
+- #3536 Granite Include Obscures included Resource Type
 
  ## 6.11.0 - 2025-03-14
 

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/granite/ui/components/include/include.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/granite/ui/components/include/include.jsp
@@ -22,5 +22,5 @@
     NamespacedTransformedResourceProvider transformedResourceProvider = sling.getService(NamespacedTransformedResourceProvider.class);
     Resource resourceWrapper = transformedResourceProvider.transformResourceWithNameSpacing(slingRequest, targetResource);
 
-    cmp.include(resourceWrapper, cfg.get("resourceType", "granite/ui/components/coral/foundation/container"), cmp.getOptions());
+    cmp.include(resourceWrapper, cfg.get("resourceType", String.class), cmp.getOptions());
 %>


### PR DESCRIPTION
The default resource type broke existing uses of the granite include feature unless the included snippet was a granite container.
The resourceType should be explicitly set by the user if the type needs to change or the snippet does not already include a resource type and not be defaulted.

Fixes #3536