### PR TITLE
Enforce bundle being deployed only once

### DIFF
--- a/bundle/bnd.bnd
+++ b/bundle/bnd.bnd
@@ -1,4 +1,4 @@
-Bundle-SymbolicName: com.adobe.acs.acs-aem-commons-bundle
+Bundle-SymbolicName: com.adobe.acs.acs-aem-commons-bundle;singleton:=true
 Import-Package: \
   com.adobe.cq.dialogconversion;resolution:=optional,\
   com.amazonaws.*;resolution:=optional,\


### PR DESCRIPTION
(https://docs.osgi.org/specification/osgi.core/8.0.0/framework.module.html#framework.module.bsn) Otherwise issues like described in
https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/3700 may happen.