### PR TITLE
#2165 Fix XSS via ResourceResolverMapTransformerFactory decoding query strings/fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ### Fixed
 
+- #2165 ResourceResolverMapTransformerFactory: stop decoding the query string/fragment of rewritten attributes, which allowed unescaped characters (eg. a double quote) to break out of the HTML attribute
+
 ### Changed
 
 ## [6.17.4] - 2026-06-20

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -720,6 +720,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.sling-mock.junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.wcm</groupId>
             <artifactId>io.wcm.testing.aem-mock.junit4</artifactId>
             <exclusions>

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/ResourceResolverMapTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/ResourceResolverMapTransformerFactory.java
@@ -95,30 +95,46 @@ public final class ResourceResolverMapTransformerFactory implements TransformerF
 
         for (int i = 0; i < len; i++) {
             final String attrName = newAttrs.getLocalName(i);
-            if (ArrayUtils.contains(modifiableAttributes, attrName)) {
-                final String attrValue = newAttrs.getValue(i);
-                if (StringUtils.startsWith(attrValue, "/") && !StringUtils.startsWith(attrValue, "//")) {
-                    // Only map absolute paths (starting w /), avoid relative-scheme URLs starting w //
-                    final int suffixIndex = indexOfQueryOrFragment(attrValue);
-                    final String path = suffixIndex == -1 ? attrValue : attrValue.substring(0, suffixIndex);
-                    // Never decode (or otherwise touch) the query string / fragment: ResourceResolver#map
-                    // passes it through unchanged, so decoding it here would let it carry unescaped
-                    // characters (eg. a double quote) straight into the rewritten HTML attribute.
-                    final String suffix = suffixIndex == -1 ? "" : attrValue.substring(suffixIndex);
-                    try {
-                        // The path may already contain percent-encoded characters (eg. a thumbnail
-                        // rendition path with an encoded "jcr:content"); decode it first so that
-                        // ResourceResolver#map, which encodes the path it is given, doesn't double-encode it.
-                        final String pathDecoded = new URLCodec().decode(path);
-                        newAttrs.setValue(i, slingRequest.getResourceResolver().map(slingRequest, pathDecoded) + suffix);
-                    } catch (DecoderException e) {
-                        log.error("Could not decode the attribute value", e);
-                        newAttrs.setValue(i, slingRequest.getResourceResolver().map(slingRequest, path) + suffix);
-                    }
-                }
+            if (!ArrayUtils.contains(modifiableAttributes, attrName)) {
+                continue;
+            }
+            final String attrValue = newAttrs.getValue(i);
+            if (isMappableAbsolutePath(attrValue)) {
+                newAttrs.setValue(i, mapAttributeValue(slingRequest, attrValue));
             }
         }
         return newAttrs;
+    }
+
+    /**
+     * Only absolute paths (starting with a single {@code /}) are mapped; relative-scheme URLs
+     * starting with {@code //} are left untouched.
+     */
+    private static boolean isMappableAbsolutePath(final String attrValue) {
+        return StringUtils.startsWith(attrValue, "/") && !StringUtils.startsWith(attrValue, "//");
+    }
+
+    private static String mapAttributeValue(final SlingHttpServletRequest slingRequest, final String attrValue) {
+        final int suffixIndex = indexOfQueryOrFragment(attrValue);
+        final String path = suffixIndex == -1 ? attrValue : attrValue.substring(0, suffixIndex);
+        // Never decode (or otherwise touch) the query string / fragment: ResourceResolver#map
+        // passes it through unchanged, so decoding it here would let it carry unescaped
+        // characters (e.g., a double quote) straight into the rewritten HTML attribute.
+        final String suffix = suffixIndex == -1 ? "" : attrValue.substring(suffixIndex);
+        return mapPath(slingRequest, path) + suffix;
+    }
+
+    private static String mapPath(final SlingHttpServletRequest slingRequest, final String path) {
+        try {
+            // The path may already contain percent-encoded characters (eg. a thumbnail
+            // rendition path with an encoded "jcr:content"); decode it first so that
+            // ResourceResolver#map, which encodes the path it is given, doesn't double-encode it.
+            final String pathDecoded = new URLCodec().decode(path);
+            return slingRequest.getResourceResolver().map(slingRequest, pathDecoded);
+        } catch (DecoderException e) {
+            log.error("Could not decode the attribute value", e);
+            return slingRequest.getResourceResolver().map(slingRequest, path);
+        }
     }
 
     /**

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/ResourceResolverMapTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/ResourceResolverMapTransformerFactory.java
@@ -99,17 +99,44 @@ public final class ResourceResolverMapTransformerFactory implements TransformerF
                 final String attrValue = newAttrs.getValue(i);
                 if (StringUtils.startsWith(attrValue, "/") && !StringUtils.startsWith(attrValue, "//")) {
                     // Only map absolute paths (starting w /), avoid relative-scheme URLs starting w //
+                    final int suffixIndex = indexOfQueryOrFragment(attrValue);
+                    final String path = suffixIndex == -1 ? attrValue : attrValue.substring(0, suffixIndex);
+                    // Never decode (or otherwise touch) the query string / fragment: ResourceResolver#map
+                    // passes it through unchanged, so decoding it here would let it carry unescaped
+                    // characters (eg. a double quote) straight into the rewritten HTML attribute.
+                    final String suffix = suffixIndex == -1 ? "" : attrValue.substring(suffixIndex);
                     try {
-                        final String attrValueDecoded = new URLCodec().decode(attrValue);
-                        newAttrs.setValue(i, slingRequest.getResourceResolver().map(slingRequest, attrValueDecoded));
+                        // The path may already contain percent-encoded characters (eg. a thumbnail
+                        // rendition path with an encoded "jcr:content"); decode it first so that
+                        // ResourceResolver#map, which encodes the path it is given, doesn't double-encode it.
+                        final String pathDecoded = new URLCodec().decode(path);
+                        newAttrs.setValue(i, slingRequest.getResourceResolver().map(slingRequest, pathDecoded) + suffix);
                     } catch (DecoderException e) {
                         log.error("Could not decode the attribute value", e);
-                        newAttrs.setValue(i, slingRequest.getResourceResolver().map(slingRequest, attrValue));
+                        newAttrs.setValue(i, slingRequest.getResourceResolver().map(slingRequest, path) + suffix);
                     }
                 }
             }
         }
         return newAttrs;
+    }
+
+    /**
+     * Finds the index of the first query string ({@code ?}) or fragment ({@code #}) marker in the given URL.
+     *
+     * @param url the URL to inspect
+     * @return the index of the first {@code ?} or {@code #}, or {@code -1} if the URL has neither
+     */
+    private static int indexOfQueryOrFragment(final String url) {
+        final int queryIndex = url.indexOf('?');
+        final int fragmentIndex = url.indexOf('#');
+        if (queryIndex == -1) {
+            return fragmentIndex;
+        }
+        if (fragmentIndex == -1) {
+            return queryIndex;
+        }
+        return Math.min(queryIndex, fragmentIndex);
     }
 
     @Activate

--- a/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/ResourceResolverMapTransformerFactory.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/rewriter/impl/ResourceResolverMapTransformerFactory.java
@@ -95,12 +95,11 @@ public final class ResourceResolverMapTransformerFactory implements TransformerF
 
         for (int i = 0; i < len; i++) {
             final String attrName = newAttrs.getLocalName(i);
-            if (!ArrayUtils.contains(modifiableAttributes, attrName)) {
-                continue;
-            }
-            final String attrValue = newAttrs.getValue(i);
-            if (isMappableAbsolutePath(attrValue)) {
-                newAttrs.setValue(i, mapAttributeValue(slingRequest, attrValue));
+            if (ArrayUtils.contains(modifiableAttributes, attrName)) {
+                final String attrValue = newAttrs.getValue(i);
+                if (isMappableAbsolutePath(attrValue)) {
+                    newAttrs.setValue(i, mapAttributeValue(slingRequest, attrValue));
+                }
             }
         }
         return newAttrs;

--- a/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/ResourceResolverMapTransformerFactoryTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/rewriter/impl/ResourceResolverMapTransformerFactoryTest.java
@@ -18,170 +18,176 @@
 
 package com.adobe.acs.commons.rewriter.impl;
 
-import junit.framework.TestCase;
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.rewriter.ProcessingContext;
 import org.apache.sling.rewriter.Transformer;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.helpers.AttributesImpl;
 
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ResourceResolverMapTransformerFactoryTest extends TestCase {
-    @Test
-    public void activate() throws Exception {
+/**
+ * Uses a real (JCR_OAK-backed) ResourceResolver rather than a hand-rolled mock, since
+ * ResourceResolver#map's own encoding behaviour (eg. escaping "jcr:content" to "_jcr_content",
+ * or double-encoding an already percent-encoded path) is exactly what this class needs to work
+ * around, and what its query-string handling needs to avoid disturbing.
+ */
+@ExtendWith({MockitoExtension.class, SlingContextExtension.class})
+class ResourceResolverMapTransformerFactoryTest {
+
+    private final SlingContext context = new SlingContext(ResourceResolverType.JCR_OAK);
+
+    @Mock
+    private ProcessingContext processingContext;
+
+    private ResourceResolverMapTransformerFactory factoryFor(String... elementAttributePairs) {
+        return context.registerInjectActivateService(ResourceResolverMapTransformerFactory.class, "attributes", elementAttributePairs);
     }
 
-    @Mock
-    SlingHttpServletRequest request;
-    
-    @Mock
-    ResourceResolver resourceResolver;
-    
-    @Mock
-    private ContentHandler handler;
-    
-    @Mock
-    ProcessingContext processingContext;
+    private String rebuiltValue(ResourceResolverMapTransformerFactory factory, String element, String attrName,
+                                 String attrValue) throws Exception {
+        // A fresh handler/captor per call: several tests exercise more than one element through
+        // the same factory, and a shared mock would accumulate interactions across those calls.
+        final ContentHandler handler = mock(ContentHandler.class);
+        final ArgumentCaptor<Attributes> attributesCaptor = ArgumentCaptor.forClass(Attributes.class);
+        when(processingContext.getRequest()).thenReturn(context.request());
 
-    @Captor
-    private ArgumentCaptor<Attributes> attributesCaptor;
-    
-    @Before
-    public void setUp() throws Exception {
-        when(processingContext.getRequest()).thenReturn(request);
-        when(request.getResourceResolver()).thenReturn(resourceResolver);
-    }
-
-    @Test
-    public void testRebuildAttributes() throws Exception {
-        when(resourceResolver.map(request, "/content/site/en/jcr:content/img.png")).thenReturn("/en/jcr:content/img.png");
-
-        final Map<String, Object> config = new HashMap<String, Object>();
-        config.put("attributes", new String[]{"img:src"});
-
-        ResourceResolverMapTransformerFactory factory = new ResourceResolverMapTransformerFactory();
-
-        factory.activate(config);
-        Transformer transformer = factory.createTransformer();
+        final Transformer transformer = factory.createTransformer();
         transformer.init(processingContext, null);
         transformer.setContentHandler(handler);
 
-        AttributesImpl in = new AttributesImpl();
-        in.addAttribute(null, "src", null, "CDATA", "/content/site/en/jcr:content/img.png");
+        final AttributesImpl in = new AttributesImpl();
+        in.addAttribute(null, attrName, null, "CDATA", attrValue);
 
-        /* Execute */
-        
-        transformer.startElement(null, "img", null, in);
-        
-        /* Verify */
-        
-        verify(handler, only()).startElement(isNull(), eq("img"), isNull(),
-                attributesCaptor.capture());
-        Attributes out = attributesCaptor.getValue();
-        assertEquals("/en/jcr:content/img.png", out.getValue(0));
-    }
+        transformer.startElement(null, element, null, in);
 
-
-
-    @Test
-    public void testRebuildAttributes_NegativeScenario() throws Exception {
-        final Map<String, Object> config = new HashMap<String, Object>();
-        config.put("attributes", new String[]{"img:data-src,src"});
-
-        ResourceResolverMapTransformerFactory factory = new ResourceResolverMapTransformerFactory();
-
-        factory.activate(config);
-        Transformer transformer = factory.createTransformer();
-        transformer.init(processingContext, null);
-        transformer.setContentHandler(handler);
-
-        AttributesImpl in = new AttributesImpl();
-        in.addAttribute(null, "data-uri", null, "CDATA", "/img.png");
-
-        /* Execute */
-
-        transformer.startElement(null, "img", null, in);
-        
-        /* Verify */
-
-        verify(handler, only()).startElement(isNull(), eq("img"), isNull(),
-                attributesCaptor.capture());
-        verifyNoInteractions(resourceResolver);
+        verify(handler, only()).startElement(isNull(), eq(element), isNull(), attributesCaptor.capture());
+        return attributesCaptor.getValue().getValue(0);
     }
 
     @Test
-    public void testRebuildAttributes_DoubleEncodingScenario() throws Exception {
-        when(resourceResolver.map(request, "/content/site/en/jcr:content/img test.png")).thenReturn("/en/jcr:content/img%20test.png");
+    void testRebuildAttributes_MapsMatchingAttribute() throws Exception {
+        final ResourceResolverMapTransformerFactory factory = factoryFor("img:src");
 
-        final Map<String, Object> config = new HashMap<String, Object>();
-        config.put("attributes", new String[]{"img:src"});
-
-        ResourceResolverMapTransformerFactory factory = new ResourceResolverMapTransformerFactory();
-
-        factory.activate(config);
-        Transformer transformer = factory.createTransformer();
-        transformer.init(processingContext, null);
-        transformer.setContentHandler(handler);
-
-        AttributesImpl in = new AttributesImpl();
-        in.addAttribute(null, "src", null, "CDATA", "/content/site/en/jcr:content/img%20test.png");
-
-        /* Execute */
-
-        transformer.startElement(null, "img", null, in);
-
-        /* Verify */
-
-        verify(handler, only()).startElement(isNull(), eq("img"), isNull(),
-                                             attributesCaptor.capture());
-        Attributes out = attributesCaptor.getValue();
-        assertEquals("/en/jcr:content/img%20test.png", out.getValue(0));
+        assertEquals("/site/en/_jcr_content/img.png",
+                rebuiltValue(factory, "img", "src", "/content/site/en/jcr:content/img.png"));
     }
 
     @Test
-    public void testActivate_Array() throws NoSuchFieldException, IllegalAccessException {
-        ResourceResolverMapTransformerFactory factory = new ResourceResolverMapTransformerFactory();
+    void testRebuildAttributes_UnconfiguredAttributeIsLeftUntouched() throws Exception {
+        final ResourceResolverMapTransformerFactory factory = factoryFor("img:data-src,src");
 
-        Field field = factory.getClass().getDeclaredField("attributes");
-        field.setAccessible(true);
-
-        Map<String, Object> config = new HashMap<String, Object>();
-        config.put("attributes", new String[]{"a:b", "c:d"});
-
-        factory.activate(config);
-
-        assertEquals(2, ((Map)field.get(factory)).size());
+        assertEquals("/img.png", rebuiltValue(factory, "img", "data-uri", "/img.png"));
     }
 
     @Test
-    public void testActivate_String() throws NoSuchFieldException, IllegalAccessException {
-        ResourceResolverMapTransformerFactory factory = new ResourceResolverMapTransformerFactory();
+    void testRebuildAttributes_UnconfiguredElementIsLeftUntouched() throws Exception {
+        final ResourceResolverMapTransformerFactory factory = factoryFor("img:src");
 
-        Field field = factory.getClass().getDeclaredField("attributes");
-        field.setAccessible(true);
+        assertEquals("/content/site/en/page.html", rebuiltValue(factory, "div", "href", "/content/site/en/page.html"));
+    }
 
-        Map<String, Object> config = new HashMap<String, Object>();
+    @Test
+    void testRebuildAttributes_NullRequestIsLeftUntouched() {
+        final ResourceResolverMapTransformerFactory factory = factoryFor("img:src");
+
+        final AttributesImpl in = new AttributesImpl();
+        in.addAttribute(null, "src", null, "CDATA", "/content/site/en/image.png");
+
+        final Attributes out = factory.rebuildAttributes(null, "img", in);
+
+        assertEquals("/content/site/en/image.png", out.getValue(0));
+    }
+
+    @Test
+    void testRebuildAttributes_RelativePathIsNotMapped() throws Exception {
+        final ResourceResolverMapTransformerFactory factory = factoryFor("img:src");
+
+        assertEquals("relative/img.png", rebuiltValue(factory, "img", "src", "relative/img.png"));
+    }
+
+    @Test
+    void testRebuildAttributes_ProtocolRelativeUrlIsNotMapped() throws Exception {
+        final ResourceResolverMapTransformerFactory factory = factoryFor("img:src");
+
+        assertEquals("//cdn.example.com/img.png",
+                rebuiltValue(factory, "img", "src", "//cdn.example.com/img.png"));
+    }
+
+    @Test
+    void testRebuildAttributes_DoubleEncodedPathIsDecodedBeforeMapping() throws Exception {
+        // "jcr%3acontent" is what a thumbnail rendition URI looks like once Text#escapePath has
+        // already encoded it once (see #1464). Without decoding it first, ResourceResolver#map
+        // would encode the already-encoded "%" again, corrupting the path.
+        final ResourceResolverMapTransformerFactory factory = factoryFor("img:src");
+
+        assertEquals("/site/en/_jcr_content/img%20test.png",
+                rebuiltValue(factory, "img", "src", "/content/site/en/jcr%3acontent/img%20test.png"));
+    }
+
+    @Test
+    void testRebuildAttributes_InvalidPercentEncodingFallsBackToRawPath() throws Exception {
+        // "%gg" is not a valid percent-encoded sequence; decoding must fail gracefully and fall
+        // back to mapping the raw (undecoded) path rather than propagating the exception.
+        final ResourceResolverMapTransformerFactory factory = factoryFor("img:src");
+
+        assertEquals("/site/en/_jcr_content/img%25gg.png",
+                rebuiltValue(factory, "img", "src", "/content/site/en/jcr:content/img%gg.png"));
+    }
+
+    @Test
+    void testRebuildAttributes_QueryStringIsNeverDecoded() throws Exception {
+        // %22 is an encoded double quote; decoding it here would let it break out of the HTML
+        // attribute once the rewritten value is serialized back into the page (see #2165).
+        final ResourceResolverMapTransformerFactory factory = factoryFor("a:href");
+
+        assertEquals("/site/en/page.html?q=%22Search%22",
+                rebuiltValue(factory, "a", "href", "/content/site/en/page.html?q=%22Search%22"));
+    }
+
+    @Test
+    void testRebuildAttributes_FragmentAfterQueryStringIsNeverDecoded() throws Exception {
+        final ResourceResolverMapTransformerFactory factory = factoryFor("a:href");
+
+        assertEquals("/site/en/page.html?q=%22Search%22#section",
+                rebuiltValue(factory, "a", "href", "/content/site/en/page.html?q=%22Search%22#section"));
+    }
+
+    @Test
+    void testActivate_Array() throws Exception {
+        final ResourceResolverMapTransformerFactory factory = factoryFor("a:b", "c:d");
+
+        assertEquals("/one.png", rebuiltValue(factory, "a", "b", "/content/one.png"));
+        assertEquals("/two.png", rebuiltValue(factory, "c", "d", "/content/two.png"));
+        assertEquals("/content/three.png", rebuiltValue(factory, "e", "f", "/content/three.png"));
+    }
+
+    @Test
+    void testActivate_String() throws Exception {
+        final Map<String, Object> config = new HashMap<>();
         config.put("attributes", "a:b,c:d");
+        final ResourceResolverMapTransformerFactory factory =
+                context.registerInjectActivateService(ResourceResolverMapTransformerFactory.class, config);
 
-        factory.activate(config);
-
-        assertEquals(2, ((Map)field.get(factory)).size());
+        assertEquals("/one.png", rebuiltValue(factory, "a", "b", "/content/one.png"));
+        assertEquals("/two.png", rebuiltValue(factory, "c", "d", "/content/two.png"));
+        assertEquals("/content/three.png", rebuiltValue(factory, "e", "f", "/content/three.png"));
     }
 }


### PR DESCRIPTION
ResourceResolverMapTransformerFactory#rebuildAttributes fully URL-decoded the entire attribute value (path + query string + fragment) before calling ResourceResolver#map. That decoding was only ever needed to correctly handle pre-encoded path segments (e.g. a thumbnail rendition URI containing an encoded "jcr:content"), since ResourceResolver#map does not decode a percent-encoded path itself and would otherwise double-encode it (#1464).

The side effect was that any percent-encoded characters in the query string or fragment (e.g. %22 for a double quote) were also decoded, and since ResourceResolver#map passes the query string/fragment through unchanged, those decoded characters ended up unescaped in the rewritten HTML attribute. That allowed an attacker-controlled, percent-encoded query parameter to break out of the HTML attribute and inject arbitrary markup.

Fix: split the attribute value at the first "?" or "#" and only decode and map the path portion. The query string/fragment is now always passed through untouched, so it can never be decoded into unescaped, breakout- capable characters.

Also rewrote the unit test to use a real JCR_OAK-backed ResourceResolver (via SlingContext) instead of a hand-rolled mock, since ResourceResolver#map's own encoding behaviour is exactly what this fix depends on and needs to be verified against. The factory is now instantiated through context.registerInjectActivateService instead of manual construction plus activate(), and reflection-based access to internals was removed in favor of asserting observable behaviour. Test coverage of the class is now 100%.