### PR TITLE
Page Root Provider Fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## Unreleased ([details][unreleased changes details])
 
+- #3715 - Add fallback logic for Page Root detection (Shared Component Properties) on Experience Fragments, Launches, and Version History
 
 ## 6.16.0 - 2026-02-10
 

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderConfig.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderConfig.java
@@ -63,15 +63,21 @@ public class PageRootProviderConfig {
 
     @Property(
             label = "Experience Fragment Root Path Method",
-            description = "Method to determine the root path for experience fragments. If not set, the page root path method will be used. Supported values are: [ site ]",
+            description = "Method to determine the root path for experience fragments. If not set (default), the page root path method will be used. Supported values are: [ site ].",
             value = { "" })
     static final String XF_ROOT_PATH_METHOD = "xf.root.path.method";
 
     @Property(
             label = "History Viewer Fallback",
-            description = "Enable this feature to use the corresponding live path when determining the page root. Note that for values reliant on page root (e.g. Shared Component Properties) the history viewer will reflect current values rather than historical values.",
+            description = "Enable this feature to use the corresponding live path when determining the page root. Note that for values reliant on page root (e.g. Shared Component Properties) the history viewer will reflect current values rather than historical values. Default false.",
             boolValue = { false })
     static final String HISTORY_VIEWER_FALLBACK = "history.viewer.fallback";
+
+    @Property(
+            label = "Content Launch Fallback",
+            description = "Enable this feature to have a content launch use the corresponding live path when determining the page root. This is generally desirable, as values reliant on page root (e.g. Shared Component Properties) will reflect the values that will apply when this page is promoted (except in the rare case where the launch also includes the page root and that page root is also being promoted with new values). Default false.",
+            boolValue = { false })
+    static final String LAUNCH_FALLBACK = "launch.fallback";
 
     private static final Logger log = LoggerFactory.getLogger(PageRootProviderConfig.class);
 
@@ -80,6 +86,7 @@ public class PageRootProviderConfig {
     private String xfRootPathMethod = null;
 
     private boolean historyViewerFallback = false;
+    private boolean launchFallback = false;
 
     /**
      * Retrieves the configured patterns.
@@ -110,6 +117,15 @@ public class PageRootProviderConfig {
         return this.historyViewerFallback;
     }
 
+    /**
+     * Get launch fallback setting
+     *
+     * @return true if launches should get root from current/live site paths
+     */
+    public boolean getLaunchFallback() {
+        return this.launchFallback;
+    }
+
     @Activate
     protected void activate(Map<String, Object> props) {
         List<Pattern> patterns = new ArrayList<Pattern>();
@@ -128,6 +144,7 @@ public class PageRootProviderConfig {
         this.pageRootPatterns = Collections.unmodifiableList(patterns);
         this.xfRootPathMethod = (String) props.get(XF_ROOT_PATH_METHOD);
         this.historyViewerFallback = PropertiesUtil.toBoolean(props.get(HISTORY_VIEWER_FALLBACK), false);
+        this.launchFallback = PropertiesUtil.toBoolean(props.get(LAUNCH_FALLBACK), false);
     }
 
     @Deactivate

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderConfig.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderConfig.java
@@ -61,9 +61,17 @@ public class PageRootProviderConfig {
     /* Page root property. */
     static final String PAGE_ROOT_PATH = "page.root.path";
 
+    @Property(
+            label = "Experience Fragment Root Path Method",
+            description = "Method to determine the root path for experience fragments. If not set, the page root path method will be used. Supported values are: [ site ]",
+            value = { "" })
+    static final String XF_ROOT_PATH_METHOD = "xf.root.path.method";
+
     private static final Logger log = LoggerFactory.getLogger(PageRootProviderConfig.class);
 
     private List<Pattern> pageRootPatterns = null;
+
+    private String xfRootPathMethod = null;
 
     /**
      * Retrieves the configured patterns.
@@ -74,6 +82,15 @@ public class PageRootProviderConfig {
         return Optional.ofNullable(this.pageRootPatterns)
                 .map(Collections::unmodifiableList)
                 .orElse(null);
+    }
+
+    /**
+     * Get XF root path method
+     *
+     * @return XF root path method
+     */
+    public String getXfRootPathMethod() {
+        return this.xfRootPathMethod;
     }
 
     @Activate
@@ -92,6 +109,7 @@ public class PageRootProviderConfig {
         }
 
         this.pageRootPatterns = Collections.unmodifiableList(patterns);
+        this.xfRootPathMethod = (String) props.get(XF_ROOT_PATH_METHOD);
     }
 
     @Deactivate

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderConfig.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderConfig.java
@@ -67,11 +67,19 @@ public class PageRootProviderConfig {
             value = { "" })
     static final String XF_ROOT_PATH_METHOD = "xf.root.path.method";
 
+    @Property(
+            label = "History Viewer Fallback",
+            description = "Enable this feature to use the corresponding live path when determining the page root. Note that for values reliant on page root (e.g. Shared Component Properties) the history viewer will reflect current values rather than historical values.",
+            boolValue = { false })
+    static final String HISTORY_VIEWER_FALLBACK = "history.viewer.fallback";
+
     private static final Logger log = LoggerFactory.getLogger(PageRootProviderConfig.class);
 
     private List<Pattern> pageRootPatterns = null;
 
     private String xfRootPathMethod = null;
+
+    private boolean historyViewerFallback = false;
 
     /**
      * Retrieves the configured patterns.
@@ -93,6 +101,15 @@ public class PageRootProviderConfig {
         return this.xfRootPathMethod;
     }
 
+    /**
+     * Get history viewer fallback setting
+     *
+     * @return true if history viewer should get root from current/live site/XF paths
+     */
+    public boolean getHistoryViewerFallback() {
+        return this.historyViewerFallback;
+    }
+
     @Activate
     protected void activate(Map<String, Object> props) {
         List<Pattern> patterns = new ArrayList<Pattern>();
@@ -110,6 +127,7 @@ public class PageRootProviderConfig {
 
         this.pageRootPatterns = Collections.unmodifiableList(patterns);
         this.xfRootPathMethod = (String) props.get(XF_ROOT_PATH_METHOD);
+        this.historyViewerFallback = PropertiesUtil.toBoolean(props.get(HISTORY_VIEWER_FALLBACK), false);
     }
 
     @Deactivate

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderConfig.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderConfig.java
@@ -20,71 +20,39 @@ package com.adobe.acs.commons.wcm.impl;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-import org.apache.felix.scr.annotations.Activate;
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.ConfigurationPolicy;
-import org.apache.felix.scr.annotations.Deactivate;
-import org.apache.felix.scr.annotations.Property;
-import org.apache.felix.scr.annotations.Service;
-import org.apache.sling.commons.osgi.PropertiesUtil;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.Designate;
+import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Component(
-        label = "ACS AEM Commons - Page Root Provider Configuration",
-        description = "Configuration instance for Page Root Provider, a service to fetch the site root page for a given resource.",
-        policy = ConfigurationPolicy.REQUIRE,
-        metatype = true,
-        configurationFactory = true
-)
-@Service(PageRootProviderConfig.class)
 /**
  * Configuration instance for Page Root Provider.
- * Use service.ranking to guarantee priority between conflicting configurations.
+ * Use `service.ranking` to guarantee priority between conflicting configurations.
  *
  * @see PageRootProviderMultiImpl
  */
+@Component(
+        service = PageRootProviderConfig.class,
+        configurationPolicy = ConfigurationPolicy.REQUIRE
+)
+@Designate(ocd = PageRootProviderConfig.Config.class, factory = true)
 public class PageRootProviderConfig {
 
     /* Default root. */
     static final String DEFAULT_PAGE_ROOT_PATH = "/content";
 
-    @Property(
-            label = "Root page path pattern",
-            description = "Regex(es) used to select the root page root path. Regex must contain at least one group (with index 1) which is used as page root. It is matched against the given path. Evaluates list top-down; first match wins. Defaults to [ " + DEFAULT_PAGE_ROOT_PATH + " ]",
-            cardinality = Integer.MAX_VALUE,
-            value = { DEFAULT_PAGE_ROOT_PATH })
-    /* Page root property. */
-    static final String PAGE_ROOT_PATH = "page.root.path";
-
-    @Property(
-            label = "Experience Fragment Root Path Method",
-            description = "Method to determine the root path for experience fragments. If not set (default), the page root path method will be used. Supported values are: [ site ].",
-            value = { "" })
-    static final String XF_ROOT_PATH_METHOD = "xf.root.path.method";
-
-    @Property(
-            label = "History Viewer Fallback",
-            description = "Enable this feature to use the corresponding live path when determining the page root. Note that for values reliant on page root (e.g. Shared Component Properties) the history viewer will reflect current values rather than historical values. Default false.",
-            boolValue = { false })
-    static final String HISTORY_VIEWER_FALLBACK = "history.viewer.fallback";
-
-    @Property(
-            label = "Content Launch Fallback",
-            description = "Enable this feature to have a content launch use the corresponding live path when determining the page root. This is generally desirable, as values reliant on page root (e.g. Shared Component Properties) will reflect the values that will apply when this page is promoted (except in the rare case where the launch also includes the page root and that page root is also being promoted with new values). Default false.",
-            boolValue = { false })
-    static final String LAUNCH_FALLBACK = "launch.fallback";
-
     private static final Logger log = LoggerFactory.getLogger(PageRootProviderConfig.class);
 
     private List<Pattern> pageRootPatterns = null;
-
     private String xfRootPathMethod = null;
-
     private boolean historyViewerFallback = false;
     private boolean launchFallback = false;
 
@@ -127,9 +95,9 @@ public class PageRootProviderConfig {
     }
 
     @Activate
-    protected void activate(Map<String, Object> props) {
-        List<Pattern> patterns = new ArrayList<Pattern>();
-        String[] regexes = PropertiesUtil.toStringArray(props.get(PAGE_ROOT_PATH), new String[] { DEFAULT_PAGE_ROOT_PATH });
+    protected void activate(Config config) {
+        List<Pattern> patterns = new ArrayList<>();
+        String[] regexes = config.page_root_path();
 
         for(String regex : regexes) {
             try {
@@ -142,9 +110,9 @@ public class PageRootProviderConfig {
         }
 
         this.pageRootPatterns = Collections.unmodifiableList(patterns);
-        this.xfRootPathMethod = (String) props.get(XF_ROOT_PATH_METHOD);
-        this.historyViewerFallback = PropertiesUtil.toBoolean(props.get(HISTORY_VIEWER_FALLBACK), false);
-        this.launchFallback = PropertiesUtil.toBoolean(props.get(LAUNCH_FALLBACK), false);
+        this.xfRootPathMethod = config.xf_root_path_method();
+        this.historyViewerFallback = config.history_viewer_fallback();
+        this.launchFallback = config.launch_fallback();
     }
 
     @Deactivate
@@ -158,4 +126,36 @@ public class PageRootProviderConfig {
         }
     }
 
+    @ObjectClassDefinition(
+            name = "ACS AEM Commons - Page Root Provider Configuration",
+            description = "Configuration instance for Page Root Provider, a service to fetch the site root page for a given resource."
+    )
+    protected @interface Config {
+        @AttributeDefinition(
+                name = "Root page path pattern",
+                description = "Regex(es) used to select the root page root path. Regex must contain at least one group (with index 1) which is used as page root. It is matched against the given path. Evaluates list top-down; first match wins. Defaults to [ " + DEFAULT_PAGE_ROOT_PATH + " ]"
+        )
+        String[] page_root_path() default { DEFAULT_PAGE_ROOT_PATH };
+
+        @AttributeDefinition(
+                name = "Experience Fragment Root Path Method",
+                description = "Method to determine the root path for experience fragments. If not set (default), the page root path method will be used. Supported values are: [ site ]."
+        )
+        String xf_root_path_method() default "";
+
+        @AttributeDefinition(
+                name = "History Viewer Fallback",
+                description = "Enable this feature to use the corresponding live path when determining the page root. Note that for values reliant on page root (e.g. Shared Component Properties) the history viewer will reflect current values rather than historical values. Default false."
+        )
+        boolean history_viewer_fallback() default false;
+
+        @AttributeDefinition(
+                name = "Content Launch Fallback",
+                description = "Enable this feature to have a content launch use the corresponding live path when determining the page root. This is generally desirable, as values reliant on page root (e.g. Shared Component Properties) will reflect the values that will apply when this page is promoted (except in the rare case where the launch also includes the page root and that page root is also being promoted with new values). Default false."
+        )
+        boolean launch_fallback() default false;
+
+        @AttributeDefinition
+        String webconsole_configurationFactory_nameHint() default "Page Root Provider - Patterns: [ {page.root.path} ]";
+    }
 }

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderMultiImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderMultiImpl.java
@@ -21,9 +21,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.felix.scr.annotations.Activate;
 import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Deactivate;
 import org.apache.felix.scr.annotations.Reference;
 import org.apache.felix.scr.annotations.ReferenceCardinality;
 import org.apache.felix.scr.annotations.ReferencePolicy;
@@ -48,7 +46,8 @@ import com.day.cq.wcm.api.PageManager;
  */
 public class PageRootProviderMultiImpl implements PageRootProvider {
 
-    private static final Logger log = LoggerFactory.getLogger(PageRootProviderMultiImpl.class);
+    private static final String XF_CONTENT_PREFIX = "/content/experience-fragments/";
+    private static final Logger LOG = LoggerFactory.getLogger(PageRootProviderMultiImpl.class);
 
     @Reference(name = "config", referenceInterface = PageRootProviderConfig.class, cardinality = ReferenceCardinality.MANDATORY_MULTIPLE, policy = ReferencePolicy.DYNAMIC)
     private RankedServices<PageRootProviderConfig> configList = new RankedServices<>(Order.ASCENDING);
@@ -62,9 +61,9 @@ public class PageRootProviderMultiImpl implements PageRootProvider {
             Page rootPage = pageManager.getPage(pagePath);
 
             if (rootPage == null) {
-                log.debug("Page Root not found at [ {} ]", pagePath);
+                LOG.debug("Page Root not found at [ {} ]", pagePath);
             } else if (!rootPage.isValid()) {
-                log.debug("Page Root invalid at [ {} ]", pagePath);
+                LOG.debug("Page Root invalid at [ {} ]", pagePath);
             } else {
                 return rootPage;
             }
@@ -76,18 +75,27 @@ public class PageRootProviderMultiImpl implements PageRootProvider {
     @Override
     public String getRootPagePath(String resourcePath) {
         for (PageRootProviderConfig config : this.configList) {
+            String pathToSearch = resourcePath;
+
+            // If XF should find use the corresponding site as the root...
+            if ("site".equals(config.getXfRootPathMethod())) {
+                if (resourcePath.startsWith(XF_CONTENT_PREFIX)) {
+                    pathToSearch = "/content/" + resourcePath.substring(XF_CONTENT_PREFIX.length());
+                }
+            }
+
             for (Pattern pattern : config.getPageRootPatterns()) {
-                final Matcher matcher = pattern.matcher(resourcePath);
+                final Matcher matcher = pattern.matcher(pathToSearch);
 
                 if (matcher.find()) {
                     String rootPath = matcher.group(1);
-                    log.debug("Page Root found at [ {} ]", rootPath);
+                    LOG.debug("Page Root found at [ {} ]", rootPath);
                     return rootPath;
                 }
             }
         }
 
-        log.debug("Resource path does not include the configured page root path.");
+        LOG.debug("Resource path does not include the configured page root path.");
         return null;
     }
 

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderMultiImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderMultiImpl.java
@@ -21,11 +21,10 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.felix.scr.annotations.Component;
-import org.apache.felix.scr.annotations.Reference;
-import org.apache.felix.scr.annotations.ReferenceCardinality;
-import org.apache.felix.scr.annotations.ReferencePolicy;
-import org.apache.felix.scr.annotations.Service;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.commons.osgi.Order;
 import org.apache.sling.commons.osgi.RankedServices;
@@ -36,14 +35,13 @@ import com.adobe.acs.commons.wcm.PageRootProvider;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.api.PageManager;
 
-@Component(metatype=false)
-@Service(PageRootProvider.class)
 /**
  * Service to fetch the site root page (i.e. home page) for a given resource.
  * Supports multiple (independent) configurations.
  *
  * @see PageRootProviderConfig
  */
+@Component(service = PageRootProvider.class)
 public class PageRootProviderMultiImpl implements PageRootProvider {
 
     private static final Pattern VERSION_HISTORY_PATTERN = Pattern.compile("/tmp/versionhistory/[0-9a-f]+/[0-9a-f-]+/(.*)");
@@ -51,8 +49,7 @@ public class PageRootProviderMultiImpl implements PageRootProvider {
     private static final Pattern LAUNCH_PATH_PATTERN = Pattern.compile("/content/launches/.*?/content/(.*)");
     private static final Logger LOG = LoggerFactory.getLogger(PageRootProviderMultiImpl.class);
 
-    @Reference(name = "config", referenceInterface = PageRootProviderConfig.class, cardinality = ReferenceCardinality.MANDATORY_MULTIPLE, policy = ReferencePolicy.DYNAMIC)
-    private RankedServices<PageRootProviderConfig> configList = new RankedServices<>(Order.ASCENDING);
+    private final RankedServices<PageRootProviderConfig> configList = new RankedServices<>(Order.ASCENDING);
 
     @Override
     public Page getRootPage(Resource resource) {
@@ -109,6 +106,7 @@ public class PageRootProviderMultiImpl implements PageRootProvider {
         return null;
     }
 
+    @Reference(name = "config", service = PageRootProviderConfig.class, cardinality = ReferenceCardinality.AT_LEAST_ONE, policy = ReferencePolicy.DYNAMIC)
     protected void bindConfig(final PageRootProviderConfig config, Map<String, Object> props) {
         this.configList.bind(config, props);
     }

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderMultiImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderMultiImpl.java
@@ -46,7 +46,8 @@ import com.day.cq.wcm.api.PageManager;
  */
 public class PageRootProviderMultiImpl implements PageRootProvider {
 
-    private static final String XF_CONTENT_PREFIX = "/content/experience-fragments/";
+    private static final Pattern VERSION_HISTORY_PATTERN = Pattern.compile("/tmp/versionhistory/[0-9a-f]+/[0-9a-f-]+/(.*)");
+    private static final Pattern XF_PATH_PATTERN = Pattern.compile("/content/experience-fragments/(.*)");
     private static final Logger LOG = LoggerFactory.getLogger(PageRootProviderMultiImpl.class);
 
     @Reference(name = "config", referenceInterface = PageRootProviderConfig.class, cardinality = ReferenceCardinality.MANDATORY_MULTIPLE, policy = ReferencePolicy.DYNAMIC)
@@ -77,11 +78,14 @@ public class PageRootProviderMultiImpl implements PageRootProvider {
         for (PageRootProviderConfig config : this.configList) {
             String pathToSearch = resourcePath;
 
-            // If XF should find use the corresponding site as the root...
+            // If page/XF history viewer should use the corresponding live content tree to determine the root...
+            if (config.getHistoryViewerFallback()) {
+                pathToSearch = VERSION_HISTORY_PATTERN.matcher(pathToSearch).replaceFirst("/content/$1");
+            }
+
+            // If XF should use the corresponding site content tree to determine the root...
             if ("site".equals(config.getXfRootPathMethod())) {
-                if (resourcePath.startsWith(XF_CONTENT_PREFIX)) {
-                    pathToSearch = "/content/" + resourcePath.substring(XF_CONTENT_PREFIX.length());
-                }
+                pathToSearch = XF_PATH_PATTERN.matcher(pathToSearch).replaceFirst("/content/$1");
             }
 
             for (Pattern pattern : config.getPageRootPatterns()) {

--- a/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderMultiImpl.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/wcm/impl/PageRootProviderMultiImpl.java
@@ -48,6 +48,7 @@ public class PageRootProviderMultiImpl implements PageRootProvider {
 
     private static final Pattern VERSION_HISTORY_PATTERN = Pattern.compile("/tmp/versionhistory/[0-9a-f]+/[0-9a-f-]+/(.*)");
     private static final Pattern XF_PATH_PATTERN = Pattern.compile("/content/experience-fragments/(.*)");
+    private static final Pattern LAUNCH_PATH_PATTERN = Pattern.compile("/content/launches/.*?/content/(.*)");
     private static final Logger LOG = LoggerFactory.getLogger(PageRootProviderMultiImpl.class);
 
     @Reference(name = "config", referenceInterface = PageRootProviderConfig.class, cardinality = ReferenceCardinality.MANDATORY_MULTIPLE, policy = ReferencePolicy.DYNAMIC)
@@ -81,6 +82,11 @@ public class PageRootProviderMultiImpl implements PageRootProvider {
             // If page/XF history viewer should use the corresponding live content tree to determine the root...
             if (config.getHistoryViewerFallback()) {
                 pathToSearch = VERSION_HISTORY_PATTERN.matcher(pathToSearch).replaceFirst("/content/$1");
+            }
+
+            // If launch content should use the corresponding live content tree to determine the root...
+            if (config.getLaunchFallback()) {
+                pathToSearch = LAUNCH_PATH_PATTERN.matcher(pathToSearch).replaceFirst("/content/$1");
             }
 
             // If XF should use the corresponding site content tree to determine the root...

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderConfigTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderConfigTest.java
@@ -130,8 +130,24 @@ public class PageRootProviderConfigTest {
         assertTrue(config.getHistoryViewerFallback());
     }
 
+    @Test
+    public void getLaunchFallback_Null() {
+        properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content"});
+        config.activate(properties);
+
+        assertFalse(config.getLaunchFallback());
+    }
+
+    @Test
+    public void getLaunchFallback_True() {
+        properties.put(PageRootProviderConfig.LAUNCH_FALLBACK, "true");
+        config.activate(properties);
+
+        assertTrue(config.getLaunchFallback());
+    }
+
     static List<String> toStringList(final List<Pattern> patterns) {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
 
         for (Pattern p : patterns) {
                 list.add(p.toString());

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderConfigTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderConfigTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 public class PageRootProviderConfigTest {
     PageRootProviderConfig config = null;
 
-    Map<String, Object> properties = new HashMap<String, Object>();
+    Map<String, Object> properties = new HashMap<>();
 
     @Before
     public final void setUp() throws Exception {
@@ -42,7 +42,7 @@ public class PageRootProviderConfigTest {
     }
 
     @Test
-    public void getPageRootPatterns() throws Exception {
+    public void getPageRootPatterns() {
         properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content"});
         config.activate(properties);
 
@@ -50,7 +50,7 @@ public class PageRootProviderConfigTest {
     }
 
     @Test
-    public void getPageRootPatterns_Regex() throws Exception {
+    public void getPageRootPatterns_Regex() {
         properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content/site/([a-z_-]+)"});
         config.activate(properties);
 
@@ -58,7 +58,7 @@ public class PageRootProviderConfigTest {
     }
 
     @Test
-    public void getPageRootPatterns_RegexEnd() throws Exception {
+    public void getPageRootPatterns_RegexEnd() {
         properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content/site/[a-z]{2}"});
         config.activate(properties);
 
@@ -66,7 +66,7 @@ public class PageRootProviderConfigTest {
     }
 
     @Test
-    public void getPageRootPatterns_Order1() throws Exception {
+    public void getPageRootPatterns_Order1() {
         properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content", "/content/a"});
         config.activate(properties);
 
@@ -74,7 +74,7 @@ public class PageRootProviderConfigTest {
     }
 
     @Test
-    public void getPageRootPatterns_Order2() throws Exception {
+    public void getPageRootPatterns_Order2() {
         properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content/a", "/content"});
         config.activate(properties);
 
@@ -83,7 +83,7 @@ public class PageRootProviderConfigTest {
 
 
     @Test
-    public void getPageRootPatterns_Deactivate() throws Exception {
+    public void getPageRootPatterns_Deactivate() {
         assertNull(config.getPageRootPatterns());
 
         properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content/a", "/content"});
@@ -95,6 +95,22 @@ public class PageRootProviderConfigTest {
         assertNull(config.getPageRootPatterns());
     }
 
+    @Test
+    public void getXFRootPathMethod_Null() {
+        properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content"});
+        config.activate(properties);
+
+        assertNull(config.getXfRootPathMethod());
+    }
+
+    @Test
+    public void getXFRootPathMethod_Site() {
+        properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content"});
+        properties.put(PageRootProviderConfig.XF_ROOT_PATH_METHOD, "site");
+        config.activate(properties);
+
+        assertEquals("site",  config.getXfRootPathMethod());
+    }
 
     static List<String> toStringList(final List<Pattern> patterns) {
         List<String> list = new ArrayList<String>();

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderConfigTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderConfigTest.java
@@ -18,7 +18,9 @@
 package com.adobe.acs.commons.wcm.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -110,6 +112,22 @@ public class PageRootProviderConfigTest {
         config.activate(properties);
 
         assertEquals("site",  config.getXfRootPathMethod());
+    }
+
+    @Test
+    public void getHistoryViewerFallback_Null() {
+        properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content"});
+        config.activate(properties);
+
+        assertFalse(config.getHistoryViewerFallback());
+    }
+
+    @Test
+    public void getHistoryViewerFallback_True() {
+        properties.put(PageRootProviderConfig.HISTORY_VIEWER_FALLBACK, "true");
+        config.activate(properties);
+
+        assertTrue(config.getHistoryViewerFallback());
     }
 
     static List<String> toStringList(final List<Pattern> patterns) {

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderConfigTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderConfigTest.java
@@ -21,12 +21,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Pattern;
 
 import org.junit.Before;
@@ -36,8 +36,6 @@ import org.junit.Test;
 public class PageRootProviderConfigTest {
     PageRootProviderConfig config = null;
 
-    Map<String, Object> properties = new HashMap<>();
-
     @Before
     public final void setUp() throws Exception {
         config = new PageRootProviderConfig();
@@ -45,40 +43,40 @@ public class PageRootProviderConfigTest {
 
     @Test
     public void getPageRootPatterns() {
-        properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content"});
-        config.activate(properties);
+        PageRootProviderConfig.Config cfg = mockConfig(new String[]{"/content"}, "", false, false);
+        config.activate(cfg);
 
         assertEquals(Arrays.asList("^(/content)(|/.*)$"), toStringList(config.getPageRootPatterns()));
     }
 
     @Test
     public void getPageRootPatterns_Regex() {
-        properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content/site/([a-z_-]+)"});
-        config.activate(properties);
+        PageRootProviderConfig.Config cfg = mockConfig(new String[]{"/content/site/([a-z_-]+)"}, "", false, false);
+        config.activate(cfg);
 
         assertEquals(Arrays.asList("^(/content/site/([a-z_-]+))(|/.*)$"), toStringList(config.getPageRootPatterns()));
     }
 
     @Test
     public void getPageRootPatterns_RegexEnd() {
-        properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content/site/[a-z]{2}"});
-        config.activate(properties);
+        PageRootProviderConfig.Config cfg = mockConfig(new String[]{"/content/site/[a-z]{2}"}, "", false, false);
+        config.activate(cfg);
 
         assertEquals(Arrays.asList("^(/content/site/[a-z]{2})(|/.*)$"), toStringList(config.getPageRootPatterns()));
     }
 
     @Test
     public void getPageRootPatterns_Order1() {
-        properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content", "/content/a"});
-        config.activate(properties);
+        PageRootProviderConfig.Config cfg = mockConfig(new String[]{"/content", "/content/a"}, "", false, false);
+        config.activate(cfg);
 
         assertEquals(Arrays.asList("^(/content)(|/.*)$", "^(/content/a)(|/.*)$"), toStringList(config.getPageRootPatterns()));
     }
 
     @Test
     public void getPageRootPatterns_Order2() {
-        properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content/a", "/content"});
-        config.activate(properties);
+        PageRootProviderConfig.Config cfg = mockConfig(new String[]{"/content/a", "/content"}, "", false, false);
+        config.activate(cfg);
 
         assertEquals(Arrays.asList("^(/content/a)(|/.*)$", "^(/content)(|/.*)$"), toStringList(config.getPageRootPatterns()));
     }
@@ -88,8 +86,8 @@ public class PageRootProviderConfigTest {
     public void getPageRootPatterns_Deactivate() {
         assertNull(config.getPageRootPatterns());
 
-        properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content/a", "/content"});
-        config.activate(properties);
+        PageRootProviderConfig.Config cfg = mockConfig(new String[]{"/content/a", "/content"}, "", false, false);
+        config.activate(cfg);
 
         assertEquals(Arrays.asList("^(/content/a)(|/.*)$", "^(/content)(|/.*)$"), toStringList(config.getPageRootPatterns()));
 
@@ -98,52 +96,60 @@ public class PageRootProviderConfigTest {
     }
 
     @Test
-    public void getXFRootPathMethod_Null() {
-        properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content"});
-        config.activate(properties);
+    public void getXFRootPathMethod_Empty() {
+        PageRootProviderConfig.Config cfg = mockConfig(new String[]{"/content"}, "", false, false);
+        config.activate(cfg);
 
-        assertNull(config.getXfRootPathMethod());
+        assertEquals("", config.getXfRootPathMethod());
     }
 
     @Test
     public void getXFRootPathMethod_Site() {
-        properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content"});
-        properties.put(PageRootProviderConfig.XF_ROOT_PATH_METHOD, "site");
-        config.activate(properties);
+        PageRootProviderConfig.Config cfg = mockConfig(new String[]{"/content"}, "site", false, false);
+        config.activate(cfg);
 
         assertEquals("site",  config.getXfRootPathMethod());
     }
 
     @Test
-    public void getHistoryViewerFallback_Null() {
-        properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content"});
-        config.activate(properties);
+    public void getHistoryViewerFallback_False() {
+        PageRootProviderConfig.Config cfg = mockConfig(new String[]{"/content"}, "", false, false);
+        config.activate(cfg);
 
         assertFalse(config.getHistoryViewerFallback());
     }
 
     @Test
     public void getHistoryViewerFallback_True() {
-        properties.put(PageRootProviderConfig.HISTORY_VIEWER_FALLBACK, "true");
-        config.activate(properties);
+        PageRootProviderConfig.Config cfg = mockConfig(new String[]{}, "", true, false);
+        config.activate(cfg);
 
         assertTrue(config.getHistoryViewerFallback());
     }
 
     @Test
-    public void getLaunchFallback_Null() {
-        properties.put(PageRootProviderConfig.PAGE_ROOT_PATH, new String[]{"/content"});
-        config.activate(properties);
+    public void getLaunchFallback_False() {
+        PageRootProviderConfig.Config cfg = mockConfig(new String[]{"/content"}, "", false, false);
+        config.activate(cfg);
 
         assertFalse(config.getLaunchFallback());
     }
 
     @Test
     public void getLaunchFallback_True() {
-        properties.put(PageRootProviderConfig.LAUNCH_FALLBACK, "true");
-        config.activate(properties);
+        PageRootProviderConfig.Config cfg = mockConfig(new String[]{}, "", false, true);
+        config.activate(cfg);
 
         assertTrue(config.getLaunchFallback());
+    }
+
+    private PageRootProviderConfig.Config mockConfig(String[] pageRootPaths, String xfRootPathMethod, boolean historyViewerFallback, boolean launchFallback) {
+        PageRootProviderConfig.Config cfg = mock(PageRootProviderConfig.Config.class);
+        when(cfg.page_root_path()).thenReturn(pageRootPaths);
+        when(cfg.xf_root_path_method()).thenReturn(xfRootPathMethod != null ? xfRootPathMethod : "");
+        when(cfg.history_viewer_fallback()).thenReturn(historyViewerFallback);
+        when(cfg.launch_fallback()).thenReturn(launchFallback);
+        return cfg;
     }
 
     static List<String> toStringList(final List<Pattern> patterns) {

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderMultiImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderMultiImplTest.java
@@ -163,6 +163,16 @@ public class PageRootProviderMultiImplTest {
 
     @Test
     public void getRootPagePath_HistoryViewerFallback_True() {
+        when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content/a"), buildPattern("/content/experience-fragments/a")));
+        when(config1.getHistoryViewerFallback()).thenReturn(true);
+        provider.bindConfig(config1, FIRST);
+
+        assertEquals("/content/experience-fragments/a", provider.getRootPagePath("/tmp/versionhistory/5dcec28ce5482dac2f0daa7f045f65b4c49391535a805c6a778761b78b5e2155/3d930917-6bcb-42e6-8b90-5d6c09e83fcf/experience-fragments/a/b/c"));
+        assertEquals("/content/a", provider.getRootPagePath("/tmp/versionhistory/5dcec28ce5482dac2f0daa7f045f65b4c49391535a805c6a778761b78b5e2155/3d930917-6bcb-42e6-8b90-5d6c09e83fcf/a/b/c"));
+    }
+
+    @Test
+    public void getRootPagePath_HistoryViewerFallback_True_XFMethodSite() {
         when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content/a")));
         when(config1.getXfRootPathMethod()).thenReturn("site");
         when(config1.getHistoryViewerFallback()).thenReturn(true);

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderMultiImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderMultiImplTest.java
@@ -153,7 +153,7 @@ public class PageRootProviderMultiImplTest {
 
     @Test
     public void getRootPagePath_HistoryViewerFallback_False() {
-        when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content/a")));
+        when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content/a"), buildPattern("/content/experience-fragments/a")));
         when(config1.getHistoryViewerFallback()).thenReturn(false);
         provider.bindConfig(config1, FIRST);
 
@@ -182,6 +182,36 @@ public class PageRootProviderMultiImplTest {
         assertEquals("/content/a", provider.getRootPagePath("/tmp/versionhistory/5dcec28ce5482dac2f0daa7f045f65b4c49391535a805c6a778761b78b5e2155/3d930917-6bcb-42e6-8b90-5d6c09e83fcf/a/b/c"));
     }
 
+    @Test
+    public void getRootPagePath_LaunchFallback_False() {
+        when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content/a"), buildPattern("/content/experience-fragments/a")));
+        when(config1.getLaunchFallback()).thenReturn(false);
+        provider.bindConfig(config1, FIRST);
+
+        assertNull(provider.getRootPagePath("/content/launches/2026/03/05/translation_reviewspanish10/content/experience-fragments/a/b/c"));
+        assertNull(provider.getRootPagePath("/content/launches/2026/03/05/translation_reviewspanish10/content/a/b/c"));
+    }
+
+    @Test
+    public void getRootPagePath_LaunchFallback_True() {
+        when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content/a"), buildPattern("/content/experience-fragments/a")));
+        when(config1.getLaunchFallback()).thenReturn(true);
+        provider.bindConfig(config1, FIRST);
+
+        assertEquals("/content/experience-fragments/a", provider.getRootPagePath("/content/launches/2026/03/05/translation_reviewspanish10/content/experience-fragments/a/b/c"));
+        assertEquals("/content/a", provider.getRootPagePath("/content/launches/2026/03/05/translation_reviewspanish10/content/a/b/c"));
+    }
+
+    @Test
+    public void getRootPagePath_LaunchFallback_True_XFMethodSite() {
+        when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content/a")));
+        when(config1.getXfRootPathMethod()).thenReturn("site");
+        when(config1.getLaunchFallback()).thenReturn(true);
+        provider.bindConfig(config1, FIRST);
+
+        assertEquals("/content/a", provider.getRootPagePath("/content/launches/2026/03/05/translation_reviewspanish10/content/experience-fragments/a/b/c"));
+        assertEquals("/content/a", provider.getRootPagePath("/content/launches/2026/03/05/translation_reviewspanish10/content/a/b/c"));
+    }
 
     @Test
     public void getRootPagePath_Unbind() {

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderMultiImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderMultiImplTest.java
@@ -151,6 +151,27 @@ public class PageRootProviderMultiImplTest {
         assertNull(provider.getRootPagePath("/content/experience-fragments/othersite/en_us/products/product-x/jcr:content/my-component"));
     }
 
+    @Test
+    public void getRootPagePath_HistoryViewerFallback_False() {
+        when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content/a")));
+        when(config1.getHistoryViewerFallback()).thenReturn(false);
+        provider.bindConfig(config1, FIRST);
+
+        assertNull(provider.getRootPagePath("/tmp/versionhistory/5dcec28ce5482dac2f0daa7f045f65b4c49391535a805c6a778761b78b5e2155/3d930917-6bcb-42e6-8b90-5d6c09e83fcf/experience-fragments/a/b/c"));
+        assertNull(provider.getRootPagePath("/tmp/versionhistory/5dcec28ce5482dac2f0daa7f045f65b4c49391535a805c6a778761b78b5e2155/3d930917-6bcb-42e6-8b90-5d6c09e83fcf/a/b/c"));
+    }
+
+    @Test
+    public void getRootPagePath_HistoryViewerFallback_True() {
+        when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content/a")));
+        when(config1.getXfRootPathMethod()).thenReturn("site");
+        when(config1.getHistoryViewerFallback()).thenReturn(true);
+        provider.bindConfig(config1, FIRST);
+
+        assertEquals("/content/a", provider.getRootPagePath("/tmp/versionhistory/5dcec28ce5482dac2f0daa7f045f65b4c49391535a805c6a778761b78b5e2155/3d930917-6bcb-42e6-8b90-5d6c09e83fcf/experience-fragments/a/b/c"));
+        assertEquals("/content/a", provider.getRootPagePath("/tmp/versionhistory/5dcec28ce5482dac2f0daa7f045f65b4c49391535a805c6a778761b78b5e2155/3d930917-6bcb-42e6-8b90-5d6c09e83fcf/a/b/c"));
+    }
+
 
     @Test
     public void getRootPagePath_Unbind() {

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderMultiImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/PageRootProviderMultiImplTest.java
@@ -60,7 +60,7 @@ public class PageRootProviderMultiImplTest {
     }
 
     @Test
-    public void getRootPagePath() throws Exception {
+    public void getRootPagePath() {
         when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content")));
         provider.bindConfig(config1, FIRST);
 
@@ -75,21 +75,23 @@ public class PageRootProviderMultiImplTest {
     }
 
     @Test
-    public void getRootPagePath_Regex() throws Exception {
-        when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content/site/([a-z_-]+)")));
+    public void getRootPagePath_Regex() {
+        when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content/site/([a-z_-]+)"), buildPattern("/content/experience-fragments/site/([a-z_-]+)")));
         provider.bindConfig(config1, FIRST);
 
         assertEquals("/content/site/en_us", provider.getRootPagePath("/content/site/en_us/products/product-x"));
         assertEquals("/content/site/fr", provider.getRootPagePath("/content/site/fr/products/product-x/jcr:content/my-component"));
         assertEquals("/content/site/de_de", provider.getRootPagePath("/content/site/de_de"));
+        assertEquals("/content/experience-fragments/site/en_us", provider.getRootPagePath("/content/experience-fragments/site/en_us/products/product-x"));
 
         assertNull(provider.getRootPagePath("/content"));
         assertNull(provider.getRootPagePath("/content/en_us/products"));
         assertNull(provider.getRootPagePath("/content/123/site"));
+        assertNull(provider.getRootPagePath("/content/experience-fragments/othersite/en_us/products"));
     }
 
     @Test
-    public void getRootPagePath_RegexEnd() throws Exception {
+    public void getRootPagePath_RegexEnd() {
         when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content/site/[a-z]{2}")));
         provider.bindConfig(config1, FIRST);
 
@@ -101,7 +103,7 @@ public class PageRootProviderMultiImplTest {
     }
 
     @Test
-    public void getRootPagePath_Order1() throws Exception {
+    public void getRootPagePath_Order1() {
         when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content"), buildPattern("/content/a")));
         provider.bindConfig(config1, FIRST);
 
@@ -109,7 +111,7 @@ public class PageRootProviderMultiImplTest {
     }
 
     @Test
-    public void getRootPagePath_Order2() throws Exception {
+    public void getRootPagePath_Order2() {
         when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content/a"), buildPattern("/content")));
         provider.bindConfig(config1, FIRST);
 
@@ -118,7 +120,7 @@ public class PageRootProviderMultiImplTest {
     }
 
     @Test
-    public void getRootPagePath_MultiOrder1() throws Exception {
+    public void getRootPagePath_MultiOrder1() {
         when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content")));
         when(config2.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content/a")));
         provider.bindConfig(config1, FIRST);
@@ -128,7 +130,7 @@ public class PageRootProviderMultiImplTest {
     }
 
     @Test
-    public void getRootPagePath_MultiOrder2() throws Exception {
+    public void getRootPagePath_MultiOrder2() {
         when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content/a")));
         when(config2.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content")));
         provider.bindConfig(config1, FIRST);
@@ -138,9 +140,20 @@ public class PageRootProviderMultiImplTest {
         assertEquals("/content", provider.getRootPagePath("/content/b"));
     }
 
+    @Test
+    public void getRootPagePath_XFRootPathMethod_Site() {
+        when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content/site/([a-z_-]+)")));
+        when(config1.getXfRootPathMethod()).thenReturn("site");
+        provider.bindConfig(config1, FIRST);
+
+        assertEquals("/content/site/en_us", provider.getRootPagePath("/content/experience-fragments/site/en_us/products/product-x"));
+
+        assertNull(provider.getRootPagePath("/content/experience-fragments/othersite/en_us/products/product-x/jcr:content/my-component"));
+    }
+
 
     @Test
-    public void getRootPagePath_Unbind() throws Exception {
+    public void getRootPagePath_Unbind() {
         when(config1.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content/a")));
         when(config2.getPageRootPatterns()).thenReturn(Arrays.asList(buildPattern("/content")));
         provider.bindConfig(config1, FIRST);


### PR DESCRIPTION
This PR addresses [Issue](https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/3360) and other scenarios that need a fallback such as Launch content trees and viewing a historical version of a page/XF.