### PR TITLE
Support OAuth in ContentSync 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->-
 
 ## Unreleased ([details][unreleased changes details])
+- # Content Sync: support OAuth authentication
+
+## 6.12.0 - 2025-04-28
 
 - #3536 Granite Include Obscures included Resource Type
 - #3537 Content Sync: preserve mix:referenceable mixin on Assets and Content Fragments

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.12.1-SNAPSHOT</version>
+        <version>6.13.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/bundle-cloud/pom.xml
+++ b/bundle-cloud/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.12.1-SNAPSHOT</version>
+        <version>6.13.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/bundle-onprem/pom.xml
+++ b/bundle-onprem/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.12.1-SNAPSHOT</version>
+        <version>6.13.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.12.1-SNAPSHOT</version>
+        <version>6.13.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/bundle/src/main/java/com/adobe/acs/commons/contentsync/RemoteInstance.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/contentsync/RemoteInstance.java
@@ -95,7 +95,7 @@ public class RemoteInstance implements Closeable {
         HttpClientBuilder builder = HttpClients.custom();
         if (hostConfiguration.isOAuthEnabled()) {
             // If OAuth is enabled, use the AccessTokenProvider to get the token
-            String accessToken = tokenProvider.getAccessToken(resourceResolver, hostConfiguration.getAgentUserId(), null);
+            String accessToken = tokenProvider.getAccessToken(resourceResolver, resourceResolver.getUserID(), null);
             builder.addInterceptorFirst((HttpRequestInterceptor) (request, context) -> {
                 request.addHeader("Authorization", "Bearer " + accessToken);
             });

--- a/bundle/src/main/java/com/adobe/acs/commons/contentsync/SyncHostConfiguration.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/contentsync/SyncHostConfiguration.java
@@ -26,6 +26,7 @@ import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.InjectionStrategy;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
+import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,8 +49,20 @@ public class SyncHostConfiguration {
     @ValueMapValue
     private String password;
 
+    @ValueMapValue
+    private String authType;
+
+    @ValueMapValue
+    private String agentId;
+
+    @ValueMapValue
+    private String accessTokenProviderName;
+
     @OSGiService
     private CryptoSupport crypto;
+
+    @Self
+    private Resource resource;
 
     public String getHost() {
         return host;
@@ -68,5 +81,17 @@ public class SyncHostConfiguration {
             }
         }
         return password;
+    }
+
+    public boolean isOAuthEnabled(){
+        return "oauth".equals(authType);
+    }
+
+    public String getAccessTokenProviderName(){
+        return accessTokenProviderName;
+    }
+
+    public String getAgentUserId(){
+        return agentId == null ? resource.getResourceResolver().getUserID() : agentId;
     }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/contentsync/SyncHostConfiguration.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/contentsync/SyncHostConfiguration.java
@@ -53,9 +53,6 @@ public class SyncHostConfiguration {
     private String authType;
 
     @ValueMapValue
-    private String agentId;
-
-    @ValueMapValue
     private String accessTokenProviderName;
 
     @OSGiService
@@ -91,7 +88,4 @@ public class SyncHostConfiguration {
         return accessTokenProviderName;
     }
 
-    public String getAgentUserId(){
-        return agentId == null ? resource.getResourceResolver().getUserID() : agentId;
-    }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/contentsync/package-info.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/contentsync/package-info.java
@@ -17,5 +17,5 @@
  * limitations under the License.
  * #L%
  */
-@org.osgi.annotation.versioning.Version("6.12.0")
+@org.osgi.annotation.versioning.Version("6.13.0")
 package com.adobe.acs.commons.contentsync;

--- a/bundle/src/test/java/com/adobe/acs/commons/contentsync/TestContentSync.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/contentsync/TestContentSync.java
@@ -19,6 +19,7 @@
  */
 package com.adobe.acs.commons.contentsync;
 
+import com.adobe.granite.auth.oauth.AccessTokenProvider;
 import com.adobe.granite.crypto.CryptoSupport;
 import com.day.cq.dam.api.Asset;
 import com.day.cq.wcm.api.Page;
@@ -50,6 +51,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static com.adobe.acs.commons.contentsync.ConfigurationUtils.CONNECT_TIMEOUT_KEY;
@@ -61,9 +63,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mockConstructionWithAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -97,7 +104,7 @@ public class TestContentSync {
                 context.getService(ModelFactory.class)
                         .createModel(context.resourceResolver().getResource(configPath), SyncHostConfiguration.class);
         ContentImporter contentImporter = context.registerInjectActivateService(new DefaultContentImporter());
-        remoteInstance = spy(new RemoteInstance(hostConfiguration, generalSettings));
+        remoteInstance = spy(new RemoteInstance(hostConfiguration, generalSettings, null, context.resourceResolver()));
 
         contentSync = new ContentSync(remoteInstance, context.resourceResolver(), contentImporter);
 
@@ -426,5 +433,48 @@ public class TestContentSync {
         ValueMap vm = context.resourceResolver().getResource(path + "/jcr:content").getValueMap();
         assertEquals("FAQs", vm.get("jcr:title"));
         assertEquals(true, vm.get("jcr:isCheckedOut"));
+    }
+
+    @Test
+    public void testSetupOauthInstance() throws Exception {
+        String configPath =  HOSTS_PATH + "/oauthHost";
+
+        AccessTokenProvider accessTokenProvider = mock(AccessTokenProvider.class);
+        context.registerService(AccessTokenProvider.class, accessTokenProvider, Collections.singletonMap("name", "publish-cloud"));
+
+        Resource configResource = context.create().resource(configPath,
+                        "host", "http://localhost:4502", "authType", "oauth", "accessTokenProviderName", "publish-cloud");
+        Resource generalSettings = context.resourceResolver().getResource(SETTINGS_PATH);
+        SyncHostConfiguration hostConfiguration =
+                context.getService(ModelFactory.class).createModel(configResource, SyncHostConfiguration.class);
+
+        remoteInstance = new RemoteInstance(hostConfiguration, generalSettings.getValueMap(), context.slingScriptHelper(), context.resourceResolver());
+        verify(accessTokenProvider, atLeastOnce()).getAccessToken(eq(context.resourceResolver()), eq(context.resourceResolver().getUserID()), isNull()); // no need to call the remote instance
+    }
+
+    @Test
+    public void testErrorGettingAccessToken() throws Exception {
+        String configPath =  HOSTS_PATH + "/oauthHost";
+
+        AccessTokenProvider accessTokenProvider = mock(AccessTokenProvider.class);
+        doThrow(new RuntimeException("user key store is not initialized")).when(accessTokenProvider).getAccessToken(
+                eq(context.resourceResolver()), eq(context.resourceResolver().getUserID()), isNull());
+
+        context.registerService(AccessTokenProvider.class, accessTokenProvider, Collections.singletonMap("name", "publish-cloud"));
+
+        Resource configResource = context.create().resource(configPath,
+                "host", "http://localhost:4502", "authType", "oauth", "accessTokenProviderName", "publish-cloud");
+        Resource generalSettings = context.resourceResolver().getResource(SETTINGS_PATH);
+        SyncHostConfiguration hostConfiguration =
+                context.getService(ModelFactory.class).createModel(configResource, SyncHostConfiguration.class);
+
+        try {
+            remoteInstance = new RemoteInstance(hostConfiguration, generalSettings.getValueMap(), context.slingScriptHelper(), context.resourceResolver());
+            fail("Expected exception");
+        } catch (IllegalArgumentException e) {
+            String expectedMsg = "Failed to get an access token for user: admin user key store is not initialized. " +
+                    "Ensure that the Access Token Provider is configured correctly and the user has the necessary permissions.";
+            assertEquals(expectedMsg, e.getMessage());
+        }
     }
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/contentsync/TestSyncHostConfiguration.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/contentsync/TestSyncHostConfiguration.java
@@ -69,4 +69,15 @@ public class TestSyncHostConfiguration {
         verify(crypto, times(1)).isProtected(captor.capture());
         verify(crypto, times(1)).unprotect(captor.capture());
     }
+
+    @Test
+    public void testIsAuthEnabled() {
+        configPath = HOSTS_PATH + "/host2";
+        SyncHostConfiguration oauthConfiguration = getConfiguration("host", "http://localhost:4502", "authType", "oauth");
+        assertEquals(true, oauthConfiguration.isOAuthEnabled());
+
+        configPath = HOSTS_PATH + "/host3";
+        SyncHostConfiguration basicConfiguration = getConfiguration("host", "http://localhost:4502", "authType", "basic");
+        assertEquals(false, basicConfiguration.isOAuthEnabled());
+    }
 }

--- a/oakpal-checks/pom.xml
+++ b/oakpal-checks/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.12.1-SNAPSHOT</version>
+        <version>6.13.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>com.adobe.acs</groupId>
     <artifactId>acs-aem-commons</artifactId>
-    <version>6.12.1-SNAPSHOT</version>
+    <version>6.13.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>ACS AEM Commons - Reactor Project</name>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.12.1-SNAPSHOT</version>
+        <version>6.13.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/contentsync/POST.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/contentsync/POST.jsp
@@ -36,7 +36,8 @@
 	org.apache.sling.api.resource.ResourceUtil,
 	org.apache.commons.lang3.time.DurationFormatUtils,
     org.apache.commons.io.output.TeeWriter,
-	com.adobe.acs.commons.contentsync.*
+	com.adobe.acs.commons.contentsync.*,
+	com.adobe.acs.commons.adobeio.service.IntegrationService
 "%><%
 %>
 <html>
@@ -86,8 +87,9 @@
 	StringWriter tempWriter = new StringWriter();
     TeeWriter printWriter = new TeeWriter(Arrays.asList(new PrintWriter(out), new PrintWriter(tempWriter)));
 
+    IntegrationService integrationService = sling.getService(IntegrationService.class);
     UpdateStrategy updateStrategy = sling.getServices(UpdateStrategy.class, "(component.name=" + strategyPid + ")")[0];
-    try(RemoteInstance remoteInstance = new RemoteInstance(hostConfig, generalSettings, sling, resourceResolver)){
+    try(RemoteInstance remoteInstance = new RemoteInstance(hostConfig, generalSettings, integrationService)){
         ContentImporter importer = sling.getService(ContentImporter.class);
         ContentSync contentSync = new ContentSync(remoteInstance, resourceResolver, importer);
         ContentCatalog contentCatalog = new ContentCatalog(remoteInstance, catalogServlet);

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/contentsync/POST.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/contentsync/POST.jsp
@@ -87,7 +87,7 @@
     TeeWriter printWriter = new TeeWriter(Arrays.asList(new PrintWriter(out), new PrintWriter(tempWriter)));
 
     UpdateStrategy updateStrategy = sling.getServices(UpdateStrategy.class, "(component.name=" + strategyPid + ")")[0];
-    try(RemoteInstance remoteInstance = new RemoteInstance(hostConfig, generalSettings)){
+    try(RemoteInstance remoteInstance = new RemoteInstance(hostConfig, generalSettings, sling, resourceResolver)){
         ContentImporter importer = sling.getService(ContentImporter.class);
         ContentSync contentSync = new ContentSync(remoteInstance, resourceResolver, importer);
         ContentCatalog contentCatalog = new ContentCatalog(remoteInstance, catalogServlet);

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/contentsync/clientlibs/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/contentsync/clientlibs/.content.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
     jcr:primaryType="cq:ClientLibraryFolder"
     categories="[acs-commons.contentsync]"
     dependencies="[granite.operations-dashboard.common]"/>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/contentsync/clientlibs/css/app.css
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/contentsync/clientlibs/css/app.css
@@ -11,3 +11,27 @@
 .checkboxes-panel {
     column-width: 400px;
 }
+
+#modalConfigureHost ._coral-Dialog-content {
+    column-width: 600px;
+}
+
+.hidden {
+	display: none;
+}
+
+.createwarn {
+    margin-top: 1rem;
+    display: flex;
+    max-width: 37rem;
+}
+
+.createwarn-left {
+    flex-grow: 0;
+    margin-right: 1rem;
+}
+
+.createwarn-right {
+    flex-grow: 1;
+}
+ 

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/contentsync/clientlibs/js/app.js
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/contentsync/clientlibs/js/app.js
@@ -54,19 +54,57 @@
         }
     });
 
-    $(document).on("click", ".configureQuickAction", function(e) {
-		var form = $(this).closest("coral-masonry-item").find("coral-card");
-        var host = $(form).data("host");
-        var username = $(form).data("username");
-        var password = $(form).data("password");
-        var action = $(form).data("path");
-        var  dlg = document.querySelector('#modalConfigureHost');
-         $("#configureHost-host").val(host);
-         $("#configureHost-username").val(username);
-         $("#configureHost-password").val(password);
-         $(dlg).find("#createHostForm").attr("action", action);
-         dlg.show();
+    $(window).adaptTo("foundation-registry").register("foundation.collection.action.action", {
+        name: "acs-commons.contentsync.host.create",
+        handler: function(name, el, config, collection, selections) {
+            var dlg = document.getElementById("modalConfigureHost");
+            var form = dlg.querySelector("form");
+            form.action = "/etc/replication/agents.author/*";
+            form.reset();
+            dlg.show();
+        }
+    });
+    $(window).adaptTo("foundation-registry").register("foundation.collection.action.action", {
+        name: "acs-commons.contentsync.host.edit",
+        handler: function(name, el, config, collection, selections) {
+			var card = $(selections).find("coral-card");
+            var properties = card.data("properties");
+            var dlg = document.getElementById("modalConfigureHost");
+            var form = dlg.querySelector("form");
+            form.action = card.data("path");
+            var select = dlg.querySelector("coral-select[name=\"./authType\"]");
+			select.value = properties.authType;
+            select.trigger("change");
+            for(var i=0; i<form.elements.length;i++){
+                var e = form.elements[i];
+                var prefix = "./";
+                if(e.name.startsWith(prefix)){
+                    var key = e.name.substring(prefix.length); // remove leading './'
+                    var value = properties[key];
+                    if(value) e.value = value;
+                }
+            }
+            dlg.show();
+        }
     });
 
+	document.addEventListener("DOMContentLoaded", function() {
+        var dlg = document.getElementById("modalConfigureHost");
+    	dlg.querySelector("coral-select[name=\"./authType\"]")
+            .addEventListener("change", function(e) {
+            	var authType = e.target.value;
+            	dlg.querySelectorAll(".list-option-showhide-target").forEach(function(c){
+                    if(authType === c.dataset.showhidetargetvalue){
+                        c.classList.remove("hidden");
+                    } else {
+                        c.classList.add("hidden");
+                    }
+                });
+        	}	
+        );
+        
+    });
+    
 
+    
 })(document, Granite.$);

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/contentsync/configure/configurehostentry/configurehostentry.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/contentsync/configure/configurehostentry/configurehostentry.jsp
@@ -19,31 +19,31 @@
 %><%@page session="false" import="
         org.apache.sling.api.resource.ValueMap,
         com.adobe.granite.ui.components.Tag,
-        com.adobe.granite.ui.components.AttrBuilder" %><%
+        com.adobe.granite.ui.components.AttrBuilder,
+        com.fasterxml.jackson.databind.ObjectMapper,
+        com.fasterxml.jackson.databind.MapperFeature" %><%
 
     String contextPath = request.getContextPath();
     ValueMap valueMap = resource.adaptTo(ValueMap.class);
-	String username = valueMap.get("username", "");
-	String password = valueMap.get("password", "");
-	String url = valueMap.get("host", "");
 	String icon = "viewList";
 	String smallIcon = "search";
 	String path =  resource.getPath();
 	String href = "/apps/acs-commons/content/contentsync.html" + path;
+	String url = valueMap.get("host", "");
+
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
 
     Tag tag = cmp.consumeTag();
     AttrBuilder attrs = tag.getAttrs();
 
+    attrs.add("data-properties", mapper.writeValueAsString(valueMap));
     attrs.addClass("foundation-collection-navigator");
+    attrs.add("data-foundation-collection-navigator-href", href);
+    attrs.add("data-path", path);
     attrs.addClass("whitecard");
 %>
-<coral-card assetwidth="400" assetheight="380" <%= attrs %>
-    data-foundation-collection-navigator-href="<%= href %>"
-	data-host="<%=url%>"
-	data-username="<%=username%>"
-	data-password="<%=password%>"
-	data-path="<%=path%>"
-    colorhint="#FFFFFF">
+<coral-card assetwidth="400" assetheight="380" <%= attrs %> colorhint="#FFFFFF">
     <coral-card-asset class="whitecard">
         <coral-icon icon="<%= icon %>" class="largeIcon centerText">
         </coral-icon>
@@ -68,6 +68,4 @@
 </coral-card>
 <coral-quickactions target="_prev">
     <coral-quickactions-item icon="check" class="foundation-collection-item-activator">Select</coral-quickactions-item>
-    <coral-quickactions-item icon="gears" class="configureQuickAction"
-    data-editpath="<%=path%>">Configure</coral-quickactions-item>
 </coral-quickactions>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/contentsync/configure/warn/warn.html
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/contentsync/configure/warn/warn.html
@@ -1,0 +1,20 @@
+<!--/*
+  ADOBE CONFIDENTIAL
+  ___________________
+
+   Copyright 2021 Adobe
+   All Rights Reserved.
+
+  NOTICE:  All information contained herein is, and remains
+  the property of Adobe and its suppliers, if any. The intellectual
+  and technical concepts contained herein are proprietary to Adobe
+  and its suppliers and are protected by all applicable intellectual
+  property laws, including trade secret and copyright laws.
+  Dissemination of this information or reproduction of this material
+  is strictly forbidden unless prior written permission is obtained
+  from Adobe.
+*/-->
+<div class="createwarn">
+    <div class="createwarn-left"><coral-icon icon="alert" size="XL"></coral-icon></div>
+    <div class="createwarn-right">${properties.text @ context='html'}</div>
+</div>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/contentsync/iframe/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/contentsync/iframe/.content.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
     jcr:primaryType="sling:Folder"/>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/contentsync/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/contentsync/.content.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
     jcr:primaryType="cq:Page">
+    <history/>
     <configure/>
     <jcr:content
         jcr:primaryType="cq:PageContent"
@@ -27,12 +28,12 @@
                     text="Configure"
                     variant="primary"/>
                 <history
-                        jcr:primaryType="nt:unstructured"
-                        sling:resourceType="granite/ui/components/coral/foundation/anchorbutton"
-                        href="/apps/acs-commons/content/contentsync/history.html"
-                        icon="stopwatch"
-                        text="History"
-                        variant="primary"/>
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="granite/ui/components/coral/foundation/anchorbutton"
+                    href="/apps/acs-commons/content/contentsync/history.html"
+                    icon="stopwatch"
+                    text="History"
+                    variant="primary"/>
             </secondary>
         </actions>
         <content
@@ -114,12 +115,12 @@
                                     text="Delete resources that exist in the destination but not in the source"
                                     value="true"/>
                                 <recursive
-                                        jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                        name="recursive"
-                                        text="Recursive"
-                                        checked="{Boolean}true"
-                                        value="true"/>
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                    checked="{Boolean}true"
+                                    name="recursive"
+                                    text="Recursive"
+                                    value="true"/>
                             </items>
                         </checkboxes>
                         <submit

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/contentsync/configure/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/contentsync/configure/.content.xml
@@ -165,15 +165,10 @@
                                             sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                             fieldLabel="Access Token Provider Name"
                                             name="./accessTokenProviderName"/>
-                                        <agentId
-                                            jcr:primaryType="nt:unstructured"
-                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                            fieldLabel="Agent User ID"
-                                            name="./agentId"/>
                                         <warning
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="acs-commons/components/utilities/contentsync/configure/warn"
-                                            text="The name of the token provider must match the name property in your OAuth Access Token Provider configuration, see &quot;&#x9;Adobe Granite Access Token provider using Client Credentials/JWT Credential flow&quot; in the OSGi console&lt;p>The Agent User must have the private key from the AEMaaCS technical account installed in the user key store&lt;/p>"/>
+                                            text="The name of the token provider must match the name property in your OAuth Access Token Provider configuration, see &quot;&#x9;Adobe Granite Access Token provider using Client Credentials/JWT Credential flow&quot; in the OSGi console&lt;p>The user running sync must have the private key from the AEMaaCS technical account installed in the user key store&lt;/p>"/>
                                     </items>
                                     <granite:data
                                         jcr:primaryType="nt:unstructured"

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/contentsync/configure/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/contentsync/configure/.content.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
         jcr:primaryType="nt:unstructured"
@@ -44,73 +44,42 @@
         </views>
         <actions jcr:primaryType="nt:unstructured">
             <primary jcr:primaryType="nt:unstructured">
-                <configure
+                <general
                     granite:class="foundation-toggleable-control"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="granite/ui/components/coral/foundation/button"
-                    href="#"
                     icon="gear"
                     text="General Settings"
-                    variant="actionBar"
-                    x-cq-linkchecker="skip">
+                    variant="actionBar">
                     <granite:data
                         jcr:primaryType="nt:unstructured"
                         foundation-toggleable-control-action="show"
                         foundation-toggleable-control-target="#modalGeneralSettings"/>
-                </configure>
-                <back
-                    granite:hidden="{Boolean}true"
-                    granite:id="backButton"
-                    jcr:primaryType="nt:unstructured"
-                    sling:resourceType="granite/ui/components/coral/foundation/anchorbutton"
-                    href="/libs/granite/operations/content/healthreports/healthreportlist.html"
-                    icon="chevronLeft"
-                    variant="actionBar"/>
+                </general>
                 <add
                     granite:class="foundation-toggleable-control"
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="granite/ui/components/coral/foundation/button"
-                    href="#"
+                    sling:resourceType="granite/ui/components/coral/foundation/collection/action"
+                    action="acs-commons.contentsync.host.create"
                     icon="addCircle"
                     text="Add Host"
-                    variant="actionBar"
-                    x-cq-linkchecker="skip">
-                    <granite:data
-                        jcr:primaryType="nt:unstructured"
-                        foundation-toggleable-control-action="show"
-                        foundation-toggleable-control-target="#modalConfigureHost"/>
-                </add>
+                    variant="actionBar"/>
             </primary>
             <secondary jcr:primaryType="nt:unstructured"/>
             <selection jcr:primaryType="nt:unstructured">
                 <configure
-                    granite:hidden="{Boolean}true"
-                    granite:id="configureHealthCheckButton"
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="granite/ui/components/coral/foundation/anchorbutton"
-                    foundation-collection-action="\{&quot;target&quot;:&quot;.granite-health-reports-collection&quot;, &quot;activeSelectionCount&quot;:&quot;single&quot;}"
-                    href="/system/console/configMgr"
+                    sling:resourceType="granite/ui/components/coral/foundation/collection/action"
+                    action="acs-commons.contentsync.host.edit"
                     icon="gear"
-                    target="_blank"
                     text="Configure"
-                    variant="actionBar"
-                    x-cq-linkchecker="skip"/>
-                <view
-                    granite:hidden="{Boolean}true"
-                    granite:id="viewHealthCheckDetailsButton"
-                    jcr:primaryType="nt:unstructured"
-                    sling:resourceType="granite/ui/components/coral/foundation/anchorbutton"
-                    href="/system/console/configMgr"
-                    icon="browse"
-                    text="View"
-                    variant="actionBar"
-                    x-cq-linkchecker="skip"/>
+                    variant="actionBar"/>
                 <delete
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="granite/ui/components/coral/foundation/collection/action"
-                    action="acs-commons.dashboard.task.delete"
+                    action="acs-commons.contentsync.host.delete"
                     activeSelectionCount="single"
-                    href=""
+                    href="\0"
                     icon="delete"
                     target=".contentsync-hosts-task-collection"
                     text="Delete"
@@ -146,18 +115,70 @@
                                     sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                     emptyText="http://localhost:4502"
                                     name="./host"/>
-                                <username
-                                    granite:id="configureHost-username"
+                                <authType
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                    emptyText="username"
-                                    name="./username"/>
-                                <password
-                                    granite:id="configureHost-password"
+                                    sling:resourceType="granite/ui/components/coral/foundation/form/select"
+                                    fieldLabel="Auth Type"
+                                    name="./authType">
+                                    <items jcr:primaryType="nt:unstructured">
+                                        <basic
+                                            jcr:primaryType="nt:unstructured"
+                                            text="Basic Auth"
+                                            value="basic"/>
+                                        <oauth
+                                            jcr:primaryType="nt:unstructured"
+                                            text="OAuth 2.0"
+                                            value="oauth"/>
+                                    </items>
+                                </authType>
+                                <basic
+                                    granite:class="list-option-showhide-target"
                                     jcr:primaryType="nt:unstructured"
-                                    sling:resourceType="granite/ui/components/coral/foundation/form/password"
-                                    emptyText="password"
-                                    name="./password"/>
+                                    sling:resourceType="granite/ui/components/coral/foundation/container">
+                                    <items jcr:primaryType="nt:unstructured">
+                                        <username
+                                            granite:id="configureHost-username"
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                            emptyText="username"
+                                            fieldLabel="User"
+                                            name="./username"/>
+                                        <password
+                                            granite:id="configureHost-password"
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/password"
+                                            emptyText="password"
+                                            fieldLabel="Password"
+                                            name="./password"/>
+                                    </items>
+                                    <granite:data
+                                        jcr:primaryType="nt:unstructured"
+                                        showhidetargetvalue="basic"/>
+                                </basic>
+                                <oauth
+                                    granite:class="hidden list-option-showhide-target"
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="granite/ui/components/coral/foundation/container">
+                                    <items jcr:primaryType="nt:unstructured">
+                                        <accessTokenProviderName
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                            fieldLabel="Access Token Provider Name"
+                                            name="./accessTokenProviderName"/>
+                                        <agentId
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                            fieldLabel="Agent User ID"
+                                            name="./agentId"/>
+                                        <warning
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="acs-commons/components/utilities/contentsync/configure/warn"
+                                            text="The name of the token provider must match the name property in your OAuth Access Token Provider configuration, see &quot;&#x9;Adobe Granite Access Token provider using Client Credentials/JWT Credential flow&quot; in the OSGi console&lt;p>The Agent User must have the private key from the AEMaaCS technical account installed in the user key store&lt;/p>"/>
+                                    </items>
+                                    <granite:data
+                                        jcr:primaryType="nt:unstructured"
+                                        showhidetargetvalue="oauth"/>
+                                </oauth>
                                 <resourceType
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="granite/ui/components/coral/foundation/form/hidden"
@@ -257,12 +278,12 @@
                                             name="./connTimeout"
                                             value="5000"/>
                                         <disable-cert-check
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                                text="Disable SSL Certificate Check"
-                                                fieldDescription="If selected it will disable certificate check for the SSL connection."
-                                                name="./disableCertCheck"
-                                                value="true"/>
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                            fieldDescription="If selected it will disable certificate check for the SSL connection."
+                                            name="./disableCertCheck"
+                                            text="Disable SSL Certificate Check"
+                                            value="true"/>
                                     </items>
                                 </fieldset>
                             </items>

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/contentsync/configure/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/contentsync/configure/.content.xml
@@ -114,6 +114,7 @@
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                     emptyText="http://localhost:4502"
+                                    required="true"
                                     name="./host"/>
                                 <authType
                                     jcr:primaryType="nt:unstructured"
@@ -160,15 +161,10 @@
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="granite/ui/components/coral/foundation/container">
                                     <items jcr:primaryType="nt:unstructured">
-                                        <accessTokenProviderName
-                                            jcr:primaryType="nt:unstructured"
-                                            sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
-                                            fieldLabel="Access Token Provider Name"
-                                            name="./accessTokenProviderName"/>
                                         <warning
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="acs-commons/components/utilities/contentsync/configure/warn"
-                                            text="The name of the token provider must match the name property in your OAuth Access Token Provider configuration, see &quot;&#x9;Adobe Granite Access Token provider using Client Credentials/JWT Credential flow&quot; in the OSGi console&lt;p>The user running sync must have the private key from the AEMaaCS technical account installed in the user key store&lt;/p>"/>
+                                            text="To use OAuth you need to configure &lt;code>ACS AEM Commons - Adobe I/O Integration Configuration&lt;/code> via &lt;a href=&quot;http://localhost:4504/system/console/configMgr/com.adobe.acs.commons.adobeio.service.impl.IntegrationServiceImpl&quot;>/system/console/configMgr&lt;/a>&#xa;&lt;p>&#xa;References:&#xa;&lt;ul>&#xa;&lt;li>&lt;a href=&quot;https://adobe-consulting-services.github.io/acs-aem-commons/features/adobe-io-apis/index.html&quot;>https://adobe-consulting-services.github.io/acs-aem-commons/features/adobe-io-apis/index.html&lt;/a>&lt;/li>&#xa;&lt;li>&lt;a href=&quot;https://adobe-consulting-services.github.io/acs-aem-commons/features/contentsync/index.html&quot;>https://adobe-consulting-services.github.io/acs-aem-commons/features/contentsync/index.html&lt;/a>&lt;/li>&#xa;&lt;/ul>&#xa;&lt;/p>&#xa;"/>
                                     </items>
                                     <granite:data
                                         jcr:primaryType="nt:unstructured"

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/contentsync/history/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/content/contentsync/history/.content.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:granite="http://www.adobe.com/jcr/granite/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
         jcr:primaryType="cq:PageContent"

--- a/ui.config/pom.xml
+++ b/ui.config/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.12.1-SNAPSHOT</version>
+        <version>6.13.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>com.adobe.acs</groupId>
         <artifactId>acs-aem-commons</artifactId>
-        <version>6.12.1-SNAPSHOT</version>
+        <version>6.13.0-SNAPSHOT</version>
     </parent>
 
     <!-- ====================================================================== -->


### PR DESCRIPTION
In some AEMaaCS environments, security policies may disallow Basic Auth. In such cases, ContentSync can use an Adobe IMS Technical Account with OAuth. 

# How it works

1. Create an [AEMaaCS technical account](https://experienceleague.adobe.com/en/docs/experience-manager-learn/getting-started-with-aem-headless/authentication/service-credentials) and download the service credentials JSON from the Adobe Dev Console
2. Convert the service credentials JSON into a `com.adobe.acs.commons.adobeio.service.impl.IntegrationServiceImpl.cfg.json` OSGi configuration. This can be done via one-liner script:
 ```shell
cat cm-p12345-e9876-integration-1.json | \
jq -r '.integration | {
  "endpoint": ("https://" + .imsEndpoint + "/ims/exchange/jwt"),
  "loginEndpoint": "https://ims-na1.adobelogin.com/c/",
  "privateKey":  .privateKey,
	"clientId":  .technicalAccount.clientId, 
	"clientSecret": .technicalAccount.clientSecret,
	"amcOrgId": .org,
	"techAccountId": .id,
	"adobeLoginClaimKey": ("https://" + .imsEndpoint + "/s/ent_aem_cloud_api")
 }' >com.adobe.acs.commons.adobeio.service.impl.IntegrationServiceImpl.cfg.json
```
which will output
 
```json
{
  "endpoint": "https://ims-na1.adobelogin.com/ims/exchange/jwt",
  "loginEndpoint": "https://ims-na1.adobelogin.com/c/",
  "privateKey": "************************************",
  "clientId": "cm-p12345-e9876-integration-1",
  "clientSecret": "************************************",
  "amcOrgId": "************************************@AdobeOrg",
  "techAccountId": "************************************@techacct.adobe.com",
  "adobeLoginClaimKey": "https://ims-na1.adobelogin.com/s/ent_aem_cloud_api"
}
```
3. deploy the OSGi config and change the Auth type in the host configuration to OAuth:
<img width="673" alt="image" src="https://github.com/user-attachments/assets/b1de16a1-3087-496c-acf8-ba4bef54d050" />
4. Ensure the Technical Account User has read access to the content being sync-ed