### PR TITLE
fix: URL Asset Importer did not use stored Credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,19 +12,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 [Unreleased]: https://github.com/Adobe-Consulting-Services/acs-aem-commons/compare/acs-aem-commons-6.17.0...HEAD
 
+### Fixed
+
+- #3763 Fix URL Asset Import using stored Credentials
+
 ## [6.17.0] - 2026-04-29
 
 ## Changed
 
-- #3644 All Result checkbox on Reports could be configurable 
+- #3644 All Result checkbox on Reports could be configurable
 - #3732 Redirect Manager: evaluate "contextPrefixIgnored" for source path matching in addition to target path construction
-- #3734 RedirectManager: Support regular expression in source without capturing groups 
+- #3734 RedirectManager: Support regular expression in source without capturing groups
 - #3715 Add fallback logic for Page Root detection (Shared Component Properties) on Experience Fragments, Launches, and Version History
 
 ## Fixed
 
-- #3730 RedirectManager: Trailing "*" in source path being converted to "(.*)" might destroy regular expression
-- #3718 Redirect Manager: Fix replacing sharded redirects from a spreadsheet 
+- #3730 RedirectManager: Trailing "_" in source path being converted to "(._)" might destroy regular expression
+- #3718 Redirect Manager: Fix replacing sharded redirects from a spreadsheet
 - #3742 Remove usage of Apache Tika 1.x
 
 ## 6.16.0 - 2026-02-10
@@ -39,7 +43,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #3692 Redirect Manager: prevent java.lang.IllegalStateException in author logs when publishing redirects
 - #3683 RedirectFilter: Ignore Case value not showing in export
 - #3604 ClassCastException with org.apache.sling.distribution.DistributionRequestType in CloudDispatcherFlushRulesExecutor.handleEvent
-- #2524 Add dependency to enable PathField as report parameter. 
+- #2524 Add dependency to enable PathField as report parameter.
 
 ## 6.15.4 - 2025-11-19
 
@@ -66,6 +70,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ## 6.14.0 - 2025-07-15
 
 ### Changed
+
 - #3636 Content Sync: support dedicated egress IP address
 - #3623 Content Sync: improve error handling
 
@@ -77,7 +82,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #3594 Redirect Manager: create parent structure if user enters a non-existing /conf path in Add Configuration.
 - #3327 Update to mockito 5.x, which allows static mocking without needing mockito-inline. Java11+ is the standard nowadays, so we can use 5.x+
 - #3601 Content Sync: in case of an error print the exception and continue instead of aborting
-- #3596 Redirect Manager: com.adobe.acs.commons.redirects.servlets.* should expose error messages to end users
+- #3596 Redirect Manager: com.adobe.acs.commons.redirects.servlets.\* should expose error messages to end users
 - #3594 Redirect Manager: create parent structure if user enters a non-existing /conf path in Add Configuration.
 - #3626 Redirect Manager: Fix Replace Mode issue, delete only 'redirect-row' nodes
 
@@ -98,13 +103,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #3562 Fixed compilation errors in iscurrentusermemberof render condition
 - #3457 Allow disabling the ContentPolicyValueInjector
 
- ## 6.11.0 - 2025-03-14
+## 6.11.0 - 2025-03-14
 
 ### Changed
+
 - #3501 Redirect Manager: Large-Scale Import Optimization
 - #3507 - Rewrite javascript clientlibs when used in link tags for preloading.
 
 ### Fixed
+
 - #3497 - Redirect Manager: allow creating redirect configurations in a nested hierarchy
 - #3497 - Redirect Manager: allow creating redirect configurations in a nested hierarchy
 - #3539 - Fixed NPE issue in AcsCommonsConsoleAuthoringUIModeFilter, if cq-authoring-mode cookie is missing
@@ -409,7 +416,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 - #3060 - Query packager does only picks last list item when in list mode
 - #3057 - Re-labled asset packager, added missing excludePages property
-- Updated dependencies with vulnerabilities:  guava-30.1-jre.jar: CVE-2020-8908, jjwt-api-0.11.2.jar: CVE-2022-45688
+- Updated dependencies with vulnerabilities: guava-30.1-jre.jar: CVE-2020-8908, jjwt-api-0.11.2.jar: CVE-2022-45688
 
 ### Changed
 
@@ -1228,7 +1235,7 @@ v4.8.2 failed to release properly. v4.8.4 is a re-release of v4.8.2
 - #1649 - Added support for custom Content-Type header.
 - #1720 - Adjusted metatype for HTTP Cache components.
 - #1729 - Url Asset Ingestor | Support case sensitive properties
-- #1753 - Remove Dynamic*ClientLibraryServlet and breaks out TouchUI widgets into discrete Client Libraries
+- #1753 - Remove Dynamic\*ClientLibraryServlet and breaks out TouchUI widgets into discrete Client Libraries
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ## Changed
 
-- #3644 All Result checkbox on Reports could be configurable
+- #3644 All Result checkbox on Reports could be configurable 
 - #3732 Redirect Manager: evaluate "contextPrefixIgnored" for source path matching in addition to target path construction
-- #3734 RedirectManager: Support regular expression in source without capturing groups
+- #3734 RedirectManager: Support regular expression in source without capturing groups 
 - #3715 Add fallback logic for Page Root detection (Shared Component Properties) on Experience Fragments, Launches, and Version History
 
 ## Fixed
 
-- #3730 RedirectManager: Trailing "_" in source path being converted to "(._)" might destroy regular expression
-- #3718 Redirect Manager: Fix replacing sharded redirects from a spreadsheet
+- #3730 RedirectManager: Trailing "*" in source path being converted to "(.*)" might destroy regular expression
+- #3718 Redirect Manager: Fix replacing sharded redirects from a spreadsheet 
 - #3742 Remove usage of Apache Tika 1.x
 
 ## 6.16.0 - 2026-02-10
@@ -43,7 +43,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #3692 Redirect Manager: prevent java.lang.IllegalStateException in author logs when publishing redirects
 - #3683 RedirectFilter: Ignore Case value not showing in export
 - #3604 ClassCastException with org.apache.sling.distribution.DistributionRequestType in CloudDispatcherFlushRulesExecutor.handleEvent
-- #2524 Add dependency to enable PathField as report parameter.
+- #2524 Add dependency to enable PathField as report parameter. 
 
 ## 6.15.4 - 2025-11-19
 
@@ -70,7 +70,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 ## 6.14.0 - 2025-07-15
 
 ### Changed
-
 - #3636 Content Sync: support dedicated egress IP address
 - #3623 Content Sync: improve error handling
 
@@ -82,7 +81,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #3594 Redirect Manager: create parent structure if user enters a non-existing /conf path in Add Configuration.
 - #3327 Update to mockito 5.x, which allows static mocking without needing mockito-inline. Java11+ is the standard nowadays, so we can use 5.x+
 - #3601 Content Sync: in case of an error print the exception and continue instead of aborting
-- #3596 Redirect Manager: com.adobe.acs.commons.redirects.servlets.\* should expose error messages to end users
+- #3596 Redirect Manager: com.adobe.acs.commons.redirects.servlets.* should expose error messages to end users
 - #3594 Redirect Manager: create parent structure if user enters a non-existing /conf path in Add Configuration.
 - #3626 Redirect Manager: Fix Replace Mode issue, delete only 'redirect-row' nodes
 
@@ -103,15 +102,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 - #3562 Fixed compilation errors in iscurrentusermemberof render condition
 - #3457 Allow disabling the ContentPolicyValueInjector
 
-## 6.11.0 - 2025-03-14
+ ## 6.11.0 - 2025-03-14
 
 ### Changed
-
 - #3501 Redirect Manager: Large-Scale Import Optimization
 - #3507 - Rewrite javascript clientlibs when used in link tags for preloading.
 
 ### Fixed
-
 - #3497 - Redirect Manager: allow creating redirect configurations in a nested hierarchy
 - #3497 - Redirect Manager: allow creating redirect configurations in a nested hierarchy
 - #3539 - Fixed NPE issue in AcsCommonsConsoleAuthoringUIModeFilter, if cq-authoring-mode cookie is missing
@@ -416,7 +413,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 - #3060 - Query packager does only picks last list item when in list mode
 - #3057 - Re-labled asset packager, added missing excludePages property
-- Updated dependencies with vulnerabilities: guava-30.1-jre.jar: CVE-2020-8908, jjwt-api-0.11.2.jar: CVE-2022-45688
+- Updated dependencies with vulnerabilities:  guava-30.1-jre.jar: CVE-2020-8908, jjwt-api-0.11.2.jar: CVE-2022-45688
 
 ### Changed
 
@@ -1235,7 +1232,7 @@ v4.8.2 failed to release properly. v4.8.4 is a re-release of v4.8.2
 - #1649 - Added support for custom Content-Type header.
 - #1720 - Adjusted metatype for HTTP Cache components.
 - #1729 - Url Asset Ingestor | Support case sensitive properties
-- #1753 - Remove Dynamic\*ClientLibraryServlet and breaks out TouchUI widgets into discrete Client Libraries
+- #1753 - Remove Dynamic*ClientLibraryServlet and breaks out TouchUI widgets into discrete Client Libraries
 
 ### Removed
 

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileOrRendition.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileOrRendition.java
@@ -32,16 +32,21 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -249,14 +254,22 @@ public class FileOrRendition implements HierarchicalElement {
             if (connection == null) {
                 try {
                     lastRequest = new HttpGet(url);
+                    HttpClientContext context = HttpClientContext.create();
                     if (StringUtils.isNotBlank(clientProvider.getUsername())) {
-                        String credentials = clientProvider.getUsername() + ":" +
-                                StringUtils.defaultString(clientProvider.getPassword());
-                        String encoded = Base64.getEncoder().encodeToString(
-                                credentials.getBytes(StandardCharsets.UTF_8));
-                        lastRequest.setHeader("Authorization", "Basic " + encoded);
+                        URI uri = lastRequest.getURI();
+                        HttpHost target = new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme());
+                        BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+                        credentialsProvider.setCredentials(
+                                new AuthScope(target),
+                                new UsernamePasswordCredentials(
+                                        clientProvider.getUsername(),
+                                        StringUtils.defaultString(clientProvider.getPassword())));
+                        BasicAuthCache authCache = new BasicAuthCache();
+                        authCache.put(target, new BasicScheme());
+                        context.setCredentialsProvider(credentialsProvider);
+                        context.setAuthCache(authCache);
                     }
-                    connection = clientProvider.getHttpClientSupplier().get().execute(lastRequest);
+                    connection = clientProvider.getHttpClientSupplier().get().execute(lastRequest, context);
                     size = connection.getEntity().getContentLength();
                 } catch (IOException | IllegalArgumentException ex) {
                     size = -1L;

--- a/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileOrRendition.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/mcp/impl/processes/asset/FileOrRendition.java
@@ -32,11 +32,14 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.slf4j.Logger;
@@ -246,6 +249,13 @@ public class FileOrRendition implements HierarchicalElement {
             if (connection == null) {
                 try {
                     lastRequest = new HttpGet(url);
+                    if (StringUtils.isNotBlank(clientProvider.getUsername())) {
+                        String credentials = clientProvider.getUsername() + ":" +
+                                StringUtils.defaultString(clientProvider.getPassword());
+                        String encoded = Base64.getEncoder().encodeToString(
+                                credentials.getBytes(StandardCharsets.UTF_8));
+                        lastRequest.setHeader("Authorization", "Basic " + encoded);
+                    }
                     connection = clientProvider.getHttpClientSupplier().get().execute(lastRequest);
                     size = connection.getEntity().getContentLength();
                 } catch (IOException | IllegalArgumentException ex) {


### PR DESCRIPTION
The Credentials you input into the URL Asset Importer did not get applied when the URLs were being called.

I noticed this while trying to import Assets from one AEM Author to another. The Importer would just be created files with 9KB, which, if inspected, turned out to be HTML files showing the AEM "Resource not found" page.

This Pull request should fix it.