### PR TITLE
#3594 Redirect Manager: create parent structure if user enters a non-existing /conf path in Add Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 
 ## Unreleased ([details][unreleased changes details])
-- #3594 Redirect Manager: create parent structure if user enters a non-existing /conf path in Add Configuration
+- #3594 Redirect Manager: create parent structure if user enters a non-existing /conf path in Add Configuration.
 
 ## 6.12.0 - 2025-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->-
 
+
 ## Unreleased ([details][unreleased changes details])
+- #3594 Redirect Manager: create parent structure if user enters a non-existing /conf path in Add Configuration
+
+## 6.12.0 - 2025-04-28
 
 - #3536 Granite Include Obscures included Resource Type
 - #3537 Content Sync: preserve mix:referenceable mixin on Assets and Content Fragments

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/CreateRedirectConfigurationServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/CreateRedirectConfigurationServlet.java
@@ -28,6 +28,7 @@ import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.PersistenceException;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.api.servlets.SlingAllMethodsServlet;
 import org.apache.sling.jcr.resource.api.JcrResourceConstants;
 import org.osgi.service.component.annotations.Component;
@@ -78,7 +79,8 @@ public class CreateRedirectConfigurationServlet extends SlingAllMethodsServlet {
         ResourceResolver resolver = request.getResourceResolver();
         Resource root = resolver.getResource(rootPath);
         if(root == null){
-            throw new IllegalArgumentException("not found: " + rootPath);
+            root = ResourceUtil.getOrCreateResource(resolver, rootPath, JcrResourceConstants.NT_SLING_FOLDER,
+                    JcrResourceConstants.NT_SLING_FOLDER, false);
         }
 
         Map<String, String> rsp = new HashMap<>();

--- a/bundle/src/test/java/com/adobe/acs/commons/redirects/servlets/CreateRedirectConfigurationServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/redirects/servlets/CreateRedirectConfigurationServletTest.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.Iterator;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -118,5 +119,27 @@ public class CreateRedirectConfigurationServletTest {
         // return 409 if already exists
         servlet.doPost(request, context.response());
         assertEquals(HttpServletResponse.SC_CONFLICT, context.response().getStatus());
+    }
+
+    /**
+     * #3594 create new configurations ad hoc
+     */
+    @Test
+    public void createCreateParentFolders() throws ServletException, IOException {
+        MockSlingHttpServletRequest request = context.request();
+        String path = "/conf/one/two/three";
+        request.addRequestParameter("path", path);
+        servlet.doPost(request, context.response());
+
+        assertEquals(HttpServletResponse.SC_OK, context.response().getStatus());
+
+        assertNotNull(context.resourceResolver().getResource(path));
+
+        // Read configurations via Model
+        Configurations confModel = request.adaptTo(Configurations.class);
+        Collection<RedirectConfiguration> configurations = confModel.getConfigurations();
+        RedirectConfiguration cfg = configurations.iterator().next();
+        assertEquals("/conf/one/two/three/settings/redirects", cfg.getPath());
+
     }
 }


### PR DESCRIPTION
fixes #3594