### PR TITLE
Implement logging for empty agent list in AgentIdsAgentFilter

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/replication/AgentIdsAgentFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/replication/AgentIdsAgentFilter.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 public class AgentIdsAgentFilter implements AgentFilter {
 
+    private static final Logger log = LoggerFactory.getLogger(AgentIdsAgentFilter.class);
     private final List<String> agentIds;
 
     public AgentIdsAgentFilter(List<String> agentIds) {

--- a/bundle/src/main/java/com/adobe/acs/commons/replication/AgentIdsAgentFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/replication/AgentIdsAgentFilter.java
@@ -24,7 +24,18 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * An AEM {@link AgentFilter} implementation that filters replication agents 
+ * based on a specified list of Agent IDs.
+ * <p>
+ * <strong>Note on Empty Lists:</strong> If the provided list of agent IDs is 
+ * null or empty, {@link #isIncluded(Agent)} will return {@code true} for all agents. 
+ * This fallback behavior prevents silent replication failures by defaulting to 
+ * standard AEM replication (targeting all active agents) when no specific IDs are defined.
+ */
 public class AgentIdsAgentFilter implements AgentFilter {
 
     private final List<String> agentIds;
@@ -33,6 +44,10 @@ public class AgentIdsAgentFilter implements AgentFilter {
         this.agentIds = Optional.ofNullable(agentIds)
                 .map(list -> (List<String>) new ArrayList<>(list))
                 .orElse(Collections.emptyList());
+        
+        if (this.agentIds.isEmpty()) {
+            log.debug("Initialized with an empty agent list. Default AEM behavior (allow all agents) will apply to this replication event.");
+        }
     }
 
     public boolean isIncluded(Agent agent) {

--- a/bundle/src/test/java/com/adobe/acs/commons/replication/AgentIdsAgentFilterTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/replication/AgentIdsAgentFilterTest.java
@@ -20,6 +20,7 @@ package com.adobe.acs.commons.replication;
 
 import com.day.cq.replication.Agent;
 import com.google.common.collect.ImmutableList;
+import java.util.Collections;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,5 +58,21 @@ public class AgentIdsAgentFilterTest {
         assertTrue(filter.isIncluded(agentAcceptOne));
         assertTrue(filter.isIncluded(agentAcceptTwo));
         assertFalse(filter.isIncluded(agentAcceptThree));
+    }
+
+    @Test
+    public void isIncluded_emptyList() throws Exception {
+        filter = new AgentIdsAgentFilter(Collections.emptyList());
+        assertTrue(filter.isIncluded(agentAcceptOne));
+        assertTrue(filter.isIncluded(agentAcceptTwo));
+        assertTrue(filter.isIncluded(agentAcceptThree));
+    }
+
+    @Test
+    public void isIncluded_nullList() throws Exception {
+        filter = new AgentIdsAgentFilter(null);
+        assertTrue(filter.isIncluded(agentAcceptOne));
+        assertTrue(filter.isIncluded(agentAcceptTwo));
+        assertTrue(filter.isIncluded(agentAcceptThree));
     }
 }


### PR DESCRIPTION
Related Issue
Closes #3788

it improves the observability and developer experience of the `AgentIdsAgentFilter` when it is initialized with an empty or null list.

Previously, if an empty list was passed, the filter would silently return true (allowing replication to all agents). While this is the intended fallback to AEM's default behavior, it violates the principle of least astonishment for an allowlist and lacked documentation, risking accidental "publish all" events.

Changes Included
- Added explicit JavaDoc: Documented the constructor to clearly state that an empty/null list bypasses the filter and allows all agents.

- Added Constructor Logging: Introduced a `log.debug` statement in the constructor that triggers only when an empty list is provided.

Note: The log is intentionally placed in the constructor rather than isIncluded() to prevent log spam and disk I/O overhead during high-volume replication events.

- Added unit test cases in `AgentIdsAgentFilterTest` for empty and null agent ID list fallback scenarios.

How to Test
1. Instantiate AgentIdsAgentFilter with an empty ArrayList.
2. Verify that the debug log is emitted: "Initialized with an empty agent list. Default AEM behavior (allow all agents) will apply..."
3. Verify isIncluded() still returns true.