### PR TITLE
Never emit more than one Cache-Control header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 - #3650 Clarify description of com.adobe.acs.commons.redirects.filter.RedirectFilter -> Request Extensions/Request Paths with regards to no values
 
+### Fixed
+
+- #3653 RedirectFilter.additionalHeaders() may duplicate Cache-Control headers
+
 ## 6.15.0 - 2025-10-21
 
 ### Changed

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/filter/RedirectFilter.java
@@ -759,7 +759,8 @@ public class RedirectFilter extends AnnotatedStandardMBean
             ccHeader = redirectRule.getDefaultCacheControlHeader();
         }
         if(!StringUtils.isEmpty(ccHeader)){
-            response.addHeader("Cache-Control", ccHeader);
+            // overwrite any previously set header with that name
+            response.setHeader("Cache-Control", ccHeader);
         }
     }
 }


### PR DESCRIPTION
Make the rule/config specific one take precedence over the global one from additionalHeaders

This closes #3653