### PR TITLE
fixes #2745: Remove cyclic dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ## Unreleased ([details][unreleased changes details])
 
 ### Changed
+
 - #3327 Update to mockito 5.x, which allows static mocking without needing mockito-inline. Java11+ is the standard nowadays, so we can use 5.x+
 
 ### Fixed
+
 - #2745 Fixed circular dependency in EnsureOakIndex
 
 ## 6.12.0 - 2025-04-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #3555 Content Sync: prevent timeout errors when sync-ing AEM cloud instances with large volumes of data
 - #3560 Redirect Manager: url-encode search terms in Full Text search mode
 - #3562 Fixed compilation errors in iscurrentusermemberof render condition
+- #2745 Fixed circular dependency in EnsureOakIndex
 
  ## 6.11.0 - 2025-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #3560 Redirect Manager: url-encode search terms in Full Text search mode
 - #3562 Fixed compilation errors in iscurrentusermemberof render condition
 - #2745 Fixed circular dependency in EnsureOakIndex
+- #3327 Update to mockito 5.x, which allows static mocking without needing mockito-inline. Java11+ is the standard nowadays, so we can use 5.x+
 
  ## 6.11.0 - 2025-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,14 +10,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## Unreleased ([details][unreleased changes details])
 
+### Changed
+- #3327 Update to mockito 5.x, which allows static mocking without needing mockito-inline. Java11+ is the standard nowadays, so we can use 5.x+
+
+### Fixed
+- #2745 Fixed circular dependency in EnsureOakIndex
+
+## 6.12.0 - 2025-04-28
+
+### Changed
+
 - #3536 Granite Include Obscures included Resource Type
 - #3537 Content Sync: preserve mix:referenceable mixin on Assets and Content Fragments
 - #3551 Redirect Manager: correctly determine the redirect rules publication status for sharded and non-sharded redirects.
 - #3555 Content Sync: prevent timeout errors when sync-ing AEM cloud instances with large volumes of data
 - #3560 Redirect Manager: url-encode search terms in Full Text search mode
 - #3562 Fixed compilation errors in iscurrentusermemberof render condition
-- #2745 Fixed circular dependency in EnsureOakIndex
-- #3327 Update to mockito 5.x, which allows static mocking without needing mockito-inline. Java11+ is the standard nowadays, so we can use 5.x+
+- #3457 Allow disabling the ContentPolicyValueInjector
 
  ## 6.11.0 - 2025-03-14
 

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -157,7 +157,7 @@
                         <configuration>
                             <rules>
                                 <bannedDependencies>
-                                    <!-- here we need to explicitly list the set of dependencies which 
+                                    <!-- here we need to explicitly list the set of dependencies which
                                     are allowed with scope=compile -->
                                     <includes>
                                         <include>com.google.guava:*</include>
@@ -504,8 +504,8 @@
             <optional>true</optional>
             <scope>compile</scope>
         </dependency>
-        <!-- Due to the split of the JJWT library we need  
-                  - the api for compilation 
+        <!-- Due to the split of the JJWT library we need
+                  - the api for compilation
                   - and the impl for embedding together with
                   - the extension for serialization/deserialization support -->
         <dependency>
@@ -559,12 +559,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <scope>test</scope>
-            <version>5.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndex.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndex.java
@@ -18,18 +18,13 @@
 package com.adobe.acs.commons.oak.impl;
 
 import com.adobe.acs.commons.analysis.jcrchecksum.ChecksumGenerator;
-import com.adobe.acs.commons.oak.EnsureOakIndexManager;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.ResourceResolverFactory;
 import org.apache.sling.commons.scheduler.ScheduleOptions;
 import org.apache.sling.commons.scheduler.Scheduler;
-import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.ConfigurationPolicy;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferenceCardinality;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.annotations.*;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
@@ -37,7 +32,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jcr.RepositoryException;
+import java.io.IOException;
 import java.util.Collections;
+import java.util.Dictionary;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -104,13 +101,9 @@ public class EnsureOakIndex implements AppliableEnsureOakIndex {
 
     @Reference
     private Scheduler scheduler;
-    
-    @Reference(
-            cardinality = ReferenceCardinality.OPTIONAL,
-            policy = ReferencePolicy.DYNAMIC,
-            policyOption = ReferencePolicyOption.GREEDY
-    )
-    private volatile EnsureOakIndexManager indexManager;
+
+    @Reference
+    private ConfigurationAdmin configurationAdmin;
 
     private String ensureDefinitionsPath;
     private String oakIndexesPath;
@@ -135,10 +128,18 @@ public class EnsureOakIndex implements AppliableEnsureOakIndex {
         }
 
         this.immediate = config.immediate();
-        
+
         String[] ignoredProps = config.properties_ignore();
-        String[] indexManagerIgnoredProps = getIndexManagerConfiguredIgnoreProperties();
-        
+        String[] indexManagerConfiguredIgnoreProperties = getIndexManagerConfiguredIgnoreProperties();
+
+        setIgnoredProperties(ignoredProps, indexManagerConfiguredIgnoreProperties);
+
+        if (this.immediate) {
+            apply(false);
+        }
+    }
+
+    private void setIgnoredProperties(String[] ignoredProps, String[] indexManagerIgnoredProps) {
         if (ignoredProps.length == 0) {
             // Legacy: check if EnsureOakIndexManagerImpl has this property configured -- https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/1966
             if (indexManagerIgnoredProps.length != 0) {
@@ -155,18 +156,33 @@ public class EnsureOakIndex implements AppliableEnsureOakIndex {
                         + "; please delete it");
             }
         }
-        if (this.immediate) {
-            apply(false);
-        }
     }
 
-    
+    /**
+     * @return the ignore properties, using the ConfigurationAdmin to avoid having a circular reference between EnsureOakIndexManagerImpl and EnsureOakIndex OSGi services
+     */
     private String[] getIndexManagerConfiguredIgnoreProperties() {
-        if (indexManager instanceof EnsureOakIndexManagerImpl) {
-            EnsureOakIndexManagerImpl impl = (EnsureOakIndexManagerImpl) indexManager;
-            return impl.getIgnoredProperties();
+        try {
+             Configuration configuration = configurationAdmin.getConfiguration(EnsureOakIndexManagerImpl.class.getName());
+            if (configuration != null && configuration.getProperties() != null) {
+                return getIndexManagerConfiguredIgnoreProperties(configuration.getProperties());
+            }
+        } catch (IOException e) {
+            log.warn("Could not get ignored properties from index manager configuration", e);
         }
-        return new String[] {};
+        return new String[]{};
+    }
+
+    private static String[] getIndexManagerConfiguredIgnoreProperties(Dictionary properties) {
+        Object indexManagerIgnoredProps = properties.get(PROP_ADDITIONAL_IGNORE_PROPERTIES);
+        if (indexManagerIgnoredProps != null) {
+            if (indexManagerIgnoredProps instanceof String[]) {
+                return (String[]) indexManagerIgnoredProps;
+            } else if (indexManagerIgnoredProps instanceof String) {
+                return new String[]{(String) indexManagerIgnoredProps};
+            }
+        }
+        return new String[]{};
     }
 
     /**

--- a/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndex.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndex.java
@@ -24,7 +24,10 @@ import org.apache.sling.commons.scheduler.ScheduleOptions;
 import org.apache.sling.commons.scheduler.Scheduler;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
-import org.osgi.service.component.annotations.*;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.metatype.annotations.AttributeDefinition;
 import org.osgi.service.metatype.annotations.Designate;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
@@ -173,7 +176,7 @@ public class EnsureOakIndex implements AppliableEnsureOakIndex {
         return new String[]{};
     }
 
-    private static String[] getIndexManagerConfiguredIgnoreProperties(Dictionary properties) {
+    private static String[] getIndexManagerConfiguredIgnoreProperties(Dictionary<String, Object> properties) {
         Object indexManagerIgnoredProps = properties.get(PROP_ADDITIONAL_IGNORE_PROPERTIES);
         if (indexManagerIgnoredProps != null) {
             if (indexManagerIgnoredProps instanceof String[]) {

--- a/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexExecutor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexExecutor.java
@@ -1,0 +1,111 @@
+package com.adobe.acs.commons.oak.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.osgi.service.component.annotations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.openmbean.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@Component(service = EnsureOakIndexExecutor.class)
+public class EnsureOakIndexExecutor {
+
+    private static final Logger log = LoggerFactory.getLogger(EnsureOakIndexExecutor.class);
+
+    @Reference(
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policyOption = ReferencePolicyOption.GREEDY,
+            policy = ReferencePolicy.DYNAMIC,
+            fieldOption = FieldOption.UPDATE
+    )
+    // Thread-safe ArrayList to track EnsureIndex service registrations
+    private CopyOnWriteArrayList<AppliableEnsureOakIndex> ensureIndexes = new CopyOnWriteArrayList<>();
+
+    public final int ensureAll(boolean force) {
+        log.info("Applying all un-applied ensure index definitions");
+
+        int count = 0;
+        for (AppliableEnsureOakIndex index : this.ensureIndexes) {
+            if (!index.isApplied() || force) {
+                index.apply(force);
+                count++;
+                log.debug("Started applying index definition on [ {} ]", index);
+            } else {
+                log.debug("Skipping... [ {} ] is already applied.", index);
+            }
+        }
+
+        return count;
+    }
+
+    public final int ensure(final boolean force,
+                            final String ensureDefinitionPath) {
+        int count = 0;
+        for (AppliableEnsureOakIndex index : this.ensureIndexes) {
+            if ((!index.isApplied() || force)
+                    && StringUtils.equals(ensureDefinitionPath, index.getEnsureDefinitionsPath())) {
+                index.apply(force);
+                count++;
+                log.debug("Started async job applying index definition for {}", index);
+            } else {
+                log.debug("Skipping... [ {} ] is already applied.", index);
+            }
+        }
+        return count;
+    }
+
+
+    protected final void bindAppliableEnsureOakIndex(AppliableEnsureOakIndex index) {
+        if (index != null && !this.ensureIndexes.contains(index)) {
+            this.ensureIndexes.add(index);
+        }
+    }
+
+    protected final void unbindAppliableEnsureOakIndex(AppliableEnsureOakIndex index) {
+        if (index != null && this.ensureIndexes.contains(index)) {
+            this.ensureIndexes.remove(index);
+        }
+    }
+
+
+    /**
+     * Method for displaying Ensure Oak Index state in in the MBean
+     *
+     * @return the Ensure Oak Index data in a Tabular Format for the MBean
+     * @throws OpenDataException
+     */
+    @SuppressWarnings("squid:S1192")
+    public final TabularData getEnsureOakIndexes() throws OpenDataException {
+
+        final CompositeType configType = new CompositeType(
+                "Ensure Oak Index Configurations",
+                "Ensure Oak Index Configurations",
+                new String[]{"Ensure Definitions Path", "Oak Indexes Path", "Applied", "Immediate"},
+                new String[]{"Ensure Definitions Path", "Oak Indexes Path", "Applied", "Immediate"},
+                new OpenType[]{SimpleType.STRING, SimpleType.STRING, SimpleType.BOOLEAN, SimpleType.BOOLEAN});
+
+        final TabularDataSupport tabularData = new TabularDataSupport(new TabularType(
+                "Ensure Oak Index Configuration",
+                "Ensure Oak Index Configuration",
+                configType,
+                new String[]{"Ensure Definitions Path", "Oak Indexes Path"}));
+
+
+        for (final AppliableEnsureOakIndex index : this.ensureIndexes) {
+            final Map<String, Object> data = new HashMap<String, Object>();
+
+            data.put("Ensure Definitions Path", index.getEnsureDefinitionsPath());
+            data.put("Oak Indexes Path", index.getOakIndexesPath());
+            data.put("Applied", index.isApplied());
+            data.put("Immediate", index.isImmediate());
+
+            tabularData.put(new CompositeDataSupport(configType, data));
+        }
+
+        return tabularData;
+    }
+
+}

--- a/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexExecutor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexExecutor.java
@@ -1,8 +1,9 @@
-/*
- * ACS AEM Commons
- *
- * Copyright (C) 2013 - 2023 Adobe
- *
+/*-
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 - 2025 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.oak.impl;
 

--- a/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexExecutor.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexExecutor.java
@@ -1,11 +1,40 @@
+/*
+ * ACS AEM Commons
+ *
+ * Copyright (C) 2013 - 2023 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.adobe.acs.commons.oak.impl;
 
 import org.apache.commons.lang3.StringUtils;
-import org.osgi.service.component.annotations.*;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.FieldOption;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.management.openmbean.*;
+import javax.management.openmbean.CompositeDataSupport;
+import javax.management.openmbean.CompositeType;
+import javax.management.openmbean.OpenDataException;
+import javax.management.openmbean.OpenType;
+import javax.management.openmbean.SimpleType;
+import javax.management.openmbean.TabularData;
+import javax.management.openmbean.TabularDataSupport;
+import javax.management.openmbean.TabularType;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;

--- a/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexManagerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexManagerImpl.java
@@ -1,8 +1,9 @@
-/*
- * ACS AEM Commons
- *
- * Copyright (C) 2013 - 2023 Adobe
- *
+/*-
+ * #%L
+ * ACS AEM Commons Bundle
+ * %%
+ * Copyright (C) 2013 - 2025 Adobe
+ * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -14,6 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ * #L%
  */
 package com.adobe.acs.commons.oak.impl;
 

--- a/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexManagerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexManagerImpl.java
@@ -79,10 +79,6 @@ public class EnsureOakIndexManagerImpl extends AnnotatedStandardMBean implements
     private String[] additionalIgnoreProperties = DEFAULT_ADDITIONAL_IGNORE_PROPERTIES;
     public static final String PROP_ADDITIONAL_IGNORE_PROPERTIES = "properties.ignore";
 
-    /**
-     * The OSGi configuration is only used by the EnsureOakIndex OSGi services and would have ideally been a separate OSGi service,
-     * but we can't migrate this easily without losing the PID for existing implementations.
-     */
     @ObjectClassDefinition(
             name = "ACS AEM Commons - Ensure Oak Index Manager",
             description = "Manage for ensuring oak indexes."

--- a/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexManagerImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexManagerImpl.java
@@ -74,10 +74,12 @@ public class EnsureOakIndexManagerImpl extends AnnotatedStandardMBean implements
     private static final Logger log = LoggerFactory.getLogger(EnsureOakIndexManagerImpl.class);
 
     //@formatter:off
-    private static final String[] DEFAULT_ADDITIONAL_IGNORE_PROPERTIES = new String[]{};
-    private String[] additionalIgnoreProperties = DEFAULT_ADDITIONAL_IGNORE_PROPERTIES;
     public static final String PROP_ADDITIONAL_IGNORE_PROPERTIES = "properties.ignore";
 
+    /**
+     * The OSGi configuration is only used by the EnsureOakIndex OSGi services and would have ideally been a separate OSGi service,
+     * but we can't migrate this easily without losing the PID for existing implementations.
+     */
     @ObjectClassDefinition(
             name = "ACS AEM Commons - Ensure Oak Index Manager",
             description = "Manage for ensuring oak indexes."
@@ -91,8 +93,6 @@ public class EnsureOakIndexManagerImpl extends AnnotatedStandardMBean implements
                 cardinality = Integer.MAX_VALUE
         )
         String[] properties_ignore() default {};
-
-        String webconsole_configurationFactory_nameHint() default "Additional Ignore properties: {properties.ignore}";
 
     }
 
@@ -206,16 +206,4 @@ public class EnsureOakIndexManagerImpl extends AnnotatedStandardMBean implements
         return tabularData;
     }
 
-
-    @Activate
-    protected void activate(Config config) {
-        additionalIgnoreProperties = config.properties_ignore();
-    }
-    
-    
-    protected String[] getIgnoredProperties() {
-        return Optional.ofNullable(this.additionalIgnoreProperties)
-                .map(array -> Arrays.copyOf(array, array.length))
-                .orElse(DEFAULT_ADDITIONAL_IGNORE_PROPERTIES);
-    }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexTest.java
@@ -17,6 +17,7 @@
  */
 package com.adobe.acs.commons.oak.impl;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -74,10 +75,12 @@ public class EnsureOakIndexTest {
         ensureOakIndexProperties.put(EnsureOakIndex.PROP_OAK_INDEXES_PATH, "/oak:index");
     }
 
-    private void setupIndexManager(String[] ignoreProperties) throws NotCompliantMBeanException, IOException {
+    private void setupIndexManager(Object ignoreProperties) throws NotCompliantMBeanException, IOException {
         EnsureOakIndexManagerImpl indexManager = new EnsureOakIndexManagerImpl();
         Map<String,Object> props = new HashMap<>();
-        props.put(EnsureOakIndexManagerImpl.PROP_ADDITIONAL_IGNORE_PROPERTIES, ignoreProperties);
+        if (ignoreProperties != null) {
+            props.put(EnsureOakIndexManagerImpl.PROP_ADDITIONAL_IGNORE_PROPERTIES, ignoreProperties);
+        }
         context.registerInjectActivateService(indexManager, props );
         ConfigurationAdmin configurationAdmin = context.getService(ConfigurationAdmin.class);
         Configuration configuration = configurationAdmin.getConfiguration(indexManager.getClass().getName());
@@ -114,6 +117,31 @@ public class EnsureOakIndexTest {
         List<String> ignoreProperties = eoi.getIgnoreProperties();
         assertTrue(ignoreProperties.size() == 1);
         assertTrue(ignoreProperties.contains("localProp"));
+    }
+
+    @Test
+    public void testIndexManagerConfigurationSingleString() throws NotCompliantMBeanException, IOException {
+        setupIndexManager("globalSetting");
+        ensureOakIndexProperties.put(EnsureOakIndex.PROP_IMMEDIATE, false);
+        context.registerInjectActivateService(eoi, ensureOakIndexProperties);
+        assertTrue(eoi.getIgnoreProperties().contains("globalSetting"));
+    }
+
+    @Test
+    public void testIndexManagerConfigurationAsMultiString() throws NotCompliantMBeanException, IOException {
+        setupIndexManager(new String[] {"globalSetting"});
+        ensureOakIndexProperties.put(EnsureOakIndex.PROP_IMMEDIATE, false);
+        context.registerInjectActivateService(eoi, ensureOakIndexProperties);
+        assertTrue(eoi.getIgnoreProperties().contains("globalSetting"));
+    }
+
+    @Test
+    public void testIndexManagerConfigurationNotSet() throws NotCompliantMBeanException, IOException {
+        setupIndexManager(null);
+        ensureOakIndexProperties.put(EnsureOakIndex.PROP_IMMEDIATE, false);
+        ensureOakIndexProperties.put(EnsureOakIndex.PROP_ADDITIONAL_IGNORE_PROPERTIES, new String[] {"localProp"});
+        context.registerInjectActivateService(eoi, ensureOakIndexProperties);
+        assertTrue(eoi.getIgnoreProperties().contains("localProp"));
     }
 
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/oak/impl/EnsureOakIndexTest.java
@@ -19,12 +19,14 @@ package com.adobe.acs.commons.oak.impl;
 
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import javax.management.NotCompliantMBeanException;
 
+import org.apache.felix.utils.collections.MapToDictionary;
 import org.apache.sling.commons.scheduler.Scheduler;
 import org.apache.sling.testing.mock.sling.junit.SlingContext;
 import org.junit.Before;
@@ -37,48 +39,53 @@ import org.mockito.junit.MockitoRule;
 import com.adobe.acs.commons.analysis.jcrchecksum.ChecksumGenerator;
 import com.adobe.acs.commons.analysis.jcrchecksum.impl.ChecksumGeneratorImpl;
 import com.adobe.acs.commons.util.RequireAem;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
 
 
 public class EnsureOakIndexTest {
 
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
-    
+
     @Rule
     public SlingContext context = new SlingContext();
-    
+
     @Mock
     Scheduler scheduler;
-    
+
     @Mock
     RequireAem requireAem;
-    
+
     String[] indexManagerProps = {"managerProp1"};
-    
+
     Map<String,Object> ensureOakIndexProperties = new HashMap<>();
-    
+
     EnsureOakIndex eoi = new EnsureOakIndex();
-    
-    
+
+
     @Before
     public void setup() {
         context.registerService(ChecksumGenerator.class, new ChecksumGeneratorImpl());
-        
+
         context.registerService(Scheduler.class, scheduler);
         context.registerService(RequireAem.class, requireAem,"distribution","classic");
         ensureOakIndexProperties.put(EnsureOakIndex.PROP_ENSURE_DEFINITIONS_PATH, "/apps/com/indexes");
         ensureOakIndexProperties.put(EnsureOakIndex.PROP_OAK_INDEXES_PATH, "/oak:index");
     }
-    
-    private void setupIndexManager(String[] ignoreProperties) throws NotCompliantMBeanException {
+
+    private void setupIndexManager(String[] ignoreProperties) throws NotCompliantMBeanException, IOException {
         EnsureOakIndexManagerImpl indexManager = new EnsureOakIndexManagerImpl();
         Map<String,Object> props = new HashMap<>();
         props.put(EnsureOakIndexManagerImpl.PROP_ADDITIONAL_IGNORE_PROPERTIES, ignoreProperties);
         context.registerInjectActivateService(indexManager, props );
+        ConfigurationAdmin configurationAdmin = context.getService(ConfigurationAdmin.class);
+        Configuration configuration = configurationAdmin.getConfiguration(indexManager.getClass().getName());
+        configuration.update(new MapToDictionary(props));
     }
-    
+
     @Test
-    public void testWithLocalIgnoredProperties() throws NotCompliantMBeanException {
+    public void testWithLocalIgnoredProperties() throws NotCompliantMBeanException, IOException {
         setupIndexManager(new String[] {});
         ensureOakIndexProperties.put(EnsureOakIndex.PROP_ADDITIONAL_IGNORE_PROPERTIES, new String[] {"localProp"});
         ensureOakIndexProperties.put(EnsureOakIndex.PROP_IMMEDIATE, false);
@@ -87,9 +94,9 @@ public class EnsureOakIndexTest {
         assertTrue(ignoreProperties.size() == 1);
         assertTrue(ignoreProperties.contains("localProp"));
     }
-    
+
     @Test
-    public void testLegacyMode() throws NotCompliantMBeanException {
+    public void testLegacyMode() throws NotCompliantMBeanException, IOException {
         setupIndexManager(new String[] {"globalSetting"});
         ensureOakIndexProperties.put(EnsureOakIndex.PROP_IMMEDIATE, false);
         context.registerInjectActivateService(eoi, ensureOakIndexProperties);
@@ -97,9 +104,9 @@ public class EnsureOakIndexTest {
         assertTrue(ignoreProperties.size() == 1);
         assertTrue(ignoreProperties.contains("globalSetting"));
     }
-    
+
     @Test
-    public void testMixedMode() throws NotCompliantMBeanException {
+    public void testMixedMode() throws NotCompliantMBeanException, IOException {
         setupIndexManager(new String[] {"globalSetting"});
         ensureOakIndexProperties.put(EnsureOakIndex.PROP_ADDITIONAL_IGNORE_PROPERTIES, new String[] {"localProp"});
         ensureOakIndexProperties.put(EnsureOakIndex.PROP_IMMEDIATE, false);

--- a/bundle/src/test/java/com/adobe/acs/commons/redirectmaps/impl/TestServlets.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirectmaps/impl/TestServlets.java
@@ -18,7 +18,6 @@
 package com.adobe.acs.commons.redirectmaps.impl;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -45,9 +44,12 @@ import org.apache.sling.commons.testing.sling.MockResourceResolver;
 import org.apache.tika.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.InjectMocks;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,6 +59,8 @@ import com.day.cq.commons.jcr.JcrConstants;
 
 import junitx.util.PrivateAccessor;
 
+@RunWith(MockitoJUnitRunner.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class TestServlets {
 
     private static final Logger log = LoggerFactory.getLogger(TestServlets.class);
@@ -191,7 +195,7 @@ public class TestServlets {
 
     };
 
-    @InjectMocks
+    @Mock
     private RedirectMapModel model;
 
     private List<RedirectConfigModel> redirectConfigs = new ArrayList<RedirectConfigModel>() {
@@ -232,7 +236,6 @@ public class TestServlets {
     public void init() throws IOException, NoSuchFieldException {
         log.info("init");
 
-        MockitoAnnotations.initMocks(this);
 
         final MockResourceResolver mockResolver = new MockResourceResolver() {
             public Iterator<Resource> findResources(String query, String language) {
@@ -274,7 +277,7 @@ public class TestServlets {
                 .adaptTo(InputStream.class);
 
         log.debug("Setting up the resource /etc/redirectMap.txt/jcr:content");
-        doReturn(mockMapContentResource).when(mockFileResource).getChild(JcrConstants.JCR_CONTENT);
+        Mockito.lenient().doReturn(mockMapContentResource).when(mockFileResource).getChild(JcrConstants.JCR_CONTENT);
         doReturn("/etc/redirectMap.txt/jcr:content").when(mockMapContentResource).getPath();
         doReturn(mvm).when(mockMapContentResource).adaptTo(ModifiableValueMap.class);
         mockResolver.addResource(mockMapContentResource);

--- a/pom.xml
+++ b/pom.xml
@@ -673,13 +673,13 @@ Bundle-DocURL: https://adobe-consulting-services.github.io/acs-aem-commons/
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>4.11.0</version><!-- >= 5.x requires Java 11 -->
+                <version>5.16.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
-                <version>4.11.0</version><!-- >= 5.x requires Java 11 -->
+                <version>5.16.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -807,7 +807,7 @@ Bundle-DocURL: https://adobe-consulting-services.github.io/acs-aem-commons/
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-failsafe-plugin</artifactId>
                             <configuration>
-                                <!-- 
+                                <!--
                                 for IT where you need a forked JVM to run the tests you can use this system property to make sure that
                                 the JaCoCo agent correctly instruments your code
                                 set system property also via argLine as only that allows late evaluation -->
@@ -821,7 +821,7 @@ Bundle-DocURL: https://adobe-consulting-services.github.io/acs-aem-commons/
                         <groupId>org.jacoco</groupId>
                         <artifactId>jacoco-maven-plugin</artifactId>
                         <version>${jacoco.version}</version>
-                        
+
                         <executions>
                             <execution>
                                 <id>prepare-agent</id>


### PR DESCRIPTION
Remove cyclic dependency by not using OSGi DS to reference the index manager from the EnsureOakIndex OSGi classes