### PR TITLE
Get rid of pull_request_target due to security concerns

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,13 +5,9 @@ on:
   push:
     branches:
       - master
-      - acs-aem-commons-6.0.0
-  # for PRs from forked repos and non forked repos
-  # in order to write status info to the PR we require write repository token (https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/)
-  pull_request_target:
+  pull_request:
     branches:
       - master
-      - acs-aem-commons-6.0.0
     types: [opened, synchronize, reopened]
 
 # restrict privileges except for setting commit status, adding PR comments and writing statuses
@@ -47,10 +43,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        # always act on the modified source code (even for event pull_request_target)
-        # is considered potentially unsafe (https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) but actions are only executed after approval from committers
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           # no additional git operations after checkout triggered in workflow, no need to store credentials
           persist-credentials: false
 


### PR DESCRIPTION
Requires manual approval for first time contributors This closes #3698