### PR TITLE
Remove jshint-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -403,11 +403,6 @@ Bundle-DocURL: https://adobe-consulting-services.github.io/acs-aem-commons/
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>jslint-maven-plugin</artifactId>
-                    <version>1.0.1</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <version>2.7.1</version>
                 </plugin>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -68,37 +68,6 @@
             </plugin>
 
             <plugin>
-                <groupId>com.cj.jshintmojo</groupId>
-                <artifactId>jshint-maven-plugin</artifactId>
-                <version>1.6.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>lint</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <directories>
-                        <directory>src/main/content/jcr_root</directory>
-                    </directories>
-                    <failOnError>true</failOnError>
-                    <globals>jQuery,window,$</globals>
-                    <excludes>
-                        <exclude>/src/main/content/jcr_root/apps/acs-commons/extensions/contentfinder/audio.js</exclude>
-                        <exclude>
-                            /src/main/content/jcr_root/apps/acs-commons/components/utilities/manage-controlled-processes/clientlibs/js/vendor
-                        </exclude>
-                        <exclude>
-                            /src/main/content/jcr_root/apps/acs-commons/components/utilities/version-compare/clientlibs/js/vendor/jquery.jsPlumb-1.7.2-min.js
-                        </exclude>
-                        <exclude>/src/main/content/jcr_root/apps/acs-commons/clientlibs/vendor</exclude>
-                        <exclude>/src/main/content/jcr_root/apps/acs-commons/authoring/vendor</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
It is no longer maintained and only accepts ancient ES5. This closes #3777