### PR TITLE
defect/image-transformer: fix URL decoding issue in named transform (#3628)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com)
 
 ### Fixed
 
+- #3628 Fix URL decoding issue in named transform image servlet
+
 ### Changed
 
 ## [6.17.4] - 2026-06-20

--- a/bundle/src/main/java/com/adobe/acs/commons/images/impl/NamedTransformImageServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/images/impl/NamedTransformImageServlet.java
@@ -284,17 +284,15 @@ public class NamedTransformImageServlet extends SlingSafeMethodsServlet implemen
 
             ValueMap transformParams = imageTransformersWithParams.get(type, EMPTY_PARAMS);
 
-            if (transformParams != null) {
-              if (Boolean.valueOf(transformParams.get(PROP_ADD_URL_PARAMETERS, false))) {
+            if (transformParams.get(PROP_ADD_URL_PARAMETERS, false)) {
                 LinkedHashMap<String, Object> cropParamsFromUrl = getCropParamsFromUrl(request);
-                if(!cropParamsFromUrl.isEmpty()) {
-                  transformParams = new ValueMapDecorator(new LinkedHashMap<String, Object>(transformParams));
-                  transformParams.putAll(cropParamsFromUrl);
+                if (!cropParamsFromUrl.isEmpty()) {
+                    transformParams = new ValueMapDecorator(new LinkedHashMap<String, Object>(transformParams));
+                    transformParams.putAll(cropParamsFromUrl);
                 }
-              }
-
-                layer = imageTransformer.transform(layer, transformParams);
             }
+
+            layer = imageTransformer.transform(layer, transformParams);
         }
 
         return layer;

--- a/bundle/src/main/java/com/adobe/acs/commons/images/impl/NamedTransformImageServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/images/impl/NamedTransformImageServlet.java
@@ -64,6 +64,9 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -494,12 +497,19 @@ public class NamedTransformImageServlet extends SlingSafeMethodsServlet implemen
      */
     private String getMimeType(final SlingHttpServletRequest request, final Image image) {
         final String lastSuffix = PathInfoUtil.getLastSuffixSegment(request);
+        String cleanLastSuffix = lastSuffix;
+        try {
+            if (lastSuffix != null) {
+                cleanLastSuffix = StringUtils.substringBefore(URLDecoder.decode(lastSuffix, StandardCharsets.UTF_8.name()), " ");
+            }
+        } catch (UnsupportedEncodingException e) {
+            log.error("An error occurred while decoding the URL.");
+        }
+        final String mimeType = mimeTypeService.getMimeType(cleanLastSuffix);
 
-        final String mimeType = mimeTypeService.getMimeType(lastSuffix);
-
-        if (!StringUtils.endsWithIgnoreCase(lastSuffix, ".orig")
-            && !StringUtils.endsWithIgnoreCase(lastSuffix, ".original")
-            && (ImageIO.getImageWritersByMIMEType(mimeType).hasNext())) {
+        if (!StringUtils.endsWithIgnoreCase(cleanLastSuffix, ".orig")
+                && !StringUtils.endsWithIgnoreCase(cleanLastSuffix, ".original")
+                && (ImageIO.getImageWritersByMIMEType(mimeType).hasNext())) {
             return mimeType;
         } else {
             try {

--- a/bundle/src/main/java/com/adobe/acs/commons/images/impl/NamedTransformImageServlet.java
+++ b/bundle/src/main/java/com/adobe/acs/commons/images/impl/NamedTransformImageServlet.java
@@ -138,6 +138,9 @@ public class NamedTransformImageServlet extends SlingSafeMethodsServlet implemen
 
     public static final String DEFAULT_FILENAME_PATTERN = "(image|img)\\.(.+)";
 
+    private static final Pattern SRCSET_DESCRIPTOR_PATTERN =
+            Pattern.compile("\\s+(?:\\d+w|(?:\\d+(?:\\.\\d+)?|\\.\\d+)x)$");
+
     public static final String RT_LOCAL_SOCIAL_IMAGE = "social:asiFile";
 
     public static final String RT_REMOTE_SOCIAL_IMAGE = "nt:adobesocialtype";
@@ -500,10 +503,13 @@ public class NamedTransformImageServlet extends SlingSafeMethodsServlet implemen
         String cleanLastSuffix = lastSuffix;
         try {
             if (lastSuffix != null) {
-                cleanLastSuffix = StringUtils.substringBefore(URLDecoder.decode(lastSuffix, StandardCharsets.UTF_8.name()), " ");
+                cleanLastSuffix = SRCSET_DESCRIPTOR_PATTERN.matcher(
+                        URLDecoder.decode(lastSuffix, StandardCharsets.UTF_8.name())).replaceFirst("");
             }
         } catch (UnsupportedEncodingException e) {
-            log.error("An error occurred while decoding the URL.");
+            log.warn("Failed to URL-decode request URL [{}]. Falling back to PNG mime type.",
+                    request.getRequestURI(), e);
+            return MIME_TYPE_PNG;
         }
         final String mimeType = mimeTypeService.getMimeType(cleanLastSuffix);
 

--- a/bundle/src/test/java/com/adobe/acs/commons/images/impl/NamedTransformImageServletTest.java
+++ b/bundle/src/test/java/com/adobe/acs/commons/images/impl/NamedTransformImageServletTest.java
@@ -35,9 +35,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+import com.adobe.acs.commons.testing.PrivateAccessor;
+import com.day.cq.wcm.api.PageManager;
+import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.request.RequestPathInfo;
+import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.wrappers.ValueMapDecorator;
+import org.apache.sling.commons.mime.MimeTypeService;
 import org.apache.sling.commons.testing.sling.MockSlingHttpServletRequest;
 import org.junit.Before;
 import org.junit.Test;
@@ -102,6 +107,15 @@ public final class NamedTransformImageServletTest {
     private Resource metadataResource;
 
     private ValueMap metadataValueMap;
+
+    @Mock
+    private SlingHttpServletResponse response;
+
+    @Mock
+    private RequestPathInfo requestPathInfo;
+
+    @Mock
+    private ResourceResolver resourceResolver;
 
     @Before
     public void setUp() {
@@ -428,6 +442,28 @@ public final class NamedTransformImageServletTest {
       Map<String, Object> metadataMap = new HashMap<String, Object>();
       metadataMap.put(TIFF_ORIENTATION, num);
       metadataValueMap = new ValueMapDecorator(metadataMap);
+    }
+
+    @Test
+    public void testDoGet_WithUrlEncodedSuffix() throws Exception {
+        when(request.getRequestPathInfo()).thenReturn(requestPathInfo);
+        when(requestPathInfo.getSuffix()).thenReturn("/my-transform/my%20image.jpg%202x");
+
+        when(request.getResourceResolver()).thenReturn(resourceResolver);
+        Resource resource = mock(Resource.class);
+        when(request.getResource()).thenReturn(resource);
+        when(resource.getResourceResolver()).thenReturn(resourceResolver);
+
+        PageManager pageManager = mock(PageManager.class);
+        when(resourceResolver.adaptTo(PageManager.class)).thenReturn(pageManager);
+
+        MimeTypeService mimeTypeService = mock(MimeTypeService.class);
+        when(mimeTypeService.getMimeType("my image.jpg")).thenReturn("image/jpeg");
+
+        PrivateAccessor.setField(servlet, "mimeTypeService", mimeTypeService);
+
+        servlet.doGet(request, response);
+        verify(mimeTypeService).getMimeType("my image.jpg");
     }
 
   /* Testing for resolveImage requires too much orchestration/mocking to be useful */


### PR DESCRIPTION
## Description
Resolves an issue where URL decoding was not properly handled in the named transform image servlet.

Fixes #3628

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have updated the CHANGELOG.md file.
- [x] My code follows the code style of this project.
<img width="1911" height="800" alt="imageWIthEncodeExtension" src="https://github.com/user-attachments/assets/44a13067-d467-4e44-a26c-40255cee2e72" />
<img width="1884" height="984" alt="imageWIthNormalExtension" src="https://github.com/user-attachments/assets/c2f32564-a63a-489c-9df6-8ead8cb39b17" />
