### PR TITLE
Upgrade to Hamcrest 3.0

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -563,7 +563,7 @@
         <!-- START: test dependencies -->
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bundle/src/test/java/com/adobe/acs/commons/http/impl/HttpClientFactoryImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/http/impl/HttpClientFactoryImplTest.java
@@ -17,10 +17,10 @@
  */
 package com.adobe.acs.commons.http.impl;
 
-import static org.junit.Assert.*;
-import static org.hamcrest.CoreMatchers.*;
-import static org.mockserver.model.HttpRequest.*;
-import static org.mockserver.model.HttpResponse.*;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
 
 import com.adobe.acs.commons.http.JsonObjectResponseHandler;
 import com.google.gson.JsonObject;
@@ -125,7 +125,7 @@ public class HttpClientFactoryImplTest {
     public void testDisableSSLCertCheck() throws Exception {
         // this test doesn't actually test anything, but at least ensures that the SSL
         // initialization code doesn't throw exceptions
-        HttpClientFactoryImpl impl = createFactory(false, null, null);
+        createFactory(false, null, null);
     }
 
 }

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileAssetIngestorTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/bundle/src/test/java/com/adobe/acs/commons/mcp/model/GenericBlobReportTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/mcp/model/GenericBlobReportTest.java
@@ -20,7 +20,7 @@ package com.adobe.acs.commons.mcp.model;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/bundle/src/test/java/com/adobe/acs/commons/util/TemplateUtilTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/util/TemplateUtilTest.java
@@ -17,9 +17,10 @@
  */
 package com.adobe.acs.commons.util;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.Map;
@@ -28,15 +29,14 @@ import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
 import org.junit.Test;
 
-import com.adobe.acs.commons.util.TemplateUtil;
 import com.day.cq.wcm.api.NameConstants;
 import com.day.cq.wcm.api.Page;
 
 public class TemplateUtilTest {
 
-    static String TMPL_FAKE = "/apps/templates/fake";
+    static final String TMPL_FAKE = "/apps/templates/fake";
 
-    static String TMPL_FAKE2 = "/apps/templates/fake2";
+    static final String TMPL_FAKE2 = "/apps/templates/fake2";
 
     @Test
     public void test_that_null_page_always_returns_false() {

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/PageCompareDataImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/PageCompareDataImplTest.java
@@ -19,7 +19,7 @@ package com.adobe.acs.commons.wcm.comparisons.impl;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/PageCompareDataLineImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/PageCompareDataLineImplTest.java
@@ -30,7 +30,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/PageCompareDataLinesTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/PageCompareDataLinesTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/VersionSelectionTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/VersionSelectionTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class VersionSelectionTest {
 

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/lines/LineImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/lines/LineImplTest.java
@@ -29,7 +29,7 @@ import static com.adobe.acs.commons.wcm.comparisons.lines.Line.State.ONLY_RIGHT;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LineImplTest {

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/lines/LinesTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/lines/LinesTest.java
@@ -18,7 +18,7 @@
 package com.adobe.acs.commons.wcm.comparisons.impl.lines;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.Serializable;
 import java.util.Iterator;

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/lines/StepperTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/impl/lines/StepperTest.java
@@ -29,7 +29,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class StepperTest {

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/model/PageCompareModelTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/comparisons/model/PageCompareModelTest.java
@@ -43,7 +43,7 @@ import static com.adobe.acs.commons.wcm.comparisons.lines.Line.State.NOT_EQUAL;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/SiteMapServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/impl/SiteMapServletTest.java
@@ -17,8 +17,17 @@
  */
 package com.adobe.acs.commons.wcm.impl;
 
-import com.day.cq.commons.Externalizer;
-import io.wcm.testing.mock.aem.junit.AemContext;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.xmlunit.matchers.EvaluateXPathMatcher.hasXPath;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletResponse;
@@ -30,14 +39,9 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import com.day.cq.commons.Externalizer;
 
-import static org.mockito.Mockito.*;
-import static org.junit.Assert.*;
-import static org.hamcrest.Matchers.*;
-import static org.xmlunit.matchers.EvaluateXPathMatcher.hasXPath;
+import io.wcm.testing.mock.aem.junit.AemContext;
 
 public class SiteMapServletTest {
 

--- a/bundle/src/test/java/com/adobe/acs/commons/wcm/notifications/impl/SystemNotificationsImplTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/wcm/notifications/impl/SystemNotificationsImplTest.java
@@ -23,7 +23,7 @@ import static org.apache.jackrabbit.JcrConstants.NT_UNSTRUCTURED;
 import static org.apache.sling.jcr.resource.api.JcrResourceConstants.NT_SLING_ORDERED_FOLDER;
 import static org.hamcrest.text.StringContainsInOrder.stringContainsInOrder;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.Calendar;

--- a/pom.xml
+++ b/pom.xml
@@ -717,8 +717,8 @@ Bundle-DocURL: https://adobe-consulting-services.github.io/acs-aem-commons/
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-all</artifactId>
-                <version>1.3</version>
+                <artifactId>hamcrest</artifactId>
+                <version>3.0</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Get rid of deprecated calls to org.junit.Assert.assertThat(...)