### PR TITLE
ContentSync : improve error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 <!-- Keep this up to date! After a release, change the tag name to the latest release -->-
 
+
 ## Unreleased ([details][unreleased changes details])
+- # Content Sync: in case of an error print the exception and continue instead of aborting
+
+## 6.12.0 - 2025-04-28
 
 - #3536 Granite Include Obscures included Resource Type
 - #3537 Content Sync: preserve mix:referenceable mixin on Assets and Content Fragments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 
 ## Unreleased ([details][unreleased changes details])
-- # Content Sync: in case of an error print the exception and continue instead of aborting
+- #3601 Content Sync: in case of an error print the exception and continue instead of aborting
 
 ## 6.12.0 - 2025-04-28
 

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/contentsync/POST.jsp
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/contentsync/POST.jsp
@@ -162,29 +162,30 @@
                     println(printWriter, "\timporting data");
                     try {
                         contentSync.importData(item, sanitizedJson);
+                        if(!binaryProperties.isEmpty()){
+                            println(printWriter, "\tcopying " + binaryProperties.size() + " binary propert" + (binaryProperties.size() > 1 ? "ies" : "y"));
+                            boolean contentResource = item.hasContentResource();
+                            String basePath = path + (contentResource ? "/jcr:content" : "");
+                            List<String> propertyPaths = binaryProperties.stream().map(p -> basePath + p).collect(Collectors.toList());
+                            contentSync.copyBinaries(propertyPaths);
+                        }
+
+                        String parentPath = ResourceUtil.getParent(path);
+                        if(parentPath.startsWith(root)){
+                            sortedNodes.add(parentPath);
+                        }
+
+                        if(observationData != null){
+                            session.getWorkspace().getObservationManager().setUserData(observationData);
+                        }
+
+                        session.save();
+                        updatedResources.add(path);
                     } catch (RepositoryException e){
                         error(out, e);
                         resourceResolver.revert();
                         continue;
                     }
-                    if(!binaryProperties.isEmpty()){
-                        println(printWriter, "\tcopying " + binaryProperties.size() + " binary propert" + (binaryProperties.size() > 1 ? "ies" : "y"));
-                        boolean contentResource = item.hasContentResource();
-                        String basePath = path + (contentResource ? "/jcr:content" : "");
-                        List<String> propertyPaths = binaryProperties.stream().map(p -> basePath + p).collect(Collectors.toList());
-                        contentSync.copyBinaries(propertyPaths);
-                    }
-
-			        String parentPath = ResourceUtil.getParent(path);
-                    if(parentPath.startsWith(root)){
-                        sortedNodes.add(parentPath);
-                    }
-
-                    if(observationData != null){
-                        session.getWorkspace().getObservationManager().setUserData(observationData);
-                    }
-
-                    session.save();
 
                     // print ETA every 5 seconds
                     if(System.currentTimeMillis() - t00 > 5000L){
@@ -197,8 +198,6 @@
                         t00 = System.currentTimeMillis();
                         println(printWriter, etaMsg);
                     }
-
-                    updatedResources.add(path);
 
                     out.flush();
                 }


### PR DESCRIPTION
a follow up to https://github.com/Adobe-Consulting-Services/acs-aem-commons/discussions/3585#discussioncomment-13640634

print exception and continue instead of aborting the sync loop

