### PR TITLE
fix(report-builder): Missing assets in CSV report download when the References Column is used in the AEM Report Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ### Fixed
 
+- #3533 ReferencesModel: fix NullPointerException in CSV export when a reference has a null or blank target, causing affected rows to be silently dropped from the report
+
 ### Changed
 
 ## [6.17.4] - 2026-06-20

--- a/bundle/src/main/java/com/adobe/acs/commons/reports/models/ReferencesModel.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/reports/models/ReferencesModel.java
@@ -36,7 +36,6 @@ import com.adobe.acs.commons.reports.api.ReportCellCSVExporter;
 import com.adobe.granite.references.Reference;
 import com.adobe.granite.references.ReferenceAggregator;
 import com.adobe.granite.references.ReferenceList;
-import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,18 +98,21 @@ public class ReferencesModel implements ReportCellCSVExporter {
 
             if (reference == null) {
                 log.warn("Reference is null for resource: {}", resource.getPath());
+                references.remove();
                 continue;
             }
 
             Resource target = reference.getTarget();
             if (target == null) {
                 log.warn("Reference target is null for resource: {}", resource.getPath());
+                references.remove();
                 continue;
             }
 
             String targetPath = target.getPath();
             if (StringUtils.isBlank(targetPath)) {
                 log.warn("Reference target path is blank for resource: {}", resource.getPath());
+                references.remove();
                 continue;
             }
 

--- a/bundle/src/test/java/com/adobe/acs/commons/reports/models/ReferencesModelTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/reports/models/ReferencesModelTest.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ReferencesModelTest {
@@ -102,6 +103,66 @@ public class ReferencesModelTest {
 
     assertNotNull(referencesModel.getValue(mockResourceSource));
     assertEquals("VALID - /target", referencesModel.getValue(mockResourceSource));
+
+    log.info("Test Successful!");
+  }
+
+  /**
+   * Regression test for https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/3533.
+   * A reference whose target is null should be silently removed during init(), so that getValue()
+   * does not throw a NullPointerException and the valid references are still returned.
+   */
+  @Test
+  public void testGetValue_nullTargetReferenceIsSkipped() throws Exception {
+    log.info("testGetValue_nullTargetReferenceIsSkipped");
+
+    Reference nullTargetRef = mock(Reference.class);
+    when(nullTargetRef.getTarget()).thenReturn(null);
+
+    ReferenceList references = new MockReferenceList(mockResourceSource);
+    references.add(new Reference(mockResourceSource, mockResourceTarget, "VALID"));
+    references.add(nullTargetRef);
+
+    ReferenceAggregator aggregator = new MockReferencesAggregator(references);
+
+    ReferencesModel model = new ReferencesModel(mockResourceSource, delimiterConfiguration);
+    Field af = ReferencesModel.class.getDeclaredField("aggregator");
+    af.setAccessible(true);
+    af.set(model, aggregator);
+    model.init();
+
+    // The null-target reference must be filtered out; only the valid one survives
+    assertEquals(1, model.getReferences().size());
+    assertEquals("VALID - /target", model.getValue(mockResourceSource));
+
+    log.info("Test Successful!");
+  }
+
+  /**
+   * Regression test for https://github.com/Adobe-Consulting-Services/acs-aem-commons/issues/3533.
+   * When ALL references have a null target, getValue() should return an empty string rather than
+   * throwing a NullPointerException, so the CSV export can continue to the next row.
+   */
+  @Test
+  public void testGetValue_allNullTargetReferencesReturnEmptyString() throws Exception {
+    log.info("testGetValue_allNullTargetReferencesReturnEmptyString");
+
+    Reference nullTargetRef = mock(Reference.class);
+    when(nullTargetRef.getTarget()).thenReturn(null);
+
+    ReferenceList references = new MockReferenceList(mockResourceSource);
+    references.add(nullTargetRef);
+
+    ReferenceAggregator aggregator = new MockReferencesAggregator(references);
+
+    ReferencesModel model = new ReferencesModel(mockResourceSource, delimiterConfiguration);
+    Field af = ReferencesModel.class.getDeclaredField("aggregator");
+    af.setAccessible(true);
+    af.set(model, aggregator);
+    model.init();
+
+    assertEquals(0, model.getReferences().size());
+    assertEquals("", model.getValue(mockResourceSource));
 
     log.info("Test Successful!");
   }


### PR DESCRIPTION
## Summary

Fixes #3533 — Missing assets in CSV report download when the References Column is used in the AEM Report Builder

### Impact

When the **References Column** is included in an AEM Report Builder report, assets that have broken or unresolvable references (e.g. deleted pages, dangling links) are **silently dropped from the CSV export** with no error shown to the user. The row count in the downloaded CSV is lower than what was shown on screen, and the only indication is a WARN in the server logs.

This affects both:
- The AEM Report Builder UI (Tools → ACS AEM Commons → Report Builder → Download CSV)
- Any direct HTTP call to the CSV export endpoint: `GET /var/acs-commons/reports/<report>/jcr:content.report.csv`

### Problem

`ReferencesModel.init()` iterates the reference list and correctly identifies problematic entries (null references, null targets, blank target paths), but the guard blocks used `continue` instead of `references.remove(); continue` — so bad entries were never actually removed from `referenceList`.

`getValue()` later iterates the same list and unconditionally calls `reference.getTarget().getPath()`, throwing a `NullPointerException` for null-target entries. This is caught by `ReportCSVExportServlet` as a WARN, silently dropping the row.

### Fix

Added `references.remove()` before `continue` in each of the three guard blocks inside `init()` so only valid, fully-resolvable references remain when `getValue()` consumes the list. Also removed an unused `@ValueMapValue` import.

### Tests

Two regression tests added to `ReferencesModelTest`:
- `testGetValue_nullTargetReferenceIsSkipped`
- `testGetValue_allNullTargetReferencesReturnEmptyString`

All 5 tests pass locally (Maven 3.9.16 / JDK 21 / macOS) — `Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, BUILD SUCCESS`

Full CI matrix (ubuntu/macOS/windows × JDK 11/17/21/25) passed on fork:
https://github.com/enageshwari/acs-aem-commons/actions/runs/30952127163

### Checklist
- [x] Bug fix (non-breaking change)
- [x] CHANGELOG updated under `## Unreleased > ### Fixed`
- [x] Regression tests added
- [x] Spaces, not tabs
- [x] No author tags
