### PR TITLE
Fix #3164 - Failed to construct URL when loading report with hash par…

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/report-builder/report-page/clientlibs/js/app.js
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/report-builder/report-page/clientlibs/js/app.js
@@ -96,7 +96,8 @@ angular
           if (window.location.hash !== "" && window.location.hash !== "#") {
             var params = window.location.hash.substr(1);
             loadResults(params).done(function () {
-              var url = new URL(window.location.hash.replace("#", "?"));
+              var baseUrl = window.location.href.split('#')[0];
+              var url = new URL(baseUrl + window.location.hash.replace("#", "?"));
               url.searchParams.forEach(function (val, key) {
                 $('input[name="' + key + '"]:not([type="checkbox"])').val(val);
                 var $sel = $('coral-select[name="' + key + '"]');

--- a/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/report-builder/report-page/clientlibs/js/app.js
+++ b/ui.apps/src/main/content/jcr_root/apps/acs-commons/components/utilities/report-builder/report-page/clientlibs/js/app.js
@@ -96,8 +96,8 @@ angular
           if (window.location.hash !== "" && window.location.hash !== "#") {
             var params = window.location.hash.substr(1);
             loadResults(params).done(function () {
-              var baseUrl = window.location.href.split('#')[0];
-              var url = new URL(baseUrl + window.location.hash.replace("#", "?"));
+              const baseUrl = globalThis.location.href.split('#')[0];
+              const url = new URL(baseUrl + globalThis.location.hash.replace('#', '?'));
               url.searchParams.forEach(function (val, key) {
                 $('input[name="' + key + '"]:not([type="checkbox"])').val(val);
                 var $sel = $('coral-select[name="' + key + '"]');


### PR DESCRIPTION
…ameters

new URL() was called with a relative hash string (e.g. ?path=/content/...) which throws "Failed to construct 'URL': Invalid URL" in all browsers, preventing report parameters from being populated when loading report with hash parameters in URL.

Fix: extract base URL from window.location.href before appending hash parameters.

Before:
var url = new URL(window.location.hash.replace("#", "?"));

After:
var baseUrl = window.location.href.split("#")[0];
var url = new URL(baseUrl + window.location.hash.replace("#", "?"));