### PR TITLE
#3692 prevent java.lang.IllegalStateException in author logs when publishing redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ### Changed
 
+- #3692 Redirect Manager: prevent java.lang.IllegalStateException in author logs when publishing redirects
 - #3654 RedirectFilter should always emit a trace log if no entry was found
 - #3650 Clarify description of com.adobe.acs.commons.redirects.filter.RedirectFilter -> Request Extensions/Request Paths with regards to no values
 - #2524 Add dependency to enable PathField as report parameter. 

--- a/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/ReplicateRedirectMapServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/redirects/servlets/ReplicateRedirectMapServlet.java
@@ -71,6 +71,9 @@ public class ReplicateRedirectMapServlet extends SlingAllMethodsServlet {
     @Reference
     private transient PackageHelper packageHelper;
 
+    @Reference
+    private transient Packaging packaging;
+
     @Override
     protected void doPost(SlingHttpServletRequest slingRequest, SlingHttpServletResponse slingResponse)
             throws ServletException, IOException {
@@ -140,7 +143,7 @@ public class ReplicateRedirectMapServlet extends SlingAllMethodsServlet {
         log.debug("package built in {} ms", (System.currentTimeMillis() - t0));
         log.debug("package size: {} MB", String.format("%.2f", (float) jcrPackage.getSize() / (1024 * 1024)));
 
-        JcrPackageManager packageManager = PackagingService.getPackageManager(resourceResolver.adaptTo(Session.class));
+        JcrPackageManager packageManager = packaging.getPackageManager(resourceResolver.adaptTo(Session.class));
         packageManager.assemble(jcrPackage, null);
         return jcrPackage.getNode().getPath();
     }


### PR DESCRIPTION
Fixes #3692
