### PR TITLE
Support asset URN references in Asset Packager filter resolution

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/commons/packaging/util/AssetPackageUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/packaging/util/AssetPackageUtil.java
@@ -28,6 +28,12 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import com.day.cq.dam.api.DamConstants;
+import com.day.cq.dam.commons.util.DamUtil;
+import com.day.cq.wcm.api.NameConstants;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.vault.fs.api.PathFilterSet;
 import org.apache.jackrabbit.vault.fs.filter.DefaultPathFilter;
@@ -36,12 +42,6 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.day.cq.dam.api.DamConstants;
-import com.day.cq.dam.commons.util.DamUtil;
-import com.day.cq.wcm.api.NameConstants;
-import com.day.cq.wcm.api.Page;
-import com.day.cq.wcm.api.PageManager;
 
 public class AssetPackageUtil {
 

--- a/bundle/src/main/java/com/adobe/acs/commons/packaging/util/AssetPackageUtil.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/packaging/util/AssetPackageUtil.java
@@ -24,14 +24,9 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-
-import com.day.cq.dam.api.DamConstants;
-import com.day.cq.dam.commons.util.DamUtil;
-import com.day.cq.wcm.api.NameConstants;
-import com.day.cq.wcm.api.Page;
-import com.day.cq.wcm.api.PageManager;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.vault.fs.api.PathFilterSet;
@@ -41,6 +36,12 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.day.cq.dam.api.DamConstants;
+import com.day.cq.dam.commons.util.DamUtil;
+import com.day.cq.wcm.api.NameConstants;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
 
 public class AssetPackageUtil {
 
@@ -52,6 +53,11 @@ public class AssetPackageUtil {
     private static final String PN_ASSET_PREFIX = "assetPrefix";
     private static final String PN_PAGE_EXCLUSIONS = "pageExclusions";
     private static final String PN_ASSET_EXCLUSIONS = "assetExclusions";
+
+    /** Asset URN reference pattern. */
+    private static final Pattern AEM_ASSET_URN = Pattern.compile(
+        "^/?urn:aaid:aem:([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})(?:/.*)?$"
+    );
 
     private String customPrefix;
     private List<Pattern> pageExclusionPatterns;
@@ -188,16 +194,30 @@ public class AssetPackageUtil {
 
     /**
      * Adds a property value to the filter set list if it is not empty, referencing the DAM, and is
-     * an actual DAM Asset.
+     * an actual DAM Asset. The property value can be either an asset path or an asset URN reference.
      *
      * @param filters The total list of filter sets
      * @param value   The current property value
      */
     private void addFilter(final Set<PathFilterSet> filters, final String value,
                            final ResourceResolver resourceResolver) {
-        if (StringUtils.isNotBlank(value) && DamUtil.isAsset(resourceResolver.getResource(value))
-                && fitsAssetPattern(value)) {
-            filters.add(new PathFilterSet(value));
+        if (StringUtils.isNotBlank(value)) {
+            final Matcher uuidMatcher = AEM_ASSET_URN.matcher(value);
+
+            if (uuidMatcher.matches()) {
+                final String uuid = uuidMatcher.group(1);
+
+                // Attempt to resolve asset by ID
+                final Resource assetResource = resourceResolver.getResource("/jcr:id/" + uuid);
+
+                if (DamUtil.isAsset(assetResource) && fitsAssetPattern(assetResource.getPath())) {
+                    filters.add(new PathFilterSet(assetResource.getPath()));
+                }
+            } else {
+                if (DamUtil.isAsset(resourceResolver.getResource(value)) && fitsAssetPattern(value)) {
+                    filters.add(new PathFilterSet(value));
+                }
+            }
         }
     }
 

--- a/bundle/src/test/java/com/adobe/acs/commons/packaging/impl/AssetPackageUtilTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/packaging/impl/AssetPackageUtilTest.java
@@ -1,0 +1,78 @@
+/*
+ * ACS AEM Commons
+ *
+ * Copyright (C) 2013 - 2023 Adobe
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.adobe.acs.commons.packaging.impl;
+
+import java.util.List;
+
+import org.apache.jackrabbit.vault.fs.api.PathFilterSet;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.adobe.acs.commons.packaging.util.AssetPackageUtil;
+
+import io.wcm.testing.mock.aem.junit.AemContext;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AssetPackageUtilTest {
+
+    private static final String PACKAGER_CONTENT_PATH = "/etc/acs-commons/packagers/assets";
+
+    @Rule
+    public final AemContext context = new AemContext(ResourceResolverType.JCR_OAK);
+
+    @Before
+    public void setup() {
+        context.load().json(getClass().getResourceAsStream("AssetPackageUtilContent.json"),
+            "/content/we-retail/language-masters/en/experience");
+        context.load().json(getClass().getResourceAsStream("AssetPackagerServletDamContent.json"),
+            "/content/dam/we-retail/en");
+    }
+
+    @Test
+    public void getPackageFilterPaths() {
+        context.load().json(getClass().getResourceAsStream("AssetPackagerServletConfiguration.json"),
+            PACKAGER_CONTENT_PATH);
+
+        final ResourceResolver resourceResolver = context.resourceResolver();
+        final ValueMap properties = getAssetPackagerConfigurationProperties();
+
+        final AssetPackageUtil assetPackageUtil = new AssetPackageUtil(properties, resourceResolver);
+
+        final List<PathFilterSet> packageFilterPaths = assetPackageUtil.getPackageFilterPaths();
+
+        assertEquals(4, packageFilterPaths.size());
+    }
+
+    /**
+     * @return asset packager configuration properties
+     */
+    private ValueMap getAssetPackagerConfigurationProperties() {
+        final Resource assetPackagerResource = context.resourceResolver().getResource(PACKAGER_CONTENT_PATH);
+
+        return assetPackagerResource.getChild("jcr:content/configuration").getValueMap();
+    }
+}

--- a/bundle/src/test/java/com/adobe/acs/commons/packaging/impl/AssetPackageUtilTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/packaging/impl/AssetPackageUtilTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import org.apache.jackrabbit.vault.fs.api.PathFilterSet;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.junit.Before;
@@ -57,22 +56,17 @@ public class AssetPackageUtilTest {
         context.load().json(getClass().getResourceAsStream("AssetPackagerServletConfiguration.json"),
             PACKAGER_CONTENT_PATH);
 
-        final ResourceResolver resourceResolver = context.resourceResolver();
-        final ValueMap properties = getAssetPackagerConfigurationProperties();
+        final Resource assetPackagerResource = context.resourceResolver().getResource(PACKAGER_CONTENT_PATH);
+        final ValueMap properties = assetPackagerResource.getChild("jcr:content/configuration").getValueMap();
 
-        final AssetPackageUtil assetPackageUtil = new AssetPackageUtil(properties, resourceResolver);
+        final AssetPackageUtil assetPackageUtil = new AssetPackageUtil(properties, context.resourceResolver());
 
         final List<PathFilterSet> packageFilterPaths = assetPackageUtil.getPackageFilterPaths();
 
+        // Test is inclusive of the following cases:
+        // 1. Resolve asset path references
+        // 2. Resolve asset UUID references
+        // 3. Ignore asset UUIDs that do not resolve to an asset
         assertEquals(4, packageFilterPaths.size());
-    }
-
-    /**
-     * @return asset packager configuration properties
-     */
-    private ValueMap getAssetPackagerConfigurationProperties() {
-        final Resource assetPackagerResource = context.resourceResolver().getResource(PACKAGER_CONTENT_PATH);
-
-        return assetPackagerResource.getChild("jcr:content/configuration").getValueMap();
     }
 }

--- a/bundle/src/test/resources/com/adobe/acs/commons/packaging/impl/AssetPackageUtilContent.json
+++ b/bundle/src/test/resources/com/adobe/acs/commons/packaging/impl/AssetPackageUtilContent.json
@@ -1,0 +1,92 @@
+{
+  "jcr:primaryType": "cq:Page",
+  "jcr:content": {
+    "jcr:primaryType": "cq:PageContent",
+    "jcr:title": "Experience",
+    "cq:template": "/conf/we-retail/settings/wcm/templates/hero-page",
+    "sling:resourceType": "weretail/components/structure/page",
+    "root": {
+      "jcr:primaryType": "nt:unstructured",
+      "sling:resourceType": "wcm/foundation/components/responsivegrid",
+      "hero_image": {
+        "jcr:primaryType": "nt:unstructured",
+        "fileReference": "/urn:aaid:aem:4762b252-835d-4345-928b-03f5a594125f/trekker-ama-dablam.jpg",
+        "useFullWidth": "true",
+        "title": "Experiences",
+        "heading": "Inspiring stories from around the world",
+        "sling:resourceType": "weretail/components/content/heroimage"
+      }
+    }
+  },
+  "arctic-surfing-in-lofoten": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent",
+      "jcr:title": "Arctic Surfing In Lofoten",
+      "cq:template": "/conf/we-retail/settings/wcm/templates/experience-page",
+      "sling:resourceType": "weretail/components/structure/page",
+      "root": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "wcm/foundation/components/responsivegrid",
+        "responsivegrid": {
+          "jcr:primaryType": "nt:unstructured",
+          "sling:resourceType": "wcm/foundation/components/responsivegrid",
+          "contentfragment": {
+            "jcr:primaryType": "nt:unstructured",
+            "paragraphScope": "all",
+            "elementNames": "main",
+            "text": "Aloha spirits in Northern Norway",
+            "variationName": "master",
+            "sling:resourceType": "weretail/components/content/contentfragment",
+            "displayMode": "singleText",
+            "fragmentPath": "/content/dam/we-retail/en/experiences/arctic-surfing-in-lofoten/arctic-surfing-in-lofoten",
+            "par1": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "wcm/foundation/components/responsivegrid",
+              "image": {
+                "jcr:primaryType": "nt:unstructured",
+                "fileReference": "/content/dam/we-retail/en/experiences/arctic-surfing-in-lofoten/fjord-waves.jpg",
+                "sling:resourceType": "weretail/components/content/image"
+              }
+            },
+            "par2": {
+              "jcr:primaryType": "nt:unstructured",
+              "sling:resourceType": "wcm/foundation/components/responsivegrid",
+              "image": {
+                "jcr:primaryType": "nt:unstructured",
+                "fileReference": "/urn:aaid:aem:4762b252-835d-4345-928b-03f5a5941zzz/majestic-rainbow.jpg",
+                "sling:resourceType": "weretail/components/content/image"
+              }
+            }
+          }
+        },
+        "hero_image": {
+          "jcr:primaryType": "nt:unstructured",
+          "fileReference": "/content/dam/we-retail/en/experiences/arctic-surfing-in-lofoten/surfer-wave-01.jpg",
+          "useFullWidth": "true",
+          "title": "Arctic Surfing In Lofoten",
+          "sling:resourceType": "weretail/components/content/heroimage"
+        }
+      }
+    }
+  },
+  "hours-of-wilderness": {
+    "jcr:primaryType": "cq:Page",
+    "jcr:content": {
+      "jcr:primaryType": "cq:PageContent",
+      "jcr:title": "48 hours of Wilderness",
+      "cq:template": "/conf/we-retail/settings/wcm/templates/experience-page",
+      "sling:resourceType": "weretail/components/structure/page",
+      "root": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "wcm/foundation/components/responsivegrid",
+        "hero_image": {
+          "jcr:primaryType": "nt:unstructured",
+          "fileReference": "/urn:aaid:aem:216624b6-98a7-4988-847c-2c93a238bf5c/48-hours-of-wilderness-1.jpg",
+          "useFullWidth": "true",
+          "sling:resourceType": "weretail/components/content/heroimage"
+        }
+      }
+    }
+  }
+}

--- a/bundle/src/test/resources/com/adobe/acs/commons/packaging/impl/AssetPackagerServletDamContent.json
+++ b/bundle/src/test/resources/com/adobe/acs/commons/packaging/impl/AssetPackagerServletDamContent.json
@@ -5,7 +5,8 @@
     "hiking-camping": {
       "jcr:primaryType": "sling:OrderedFolder",
       "trekker-ama-dablam.jpg": {
-        "jcr:primaryType": "dam:Asset"
+        "jcr:primaryType": "dam:Asset",
+        "jcr:uuid": "4762b252-835d-4345-928b-03f5a594125f"
       }
     }
   },
@@ -14,37 +15,47 @@
     "48-hours-of-wilderness": {
       "jcr:primaryType": "sling:Folder",
       "48-hours-of-wilderness-1.jpg": {
-        "jcr:primaryType": "dam:Asset"
+        "jcr:primaryType": "dam:Asset",
+        "jcr:uuid": "c28b3585-95f6-44d2-8ffa-58affc7e3abb"
       }
     },
     "arctic-surfing-in-lofoten": {
       "jcr:primaryType": "sling:OrderedFolder",
       "arctic-surfing-in-lofoten": {
-        "jcr:primaryType": "dam:Asset"
+        "jcr:primaryType": "dam:Asset",
+        "jcr:uuid": "d8a4b101-54bc-40df-89c9-dc05f9b1ef22"
       },
       "camp-tent.jpg": {
-        "jcr:primaryType": "dam:Asset"
+        "jcr:primaryType": "dam:Asset",
+        "jcr:uuid": "d760794b-71cd-4aee-a6c0-32b4019354de"
       },
       "surfer-ready-to-go.jpg": {
-        "jcr:primaryType": "dam:Asset"
+        "jcr:primaryType": "dam:Asset",
+        "jcr:uuid": "dab149eb-e4d6-4524-8676-cd90e37cbd37"
       },
       "camp-fire.jpg": {
-        "jcr:primaryType": "dam:Asset"
+        "jcr:primaryType": "dam:Asset",
+        "jcr:uuid": "b8bb8a57-e848-47b2-9bcb-554b3d52d3f8"
       },
       "majestic-rainbow.jpg": {
-        "jcr:primaryType": "dam:Asset"
+        "jcr:primaryType": "dam:Asset",
+        "jcr:uuid": "e5e26802-36e2-4348-80c3-c58013f16a86"
       },
       "fjord-waves.jpg": {
-        "jcr:primaryType": "dam:Asset"
+        "jcr:primaryType": "dam:Asset",
+        "jcr:uuid": "88ee494d-abe0-44fa-9e1d-3a8c3b07ef2b"
       },
       "surfer-wave-01.jpg": {
-        "jcr:primaryType": "dam:Asset"
+        "jcr:primaryType": "dam:Asset",
+        "jcr:uuid": "7ed62221-793a-496f-9195-0638d7601b01"
       },
       "surfer-wave-02.jpg": {
-        "jcr:primaryType": "dam:Asset"
+        "jcr:primaryType": "dam:Asset",
+        "jcr:uuid": "e9c2990d-4ca1-4748-b4d6-50d604720261"
       },
       "northern-lights.jpg": {
-        "jcr:primaryType": "dam:Asset"
+        "jcr:primaryType": "dam:Asset",
+        "jcr:uuid": "d9348f39-7e17-4faf-b94e-2a6cd1b4ff13"
       }
     }
   }


### PR DESCRIPTION
## Summary
- The Asset Packager's filter resolution previously only handled plain DAM asset paths; references authored as `urn:aaid:aem:<uuid>` (AEM asset ID/URN references) were silently skipped.
- `AssetPackageUtil#addFilter` now detects the `urn:aaid:aem:<uuid>` pattern, resolves the underlying asset by its `jcr:uuid`, and adds the resolved path to the package filter set — falling back to the existing path-based resolution otherwise.

## Test plan
- [x] Added `AssetPackageUtilTest` with AemContext-backed content covering both plain-path and URN-based `fileReference` values, verifying the expected filter paths are produced.
- [x] `mvn -pl bundle test -Dtest=AssetPackageUtilTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)